### PR TITLE
Support 20 bytes address

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1825,6 +1825,7 @@ dependencies = [
  "move-ir-types",
  "move-stdlib",
  "move-symbol-pool",
+ "num-bigint 0.4.0",
  "once_cell",
  "petgraph 0.5.1",
  "regex",

--- a/language/move-compiler/Cargo.toml
+++ b/language/move-compiler/Cargo.toml
@@ -17,6 +17,7 @@ petgraph = "0.5.1"
 walkdir = "2.3.1"
 tempfile = "3.2.0"
 once_cell = "1.7.2"
+num-bigint = "0.4.0"
 
 move-binary-format = { path = "../move-binary-format" }
 move-core-types = { path = "../move-core/types" }

--- a/language/move-core/types/Cargo.toml
+++ b/language/move-core/types/Cargo.toml
@@ -30,5 +30,6 @@ regex = "1.4.3"
 serde_json = "1.0.64"
 
 [features]
+address20 = []
 default = []
 fuzzing = ["proptest", "proptest-derive"]

--- a/language/move-core/types/src/account_address.rs
+++ b/language/move-core/types/src/account_address.rs
@@ -17,10 +17,20 @@ impl AccountAddress {
     }
 
     /// The number of bytes in an address.
-    pub const LENGTH: usize = 16;
+    /// Default to 16 bytes, can be set to 20 bytes with address20 feature.
+    pub const LENGTH: usize = if cfg!(feature = "address20") { 20 } else { 16 };
 
     /// Hex address: 0x0
     pub const ZERO: Self = Self([0u8; Self::LENGTH]);
+
+    /// Hex address: 0x1
+    pub const ONE: Self = Self::get_hex_address_one();
+
+    const fn get_hex_address_one() -> Self {
+        let mut addr = [0u8; AccountAddress::LENGTH];
+        addr[AccountAddress::LENGTH - 1] = 1u8;
+        Self(addr)
+    }
 
     pub fn random() -> Self {
         let mut rng = OsRng;

--- a/language/move-core/types/src/language_storage.rs
+++ b/language/move-core/types/src/language_storage.rs
@@ -13,9 +13,8 @@ use std::fmt::{Display, Formatter};
 pub const CODE_TAG: u8 = 0;
 pub const RESOURCE_TAG: u8 = 1;
 
-pub const CORE_CODE_ADDRESS: AccountAddress = AccountAddress::new([
-    0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 1u8,
-]);
+/// Hex address: 0x1
+pub const CORE_CODE_ADDRESS: AccountAddress = AccountAddress::ONE;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Hash, Eq, Clone, PartialOrd, Ord)]
 pub enum TypeTag {

--- a/language/move-prover/interpreter/src/concrete/evaluator.rs
+++ b/language/move-prover/interpreter/src/concrete/evaluator.rs
@@ -41,8 +41,7 @@ pub type EvalResult<T> = ::std::result::Result<T, BigInt>;
 // Constants
 //**************************************************************************************************
 
-const DIEM_CORE_ADDR: AccountAddress =
-    AccountAddress::new([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]);
+const DIEM_CORE_ADDR: AccountAddress = AccountAddress::ONE;
 
 //**************************************************************************************************
 // Evaluation context

--- a/language/move-prover/interpreter/src/concrete/player.rs
+++ b/language/move-prover/interpreter/src/concrete/player.rs
@@ -13,6 +13,7 @@ use bytecode_interpreter_crypto::{
 use move_binary_format::errors::Location;
 use move_core_types::{
     account_address::AccountAddress,
+    language_storage::CORE_CODE_ADDRESS,
     vm_status::{sub_status, StatusCode},
 };
 use move_model::{
@@ -53,8 +54,7 @@ pub type ExecResult<T> = ::std::result::Result<T, AbortInfo>;
 // Constants
 //**************************************************************************************************
 
-const DIEM_CORE_ADDR: AccountAddress =
-    AccountAddress::new([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]);
+const DIEM_CORE_ADDR: AccountAddress = CORE_CODE_ADDRESS;
 
 // TODO(mengxu): these constants are defined in values_impl.rs which are currently not exposed.
 const INDEX_OUT_OF_BOUNDS: u64 = sub_status::NFE_VECTOR_ERROR_BASE + 1;

--- a/language/move-stdlib/src/natives/unit_test.rs
+++ b/language/move-stdlib/src/natives/unit_test.rs
@@ -12,6 +12,13 @@ use std::collections::VecDeque;
 
 use move_core_types::account_address::AccountAddress;
 
+fn to_le_bytes(i: u64) -> [u8; AccountAddress::LENGTH] {
+    let bytes = i.to_le_bytes();
+    let mut result = [0u8; AccountAddress::LENGTH];
+    result[..bytes.len()].clone_from_slice(bytes.as_ref());
+    result
+}
+
 pub fn native_create_signers_for_testing(
     _context: &mut NativeContext,
     ty_args: Vec<Type>,
@@ -22,7 +29,7 @@ pub fn native_create_signers_for_testing(
 
     let num_signers = pop_arg!(args, u64);
     let signers = Value::vector_for_testing_only(
-        (0..num_signers).map(|i| Value::signer(AccountAddress::new((i as u128).to_le_bytes()))),
+        (0..num_signers).map(|i| Value::signer(AccountAddress::new(to_le_bytes(i)))),
     );
 
     Ok(NativeResult::ok(ONE_GAS_UNIT, smallvec![signers]))

--- a/language/tools/move-cli/tests/testsuite/cyclic_multi_module_publish/args.exp
+++ b/language/tools/move-cli/tests/testsuite/cyclic_multi_module_publish/args.exp
@@ -1,15 +1,4 @@
 Command `sandbox publish --override-ordering A --override-ordering B -v`:
-error[E02001]: duplicate declaration, item, or annotation
-  ┌─ ./sources/CyclicFriendsPart2.move:1:13
-  │
-1 │ module 0x3::A {
-  │             ^ Duplicate definition for module '0x3::A'
-  │
-  ┌─ ./sources/CyclicFriendsPart1.move:1:13
-  │
-1 │ module 0x3::A {
-  │             - Module previously defined here
-
 error[E02004]: invalid 'module' declaration
   ┌─ ./sources/CyclicFriendsPart2.move:8:24
   │

--- a/language/tools/move-cli/tests/testsuite/cyclic_multi_module_publish/sources/CyclicFriendsPart2.move
+++ b/language/tools/move-cli/tests/testsuite/cyclic_multi_module_publish/sources/CyclicFriendsPart2.move
@@ -1,4 +1,4 @@
-module 0x3::A {
+module 0x3::D {
     public fun foo() {}
     public fun bar() {}
 }


### PR DESCRIPTION
The current address is hard-coded to be 16 bytes. This works well for Diem, but could be insufficient for other systems. A common requirement is 20 bytes.
This PR adds a feature that gates the size of the address to be either 16 or 20 bytes, and change everywhere this is used to be using the right length.

Basically redo https://github.com/diem/diem/pull/10015 since the repo moved.