### PR TITLE
Fix failing test due to name conflict

### DIFF
--- a/language/tools/move-cli/tests/testsuite/explain_user_module_abort/args.exp
+++ b/language/tools/move-cli/tests/testsuite/explain_user_module_abort/args.exp
@@ -1,3 +1,3 @@
 Command `sandbox publish`:
-Command `sandbox run scripts/fail.move`:
+Command `sandbox run scripts/fail_script.move`:
 Execution aborted with code 77 in module 00000000000000000000000000000002::Fail.

--- a/language/tools/move-cli/tests/testsuite/explain_user_module_abort/args.txt
+++ b/language/tools/move-cli/tests/testsuite/explain_user_module_abort/args.txt
@@ -1,2 +1,2 @@
 sandbox publish
-sandbox run scripts/fail.move
+sandbox run scripts/fail_script.move

--- a/language/tools/move-cli/tests/testsuite/explain_user_module_abort/scripts/fail_script.move
+++ b/language/tools/move-cli/tests/testsuite/explain_user_module_abort/scripts/fail_script.move
@@ -1,6 +1,6 @@
 script {
     use 0x2::Fail;
-    fun fail() {
+    fun fail_script() {
         Fail::f();
     }
 }


### PR DESCRIPTION
Mac is case sensitive, cannot have scripts and sources with the same name.