### PR TITLE
[move-prover] Print out global memory in the counterexample trace

### DIFF
--- a/language/move-prover/bytecode/src/stackless_bytecode.rs
+++ b/language/move-prover/bytecode/src/stackless_bytecode.rs
@@ -171,6 +171,7 @@ pub enum Operation {
     TraceReturn(usize),
     TraceAbort,
     TraceExp(TraceKind, NodeId),
+    TraceGlobalMem(QualifiedInstId<StructId>),
 
     // Event
     EmitEvent,
@@ -234,6 +235,7 @@ impl Operation {
             Operation::TraceExp(..) => false,
             Operation::EmitEvent => false,
             Operation::EventStoreDiverge => false,
+            Operation::TraceGlobalMem(..) => false,
         }
     }
 }
@@ -1063,6 +1065,7 @@ impl<'env> fmt::Display for OperationDisplay<'env> {
             }
             EmitEvent => write!(f, "emit_event")?,
             EventStoreDiverge => write!(f, "event_store_diverge")?,
+            TraceGlobalMem(_) => write!(f, "trace_global_mem")?,
         }
         Ok(())
     }

--- a/language/move-prover/interpreter/src/concrete/player.rs
+++ b/language/move-prover/interpreter/src/concrete/player.rs
@@ -854,7 +854,8 @@ impl<'env> FunctionContext<'env> {
             | Operation::TraceLocal(..)
             | Operation::TraceReturn(..)
             | Operation::TraceAbort
-            | Operation::TraceExp(..) => {
+            | Operation::TraceExp(..)
+            | Operation::TraceGlobalMem(..) => {
                 unreachable!();
             }
         };

--- a/language/move-prover/tests/sources/functional/trace.cvc5_exp
+++ b/language/move-prover/tests/sources/functional/trace.cvc5_exp
@@ -25,6 +25,12 @@ error: global memory invariant does not hold
 38 │     invariant forall addr: address: exists<R>(addr) ==> global<R>(addr).x < 5;
    │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │
+   = Related Global Memory:
+   =         Resource name: TestTracing_R
+   =         Values:  {Address(0): <redacted>, Default: empty}
+   =     at tests/sources/functional/trace.move:29: publish_invalid
+   =     at tests/sources/functional/trace.move:33: publish_invalid (spec)
+   =         `let addr = Signer::address_of(s);` = <redacted>
    =     at tests/sources/functional/trace.move:29: publish_invalid
    =         s = <redacted>
    =         x = <redacted>
@@ -39,23 +45,22 @@ error: post-condition does not hold
    │
    = Related Global Memory:
    =         Resource name: TestTracing_R
-   =         Values:  {Address(6334): <redacted>, Default: empty}
+   =         Values:  {Address(0): <redacted>, Default: empty}
    = Related Bindings:
+   =         addr = <redacted>
    =         exists<R>(addr) = <redacted>
    =         global<R>(addr) = <redacted>
    =         x = <redacted>
    = Execution Trace:
+   =     at tests/sources/functional/trace.move:29: publish_invalid
+   =     at tests/sources/functional/trace.move:33: publish_invalid (spec)
+   =         `let addr = Signer::address_of(s);` = <redacted>
    =     at tests/sources/functional/trace.move:29: publish_invalid
    =         s = <redacted>
    =         x = <redacted>
    =     at tests/sources/functional/trace.move:30: publish_invalid
    =     at tests/sources/functional/trace.move:38
    =     at tests/sources/functional/trace.move:31: publish_invalid
-   =     at tests/sources/functional/trace.move:33: publish_invalid (spec)
-   =     at ../move-stdlib/sources/Signer.move:13: address_of
-   =     at tests/sources/functional/trace.move:34: publish_invalid (spec)
-   =     at tests/sources/functional/trace.move:33: publish_invalid (spec)
-   =     at ../move-stdlib/sources/Signer.move:13: address_of
    =     at tests/sources/functional/trace.move:34: publish_invalid (spec)
    =         `ensures exists<R>(addr) ==> global<R>(addr).x == x;` = <redacted>
 

--- a/language/move-prover/tests/sources/functional/trace.exp
+++ b/language/move-prover/tests/sources/functional/trace.exp
@@ -1,8 +1,8 @@
 Move prover returns: exiting with verification errors
 error: post-condition does not hold
-   ┌─ tests/sources/functional/trace.move:18:9
+   ┌─ tests/sources/functional/trace.move:19:9
    │
-18 │         ensures result == a + b;
+19 │         ensures result == a + b;
    │         ^^^^^^^^^^^^^^^^^^^^^^^^
    │
    = Related Bindings:
@@ -10,58 +10,64 @@ error: post-condition does not hold
    =         b = <redacted>
    =         result = <redacted>
    = Execution Trace:
-   =     at tests/sources/functional/trace.move:14: add_invalid
+   =     at tests/sources/functional/trace.move:15: add_invalid
    =         a = <redacted>
    =         b = <redacted>
-   =     at tests/sources/functional/trace.move:15: add_invalid
-   =         result = <redacted>
    =     at tests/sources/functional/trace.move:16: add_invalid
-   =     at tests/sources/functional/trace.move:18: add_invalid (spec)
+   =         result = <redacted>
+   =     at tests/sources/functional/trace.move:17: add_invalid
+   =     at tests/sources/functional/trace.move:19: add_invalid (spec)
    =         `ensures result == a + b;` = <redacted>
 
 error: global memory invariant does not hold
-   ┌─ tests/sources/functional/trace.move:37:5
+   ┌─ tests/sources/functional/trace.move:38:5
    │
-37 │     invariant forall addr: address: exists<R>(addr) ==> global<R>(addr).x < 5;
+38 │     invariant forall addr: address: exists<R>(addr) ==> global<R>(addr).x < 5;
    │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │
-   =     at tests/sources/functional/trace.move:28: publish_invalid
-   =     at tests/sources/functional/trace.move:32: publish_invalid (spec)
+   = Related Global Memory:
+   =         Resource name: TestTracing_R
+   =         Values:  {Address(0): <redacted>, Default: empty}
+   =     at tests/sources/functional/trace.move:29: publish_invalid
+   =     at tests/sources/functional/trace.move:33: publish_invalid (spec)
    =         `let addr = Signer::address_of(s);` = <redacted>
-   =     at tests/sources/functional/trace.move:28: publish_invalid
+   =     at tests/sources/functional/trace.move:29: publish_invalid
    =         s = <redacted>
    =         x = <redacted>
-   =     at tests/sources/functional/trace.move:29: publish_invalid
-   =     at tests/sources/functional/trace.move:37
+   =     at tests/sources/functional/trace.move:30: publish_invalid
+   =     at tests/sources/functional/trace.move:38
 
 error: post-condition does not hold
-   ┌─ tests/sources/functional/trace.move:33:9
+   ┌─ tests/sources/functional/trace.move:34:9
    │
-33 │         ensures exists<R>(addr) ==> global<R>(addr).x == x;
+34 │         ensures exists<R>(addr) ==> global<R>(addr).x == x;
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │
+   = Related Global Memory:
+   =         Resource name: TestTracing_R
+   =         Values:  {Address(6334): <redacted>, Default: empty}
    = Related Bindings:
    =         addr = <redacted>
    =         exists<R>(addr) = <redacted>
    =         global<R>(addr) = <redacted>
    =         x = <redacted>
    = Execution Trace:
-   =     at tests/sources/functional/trace.move:28: publish_invalid
-   =     at tests/sources/functional/trace.move:32: publish_invalid (spec)
+   =     at tests/sources/functional/trace.move:29: publish_invalid
+   =     at tests/sources/functional/trace.move:33: publish_invalid (spec)
    =         `let addr = Signer::address_of(s);` = <redacted>
-   =     at tests/sources/functional/trace.move:28: publish_invalid
+   =     at tests/sources/functional/trace.move:29: publish_invalid
    =         s = <redacted>
    =         x = <redacted>
-   =     at tests/sources/functional/trace.move:29: publish_invalid
-   =     at tests/sources/functional/trace.move:37
    =     at tests/sources/functional/trace.move:30: publish_invalid
-   =     at tests/sources/functional/trace.move:33: publish_invalid (spec)
+   =     at tests/sources/functional/trace.move:38
+   =     at tests/sources/functional/trace.move:31: publish_invalid
+   =     at tests/sources/functional/trace.move:34: publish_invalid (spec)
    =         `ensures exists<R>(addr) ==> global<R>(addr).x == x;` = <redacted>
 
 error: post-condition does not hold
-   ┌─ tests/sources/functional/trace.move:25:9
+   ┌─ tests/sources/functional/trace.move:26:9
    │
-25 │         ensures a == old(a) + b;
+26 │         ensures a == old(a) + b;
    │         ^^^^^^^^^^^^^^^^^^^^^^^^
    │
    = Related Bindings:
@@ -69,11 +75,11 @@ error: post-condition does not hold
    =         b = <redacted>
    =         old(a) = <redacted>
    = Execution Trace:
-   =     at tests/sources/functional/trace.move:21: update_invalid
-   =         a = <redacted>
-   =         b = <redacted>
    =     at tests/sources/functional/trace.move:22: update_invalid
    =         a = <redacted>
+   =         b = <redacted>
    =     at tests/sources/functional/trace.move:23: update_invalid
-   =     at tests/sources/functional/trace.move:25: update_invalid (spec)
+   =         a = <redacted>
+   =     at tests/sources/functional/trace.move:24: update_invalid
+   =     at tests/sources/functional/trace.move:26: update_invalid (spec)
    =         `ensures a == old(a) + b;` = <redacted>

--- a/language/move-prover/tests/sources/functional/trace.move
+++ b/language/move-prover/tests/sources/functional/trace.move
@@ -1,4 +1,5 @@
 // flag: --trace
+// separate_baseline: cvc5
 // separate_baseline: simplify
 module 0x42::TestTracing {
     use Std::Signer;


### PR DESCRIPTION
## Motivation

A new feature to print out the content of the related global memory along with the counter example trace when "--trace" is set in the prover. In this PR, we define the global memory as the memory that is accessed in the function where the verification fails.

The output looks like:

```
    =         Resource name: DiemTimestamp_CurrentTimeMicroseconds 
    =         Values: 
    =           {
    =             Address(173345816): DiemTimestamp.CurrentTimeMicroseconds{
    =               microseconds = 18446744073709551615},
    =             Default: DiemTimestamp.CurrentTimeMicroseconds{
    =               microseconds = 18446744073709551615}}
```


### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

cargo test

