### PR TITLE
[move-package] Make package system thread/process safe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -410,6 +410,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cloudabi"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "codespan"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1481,6 +1490,15 @@ checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
 
 [[package]]
 name = "lock_api"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4da24a77a3d8a6d4862d95f72e6fdb9c09a643ecdb402d754004a557f2bec75"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
+name = "lock_api"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0382880606dff6d15c9476c416d18690b72742aa7b605bb6dd6ec9030fbf07eb"
@@ -2056,6 +2074,8 @@ dependencies = [
  "move-errmapgen",
  "move-model",
  "move-symbol-pool",
+ "named-lock",
+ "once_cell",
  "petgraph 0.5.1",
  "ptree",
  "regex",
@@ -2355,7 +2375,7 @@ dependencies = [
  "move-ir-compiler",
  "move-vm-types",
  "once_cell",
- "parking_lot",
+ "parking_lot 0.11.1",
  "proptest",
  "sha3",
  "tracing",
@@ -2396,6 +2416,20 @@ dependencies = [
  "sha2",
  "smallvec",
  "workspace-hack",
+]
+
+[[package]]
+name = "named-lock"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3ab176d4bcfbcb53b8c7c5a25cb2c01674cda33db27064a85a16814c88c1f2d"
+dependencies = [
+ "libc",
+ "once_cell",
+ "parking_lot 0.10.2",
+ "thiserror",
+ "widestring",
+ "winapi",
 ]
 
 [[package]]
@@ -2720,13 +2754,37 @@ checksum = "20448fd678ec04e6ea15bbe0476874af65e98a01515d667aa49f1434dc44ebf4"
 
 [[package]]
 name = "parking_lot"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3a704eb390aafdc107b0e392f56a82b668e3a71366993b5340f5833fd62505e"
+dependencies = [
+ "lock_api 0.3.4",
+ "parking_lot_core 0.7.2",
+]
+
+[[package]]
+name = "parking_lot"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d7744ac029df22dca6284efe4e898991d28e3085c706c972bcd7da4a27a15eb"
 dependencies = [
  "instant",
- "lock_api",
- "parking_lot_core",
+ "lock_api 0.4.4",
+ "parking_lot_core 0.8.3",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d58c7c768d4ba344e3e8d72518ac13e259d7c7ade24167003b8488e10b6740a3"
+dependencies = [
+ "cfg-if 0.1.10",
+ "cloudabi",
+ "libc",
+ "redox_syscall 0.1.57",
+ "smallvec",
+ "winapi",
 ]
 
 [[package]]
@@ -4073,7 +4131,7 @@ dependencies = [
  "mio",
  "num_cpus",
  "once_cell",
- "parking_lot",
+ "parking_lot 0.11.1",
  "pin-project-lite",
  "signal-hook-registry",
  "tokio-macros",
@@ -4193,7 +4251,7 @@ version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ee73e6e4924fe940354b8d4d98cad5231175d615cd855b758adc658c0aac6a0"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "static_assertions",
 ]
 
@@ -4470,6 +4528,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "widestring"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c168940144dd21fd8046987c16a46a33d5fc84eec29ef9dcddc2ac9e31526b7c"
 
 [[package]]
 name = "winapi"

--- a/language/tools/move-cli/tests/cli_tests.rs
+++ b/language/tools/move-cli/tests/cli_tests.rs
@@ -33,3 +33,20 @@ fn run_metatest() {
     // temp workspace + without coverage
     assert!(test::run_all(&path_metatest, &path_cli_binary, true, false).is_ok());
 }
+
+#[test]
+fn cross_process_locking_git_deps() {
+    let handle = std::thread::spawn(|| {
+        std::process::Command::new("../../../../../../target/debug/move")
+            .current_dir("./tests/cross_process_tests/Package1")
+            .args(["package", "build"])
+            .output()
+            .expect("Package1 failed");
+    });
+    std::process::Command::new("../../../../../../target/debug/move")
+        .current_dir("./tests/cross_process_tests/Package2")
+        .args(["package", "build"])
+        .output()
+        .expect("Package2 failed");
+    handle.join().unwrap();
+}

--- a/language/tools/move-cli/tests/cross_process_tests/Package1/Move.toml
+++ b/language/tools/move-cli/tests/cross_process_tests/Package1/Move.toml
@@ -1,0 +1,9 @@
+[package]
+name = "Package1"
+version = "0.0.0"
+
+[addresses]
+Std = "0x1"
+
+[dependencies]
+MoveStdlib = { git = "https://github.com/diem/move.git", subdir = "language/move-stdlib", rev = "98ed299" }

--- a/language/tools/move-cli/tests/cross_process_tests/Package1/sources/Dummy.move
+++ b/language/tools/move-cli/tests/cross_process_tests/Package1/sources/Dummy.move
@@ -1,0 +1,1 @@
+module 0x1::Dummy {}

--- a/language/tools/move-cli/tests/cross_process_tests/Package2/Move.toml
+++ b/language/tools/move-cli/tests/cross_process_tests/Package2/Move.toml
@@ -1,0 +1,9 @@
+[package]
+name = "Package2"
+version = "0.0.0"
+
+[addresses]
+Std = "0x1"
+
+[dependencies]
+MoveStdlib = { git = "https://github.com/diem/move.git", subdir = "language/move-stdlib", rev = "98ed299" }

--- a/language/tools/move-cli/tests/cross_process_tests/Package2/sources/Dummy.move
+++ b/language/tools/move-cli/tests/cross_process_tests/Package2/sources/Dummy.move
@@ -1,0 +1,1 @@
+module 0x1::Dummy {}

--- a/language/tools/move-package/Cargo.toml
+++ b/language/tools/move-package/Cargo.toml
@@ -20,6 +20,8 @@ tempfile = "3.2.0"
 sha2 = "0.9.3"
 regex = "1.1.9"
 ptree = "0.4.0"
+once_cell = "1.7.2"
+named-lock = "0.1.1"
 
 move-binary-format = { path = "../../move-binary-format" }
 move-compiler = { path = "../../move-compiler" }

--- a/language/tools/move-package/src/package_lock.rs
+++ b/language/tools/move-package/src/package_lock.rs
@@ -1,0 +1,45 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use named_lock::{NamedLock, NamedLockGuard};
+use once_cell::sync::Lazy;
+use std::sync::{Mutex, MutexGuard};
+
+const PACKAGE_LOCK_NAME: &str = "move_pkg_lock";
+static PACKAGE_THREAD_MUTEX: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
+static PACKAGE_PROCESS_MUTEX: Lazy<NamedLock> =
+    Lazy::new(|| NamedLock::create(PACKAGE_LOCK_NAME).unwrap());
+
+/// The package lock is a lock held across threads and processes. This lock is held to ensure that
+/// the Move package manager has a consistent (read: serial) view of the file system. Without this
+/// lock we can easily get into race conditions around caching and overwriting of packages (e.g.,
+/// thread 1 and thread 2 compete to build package P in the same location), as well as downloading
+/// of git dependencies (thread 1 starts downloading git dependency, meanwhile thread 2 sees the
+/// git directory before it has been fully populated but assumes it has been fully downloaded and
+/// starts building the package before the git dependency has been fully downloaded by thread 1.
+/// This will then lead to file not found errors). These same issues could occur across processes,
+/// this is why we grab both a thread lock and process lock.
+pub(crate) struct PackageLock {
+    thread_lock: MutexGuard<'static, ()>,
+    process_lock: NamedLockGuard<'static>,
+}
+
+impl PackageLock {
+    pub(crate) fn lock() -> PackageLock {
+        let thread_lock = PACKAGE_THREAD_MUTEX.lock().unwrap();
+        let process_lock = PACKAGE_PROCESS_MUTEX.lock().unwrap();
+        Self {
+            thread_lock,
+            process_lock,
+        }
+    }
+
+    pub(crate) fn unlock(self) {
+        let Self {
+            thread_lock,
+            process_lock,
+        } = self;
+        drop(process_lock);
+        drop(thread_lock);
+    }
+}

--- a/language/tools/move-package/tests/test_thread_safety.rs
+++ b/language/tools/move-package/tests/test_thread_safety.rs
@@ -1,0 +1,25 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use move_package::BuildConfig;
+use std::path::Path;
+
+#[test]
+fn cross_thread_synchronization() {
+    let handle = std::thread::spawn(|| {
+        BuildConfig::default()
+            .compile_package(
+                Path::new("./tests/thread_safety_package_test_sources/Package1"),
+                &mut std::io::stdout(),
+            )
+            .unwrap()
+    });
+
+    BuildConfig::default()
+        .compile_package(
+            Path::new("./tests/thread_safety_package_test_sources/Package2"),
+            &mut std::io::stdout(),
+        )
+        .unwrap();
+    handle.join().unwrap();
+}

--- a/language/tools/move-package/tests/thread_safety_package_test_sources/Package1/Move.toml
+++ b/language/tools/move-package/tests/thread_safety_package_test_sources/Package1/Move.toml
@@ -1,0 +1,9 @@
+[package]
+name = "Package1"
+version = "0.0.0"
+
+[addresses]
+Std = "0x1"
+
+[dependencies]
+MoveStdlib = { git = "https://github.com/diem/move.git", subdir = "language/move-stdlib", rev = "98ed299" }

--- a/language/tools/move-package/tests/thread_safety_package_test_sources/Package1/sources/Dummy.move
+++ b/language/tools/move-package/tests/thread_safety_package_test_sources/Package1/sources/Dummy.move
@@ -1,0 +1,1 @@
+module 0x1::Dummy { }

--- a/language/tools/move-package/tests/thread_safety_package_test_sources/Package2/Move.toml
+++ b/language/tools/move-package/tests/thread_safety_package_test_sources/Package2/Move.toml
@@ -1,0 +1,9 @@
+[package]
+name = "Package2"
+version = "0.0.0"
+
+[addresses]
+Std = "0x1"
+
+[dependencies]
+MoveStdlib = { git = "https://github.com/diem/move.git", subdir = "language/move-stdlib", rev = "98ed299" }

--- a/language/tools/move-package/tests/thread_safety_package_test_sources/Package2/sources/Dummy.move
+++ b/language/tools/move-package/tests/thread_safety_package_test_sources/Package2/sources/Dummy.move
@@ -1,0 +1,1 @@
+module 0x1::Dummy { }


### PR DESCRIPTION
This PR adds a global package lock to the Move package manager: we have both a thread-local mutex and cross-process locking. The issue that this PR resolves was especially apparent when dealing with git dependencies. This PR also adds two tests to make sure that these locks are being respected by threads and processes and solve the issues reported in https://github.com/diem/diem/issues/10102.