### PR TITLE
Update arg parsing to clap v3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -439,10 +439,40 @@ dependencies = [
  "ansi_term 0.11.0",
  "atty",
  "bitflags",
- "strsim",
- "textwrap",
+ "strsim 0.8.0",
+ "textwrap 0.11.0",
  "unicode-width",
  "vec_map",
+]
+
+[[package]]
+name = "clap"
+version = "3.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5177fac1ab67102d8989464efd043c6ff44191b1557ec1ddd489b4f7e1447e77"
+dependencies = [
+ "atty",
+ "bitflags",
+ "clap_derive",
+ "indexmap",
+ "lazy_static 1.4.0",
+ "os_str_bytes",
+ "strsim 0.10.0",
+ "termcolor",
+ "textwrap 0.14.2",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01d42c94ce7c2252681b5fed4d3627cc807b13dfc033246bd05d5b252399000e"
+dependencies = [
+ "heck 0.4.0",
+ "proc-macro-error",
+ "proc-macro2 1.0.28",
+ "quote 1.0.9",
+ "syn 1.0.74",
 ]
 
 [[package]]
@@ -565,7 +595,7 @@ checksum = "ab327ed7354547cc2ef43cbe20ef68b988e70b4b593cbd66a2a61733123a3d23"
 dependencies = [
  "atty",
  "cast",
- "clap",
+ "clap 2.33.3",
  "criterion-plot",
  "csv",
  "itertools 0.10.1",
@@ -1429,6 +1459,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1860,12 +1896,12 @@ checksum = "c9be0862c1b3f26a88803c4a49de6889c10e608b3ee9344e6ef5b45fb37ad3d1"
 name = "mirai-dataflow-analysis"
 version = "0.1.0"
 dependencies = [
+ "clap 3.1.2",
  "csv",
  "mirai-annotations",
  "regex",
  "serde 1.0.130",
  "serde_json",
- "structopt 0.3.25",
  "workspace-hack",
 ]
 
@@ -1891,7 +1927,7 @@ dependencies = [
  "bcs",
  "codespan-reporting",
  "datatest-stable",
- "heck",
+ "heck 0.3.2",
  "log",
  "move-bytecode-verifier",
  "move-command-line-common",
@@ -1908,12 +1944,12 @@ dependencies = [
 name = "move-analyzer"
 version = "0.0.0"
 dependencies = [
+ "clap 3.1.2",
  "lsp-server",
  "lsp-types",
  "move-command-line-common",
  "move-compiler",
  "serde_json",
- "structopt 0.3.25",
  "workspace-hack",
 ]
 
@@ -1989,13 +2025,13 @@ name = "move-bytecode-viewer"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "clap 3.1.2",
  "move-binary-format",
  "move-bytecode-source-map",
  "move-command-line-common",
  "move-disassembler",
  "move-ir-types",
  "regex",
- "structopt 0.3.25",
  "termion",
  "tui",
  "workspace-hack",
@@ -2007,6 +2043,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bcs",
+ "clap 3.1.2",
  "codespan-reporting",
  "colored",
  "datatest-stable",
@@ -2038,7 +2075,6 @@ dependencies = [
  "read-write-set-dynamic",
  "serde 1.0.130",
  "serde_yaml",
- "structopt 0.3.25",
  "tempfile",
  "walkdir",
  "workspace-hack",
@@ -2063,6 +2099,7 @@ version = "0.0.1"
 dependencies = [
  "anyhow",
  "bcs",
+ "clap 3.1.2",
  "codespan-reporting",
  "datatest-stable",
  "difference",
@@ -2081,7 +2118,6 @@ dependencies = [
  "once_cell",
  "petgraph 0.5.1",
  "regex",
- "structopt 0.3.25",
  "tempfile",
  "walkdir",
  "workspace-hack",
@@ -2122,6 +2158,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bcs",
+ "clap 3.1.2",
  "codespan",
  "colored",
  "move-binary-format",
@@ -2133,7 +2170,6 @@ dependencies = [
  "once_cell",
  "petgraph 0.5.1",
  "serde 1.0.130",
- "structopt 0.3.25",
  "workspace-hack",
 ]
 
@@ -2142,6 +2178,7 @@ name = "move-disassembler"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "clap 3.1.2",
  "colored",
  "move-binary-format",
  "move-bytecode-source-map",
@@ -2151,7 +2188,6 @@ dependencies = [
  "move-core-types",
  "move-coverage",
  "move-ir-types",
- "structopt 0.3.25",
  "workspace-hack",
 ]
 
@@ -2200,9 +2236,9 @@ name = "move-explain"
 version = "0.1.0"
 dependencies = [
  "bcs",
+ "clap 3.1.2",
  "move-command-line-common",
  "move-core-types",
- "structopt 0.3.25",
  "workspace-hack",
 ]
 
@@ -2212,6 +2248,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bcs",
+ "clap 3.1.2",
  "move-binary-format",
  "move-bytecode-source-map",
  "move-bytecode-verifier",
@@ -2221,7 +2258,6 @@ dependencies = [
  "move-ir-types",
  "move-symbol-pool",
  "serde_json",
- "structopt 0.3.25",
  "workspace-hack",
 ]
 
@@ -2314,6 +2350,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bcs",
+ "clap 3.1.2",
  "colored",
  "datatest-stable",
  "move-abigen",
@@ -2335,7 +2372,6 @@ dependencies = [
  "serde 1.0.130",
  "serde_yaml",
  "sha2",
- "structopt 0.3.25",
  "tempfile",
  "toml",
  "walkdir",
@@ -2349,7 +2385,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "atty",
- "clap",
+ "clap 2.33.3",
  "codespan",
  "codespan-reporting",
  "datatest-stable",
@@ -2487,6 +2523,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bytecode-interpreter-crypto",
+ "clap 3.1.2",
  "codespan-reporting",
  "datatest-stable",
  "itertools 0.10.1",
@@ -2498,7 +2535,6 @@ dependencies = [
  "move-vm-runtime",
  "num 0.4.0",
  "serde 1.0.130",
- "structopt 0.3.25",
  "workspace-hack",
 ]
 
@@ -2546,7 +2582,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "atty",
- "clap",
+ "clap 3.1.2",
  "codespan",
  "codespan-reporting",
  "datatest-stable",
@@ -2579,7 +2615,6 @@ dependencies = [
  "sha3 0.9.1",
  "shell-words",
  "simplelog",
- "structopt 0.3.25",
  "tempfile",
  "tera",
  "tokio",
@@ -2626,6 +2661,7 @@ name = "move-unit-test"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "clap 3.1.2",
  "colored",
  "datatest-stable",
  "difference",
@@ -2643,7 +2679,6 @@ dependencies = [
  "move-vm-types",
  "rayon",
  "regex",
- "structopt 0.3.25",
  "workspace-hack",
 ]
 
@@ -3024,6 +3059,15 @@ checksum = "fb233f06c2307e1f5ce2ecad9f8121cffbbee2c95428f44ea85222e460d0d213"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "os_str_bytes"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -3438,7 +3482,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "chrono",
- "clap",
+ "clap 2.33.3",
  "codespan-reporting",
  "datatest-stable",
  "hex",
@@ -3463,7 +3507,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "chrono",
- "clap",
+ "clap 2.33.3",
  "codespan",
  "codespan-reporting",
  "datatest-stable",
@@ -4215,13 +4259,13 @@ name = "spec-flatten"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "clap 3.1.2",
  "itertools 0.10.1",
  "move-compiler",
  "move-model",
  "move-prover",
  "move-stackless-bytecode",
  "pretty",
- "structopt 0.3.25",
  "workspace-hack",
 ]
 
@@ -4253,12 +4297,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "structopt"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16c2cdbf9cc375f15d1b4141bc48aeef444806655cd0e904207edc8d68d86ed7"
 dependencies = [
- "clap",
+ "clap 2.33.3",
  "structopt-derive 0.2.18",
 ]
 
@@ -4268,7 +4318,7 @@ version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40b9788f4202aa75c240ecc9c15c65185e6a39ccdeb0fd5d008b98825464c87c"
 dependencies = [
- "clap",
+ "clap 2.33.3",
  "lazy_static 1.4.0",
  "structopt-derive 0.4.18",
 ]
@@ -4279,7 +4329,7 @@ version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53010261a84b37689f9ed7d395165029f9cc7abb9f56bbfe86bee2597ed25107"
 dependencies = [
- "heck",
+ "heck 0.3.2",
  "proc-macro2 0.4.30",
  "quote 0.6.13",
  "syn 0.15.44",
@@ -4291,7 +4341,7 @@ version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
 dependencies = [
- "heck",
+ "heck 0.3.2",
  "proc-macro-error",
  "proc-macro2 1.0.28",
  "quote 1.0.9",
@@ -4443,6 +4493,7 @@ dependencies = [
 name = "test-generation"
 version = "0.1.0"
 dependencies = [
+ "clap 3.1.2",
  "crossbeam-channel",
  "getrandom 0.2.2",
  "hex",
@@ -4460,7 +4511,6 @@ dependencies = [
  "num_cpus",
  "once_cell",
  "rand 0.8.4",
- "structopt 0.3.25",
  "tracing",
  "tracing-subscriber",
  "workspace-hack",
@@ -4474,6 +4524,12 @@ checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
 ]
+
+[[package]]
+name = "textwrap"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
 
 [[package]]
 name = "thiserror"
@@ -5073,6 +5129,7 @@ dependencies = [
  "camino",
  "cargo_metadata",
  "chrono",
+ "clap 3.1.2",
  "colored-diff",
  "determinator",
  "env_logger",
@@ -5088,7 +5145,6 @@ dependencies = [
  "regex",
  "serde 1.0.130",
  "serde_json",
- "structopt 0.3.25",
  "supports-color",
  "toml",
  "x-core",

--- a/devtools/x/Cargo.toml
+++ b/devtools/x/Cargo.toml
@@ -13,7 +13,7 @@ cargo_metadata = "0.14.0"
 determinator = "0.7.0"
 serde = { version = "1.0.124", features = ["derive"] }
 serde_json = "1.0.64"
-structopt = "0.3.21"
+clap = { version = "3.1", features = ["derive"] }
 anyhow = "1.0.52"
 colored-diff = "0.2.2"
 guppy = { version = "0.12.3", features = ["summaries"] }

--- a/devtools/x/src/bench.rs
+++ b/devtools/x/src/bench.rs
@@ -1,28 +1,29 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use clap::Args;
+
 use crate::{
     cargo::{selected_package::SelectedPackageArgs, CargoCommand},
     context::XContext,
     Result,
 };
 use std::ffi::OsString;
-use structopt::StructOpt;
 
-#[derive(Debug, StructOpt)]
-pub struct Args {
-    #[structopt(flatten)]
+#[derive(Debug, Args)]
+pub struct BenchArgs {
+    #[clap(flatten)]
     package_args: SelectedPackageArgs,
     /// Do not run the benchmarks, but compile them
-    #[structopt(long)]
+    #[clap(long)]
     no_run: bool,
-    #[structopt(name = "BENCHNAME", parse(from_os_str))]
+    #[clap(name = "BENCHNAME", parse(from_os_str))]
     benchname: Option<OsString>,
-    #[structopt(name = "ARGS", parse(from_os_str), last = true)]
+    #[clap(name = "ARGS", parse(from_os_str), last = true)]
     args: Vec<OsString>,
 }
 
-pub fn run(mut args: Args, xctx: XContext) -> Result<()> {
+pub fn run(mut args: BenchArgs, xctx: XContext) -> Result<()> {
     args.args.extend(args.benchname.clone());
 
     let mut direct_args = Vec::new();

--- a/devtools/x/src/build.rs
+++ b/devtools/x/src/build.rs
@@ -1,29 +1,29 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 use crate::{
-    cargo::{build_args::BuildArgs, selected_package::SelectedPackageArgs, CargoCommand},
+    cargo::{build_args::BuildArgsInner, selected_package::SelectedPackageArgs, CargoCommand},
     context::XContext,
     Result,
 };
+use clap::Args;
 use log::info;
 use std::ffi::OsString;
-use structopt::StructOpt;
 
-#[derive(Debug, StructOpt)]
-pub struct Args {
-    #[structopt(flatten)]
+#[derive(Debug, Args)]
+pub struct BuildArgs {
+    #[clap(flatten)]
     package_args: SelectedPackageArgs,
-    #[structopt(flatten)]
-    build_args: BuildArgs,
-    #[structopt(long, parse(from_os_str))]
+    #[clap(flatten)]
+    build_args: BuildArgsInner,
+    #[clap(long, parse(from_os_str))]
     /// Copy final artifacts to this directory (unstable)
     out_dir: Option<OsString>,
-    #[structopt(long)]
+    #[clap(long)]
     /// Output the build plan in JSON (unstable)
     build_plan: bool,
 }
 
-pub fn convert_args(args: &Args) -> Vec<OsString> {
+pub fn convert_args(args: &BuildArgs) -> Vec<OsString> {
     let mut direct_args = Vec::new();
     args.build_args.add_args(&mut direct_args);
     if let Some(out_dir) = &args.out_dir {
@@ -37,7 +37,7 @@ pub fn convert_args(args: &Args) -> Vec<OsString> {
     direct_args
 }
 
-pub fn run(args: Box<Args>, xctx: XContext) -> Result<()> {
+pub fn run(args: Box<BuildArgs>, xctx: XContext) -> Result<()> {
     info!("Build plan: {}", args.build_plan);
 
     let direct_args = convert_args(&args);

--- a/devtools/x/src/cargo/selected_package.rs
+++ b/devtools/x/src/cargo/selected_package.rs
@@ -3,29 +3,33 @@
 
 use crate::{changed_since::changed_since_impl, context::XContext, Result};
 use anyhow::{anyhow, Context};
+use clap::Args;
 use guppy::graph::DependencyDirection;
 use log::warn;
 use std::collections::BTreeSet;
-use structopt::StructOpt;
 use x_core::WorkspaceStatus;
 
 /// Arguments for the Cargo package selector.
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Args)]
 pub struct SelectedPackageArgs {
-    #[structopt(long, short, number_of_values = 1)]
     /// Run on the provided packages
+    #[clap(long, short, number_of_values = 1)]
     pub(crate) package: Vec<String>,
-    #[structopt(long, short, number_of_values = 1)]
+
     /// Run on the specified members (package subsets)
+    #[clap(long, short, number_of_values = 1)]
     pub(crate) members: Vec<String>,
-    #[structopt(long, number_of_values = 1)]
+
     /// Exclude packages
+    #[clap(long, number_of_values = 1)]
     pub(crate) exclude: Vec<String>,
-    #[structopt(long, short)]
+
     /// Run on packages changed since the merge base of this commit
+    #[clap(long, short)]
     changed_since: Option<String>,
-    #[structopt(long)]
+
     /// Run on all packages in the workspace
+    #[clap(long)]
     pub(crate) workspace: bool,
 }
 

--- a/devtools/x/src/changed_since.rs
+++ b/devtools/x/src/changed_since.rs
@@ -3,19 +3,19 @@
 
 use crate::{context::XContext, Result};
 use anyhow::Context;
+use clap::Args;
 use determinator::Determinator;
 use guppy::graph::{DependencyDirection, PackageSet};
 use log::trace;
-use structopt::StructOpt;
 use x_core::git::GitCli;
 
-#[derive(Debug, StructOpt)]
-pub struct Args {
+#[derive(Debug, Args)]
+pub struct ChangedSinceArgs {
     /// List packages changed since this commit
     pub(crate) base: String,
 }
 
-pub fn run(args: Args, xctx: XContext) -> Result<()> {
+pub fn run(args: ChangedSinceArgs, xctx: XContext) -> Result<()> {
     let git_cli = xctx.core().git_cli().with_context(|| {
         "`x changed-since` must be run within a project cloned from a git repo."
     })?;

--- a/devtools/x/src/check.rs
+++ b/devtools/x/src/check.rs
@@ -1,22 +1,23 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use clap::Args;
+
 use crate::{
-    cargo::{build_args::BuildArgs, selected_package::SelectedPackageArgs, CargoCommand},
+    cargo::{build_args::BuildArgsInner, selected_package::SelectedPackageArgs, CargoCommand},
     context::XContext,
     Result,
 };
-use structopt::StructOpt;
 
-#[derive(Debug, StructOpt)]
-pub struct Args {
-    #[structopt(flatten)]
+#[derive(Debug, Args)]
+pub struct CheckArgs {
+    #[clap(flatten)]
     pub(crate) package_args: SelectedPackageArgs,
-    #[structopt(flatten)]
-    pub(crate) build_args: BuildArgs,
+    #[clap(flatten)]
+    pub(crate) build_args: BuildArgsInner,
 }
 
-pub fn run(args: Args, xctx: XContext) -> Result<()> {
+pub fn run(args: CheckArgs, xctx: XContext) -> Result<()> {
     let mut direct_args = vec![];
     args.build_args.add_args(&mut direct_args);
 

--- a/devtools/x/src/clippy.rs
+++ b/devtools/x/src/clippy.rs
@@ -1,25 +1,26 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use clap::Args;
+
 use crate::{
-    cargo::{build_args::BuildArgs, selected_package::SelectedPackageArgs, CargoCommand},
+    cargo::{build_args::BuildArgsInner, selected_package::SelectedPackageArgs, CargoCommand},
     context::XContext,
     Result,
 };
 use std::ffi::OsString;
-use structopt::StructOpt;
 
-#[derive(Debug, StructOpt)]
-pub struct Args {
-    #[structopt(flatten)]
+#[derive(Debug, Args)]
+pub struct ClippyArgs {
+    #[clap(flatten)]
     pub(crate) package_args: SelectedPackageArgs,
-    #[structopt(flatten)]
-    pub(crate) build_args: BuildArgs,
-    #[structopt(name = "ARGS", parse(from_os_str), last = true)]
+    #[clap(flatten)]
+    pub(crate) build_args: BuildArgsInner,
+    #[clap(name = "ARGS", parse(from_os_str), last = true)]
     args: Vec<OsString>,
 }
 
-pub fn run(args: Args, xctx: XContext) -> Result<()> {
+pub fn run(args: ClippyArgs, xctx: XContext) -> Result<()> {
     let mut pass_through_args = vec!["-D".into(), "warnings".into()];
     for lint in xctx.config().allowed_clippy_lints() {
         pass_through_args.push("-A".into());

--- a/devtools/x/src/diff_summary.rs
+++ b/devtools/x/src/diff_summary.rs
@@ -2,33 +2,31 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::context::XContext;
+use clap::{ArgEnum, Args};
 use guppy::graph::summaries::{diff::SummaryDiff, Summary};
 use std::{fs, path::PathBuf};
-use structopt::{clap::arg_enum, StructOpt};
 
-arg_enum! {
-    #[derive(Debug, Copy, Clone)]
-    pub enum OutputFormat {
-        Toml,
-        Json,
-        Text,
-    }
+#[derive(Debug, Copy, Clone, ArgEnum)]
+pub enum OutputFormat {
+    Toml,
+    Json,
+    Text,
 }
 
-#[derive(Debug, StructOpt)]
-pub struct Args {
-    #[structopt(name = "BASE_SUMMARY")]
+#[derive(Debug, Args)]
+pub struct DiffSummaryArgs {
+    #[clap(name = "BASE_SUMMARY")]
     /// Path to the base summary
     base_summary: PathBuf,
-    #[structopt(name = "COMPARE_SUMMARY")]
+    #[clap(name = "COMPARE_SUMMARY")]
     /// Path to the comparison summary
     compare_summary: PathBuf,
-    #[structopt(name = "OUTPUT_FORMAT", default_value = "Text")]
+    #[clap(name = "OUTPUT_FORMAT", arg_enum, default_value_t = OutputFormat::Text)]
     /// optionally, output can be formated as json or toml
     output_format: OutputFormat,
 }
 
-pub fn run(args: Args, _xctx: XContext) -> crate::Result<()> {
+pub fn run(args: DiffSummaryArgs, _xctx: XContext) -> crate::Result<()> {
     let base_summary_text = fs::read_to_string(&args.base_summary)?;
     let base_summary = Summary::parse(&base_summary_text)?;
     let compare_summary_text = fs::read_to_string(&args.compare_summary)?;

--- a/devtools/x/src/fix.rs
+++ b/devtools/x/src/fix.rs
@@ -1,25 +1,26 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use clap::Args;
+
 use crate::{
-    cargo::{build_args::BuildArgs, selected_package::SelectedPackageArgs, CargoCommand},
+    cargo::{build_args::BuildArgsInner, selected_package::SelectedPackageArgs, CargoCommand},
     context::XContext,
     Result,
 };
 use std::ffi::OsString;
-use structopt::StructOpt;
 
-#[derive(Debug, StructOpt)]
-pub struct Args {
-    #[structopt(flatten)]
+#[derive(Debug, Args)]
+pub struct FixArgs {
+    #[clap(flatten)]
     pub(crate) package_args: SelectedPackageArgs,
-    #[structopt(flatten)]
-    pub(crate) build_args: BuildArgs,
-    #[structopt(name = "ARGS", parse(from_os_str), last = true)]
+    #[clap(flatten)]
+    pub(crate) build_args: BuildArgsInner,
+    #[clap(name = "ARGS", parse(from_os_str), last = true)]
     args: Vec<OsString>,
 }
 
-pub fn run(mut args: Args, xctx: XContext) -> Result<()> {
+pub fn run(mut args: FixArgs, xctx: XContext) -> Result<()> {
     let mut pass_through_args = vec![];
     pass_through_args.extend(args.args);
 

--- a/devtools/x/src/fmt.rs
+++ b/devtools/x/src/fmt.rs
@@ -1,28 +1,29 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use clap::Args;
+
 use crate::{cargo::Cargo, context::XContext, Result};
 use std::ffi::OsString;
-use structopt::StructOpt;
 
-#[derive(Debug, StructOpt)]
-pub struct Args {
-    #[structopt(long)]
+#[derive(Debug, Args)]
+pub struct FmtArgs {
+    #[clap(long)]
     /// Run in 'check' mode. Exits with 0 if input is
     /// formatted correctly. Exits with 1 and prints a diff if
     /// formatting is required.
     check: bool,
 
-    #[structopt(long)]
+    #[clap(long)]
     /// Run check on all packages in the workspace
     workspace: bool,
 
-    #[structopt(name = "ARGS", parse(from_os_str), last = true)]
+    #[clap(name = "ARGS", parse(from_os_str), last = true)]
     /// Pass through args to rustfmt
     args: Vec<OsString>,
 }
 
-pub fn run(args: Args, xctx: XContext) -> Result<()> {
+pub fn run(args: FmtArgs, xctx: XContext) -> Result<()> {
     // Hardcode that we want imports merged
     let mut pass_through_args = vec!["--config".into(), "imports_granularity=crate".into()];
 

--- a/devtools/x/src/generate_workspace_hack.rs
+++ b/devtools/x/src/generate_workspace_hack.rs
@@ -3,29 +3,27 @@
 
 use crate::{cargo::Cargo, context::XContext, Result};
 use anyhow::bail;
+use clap::{ArgEnum, Args};
 use log::info;
-use structopt::{clap::arg_enum, StructOpt};
 
-#[derive(Debug, StructOpt)]
-pub struct Args {
+#[derive(Debug, Args)]
+pub struct GenerateWorkspaceHackArgs {
     /// Mode to run in
-    #[structopt(long, case_insensitive = true, possible_values = &WorkspaceHackMode::variants(), default_value = "write")]
+    #[clap(long, arg_enum, ignore_case = true, default_value_t = WorkspaceHackMode::Write)]
     mode: WorkspaceHackMode,
 }
 
-arg_enum! {
-    #[derive(Clone, Copy, Debug)]
-    /// Valid modes for generate-workspace-hack
-    pub enum WorkspaceHackMode {
-        Write,
-        Diff,
-        Check,
-        Verify,
-        Disable,
-    }
+#[derive(Clone, Copy, Debug, ArgEnum)]
+/// Valid modes for generate-workspace-hack
+pub enum WorkspaceHackMode {
+    Write,
+    Diff,
+    Check,
+    Verify,
+    Disable,
 }
 
-pub fn run(args: Args, xctx: XContext) -> Result<()> {
+pub fn run(args: GenerateWorkspaceHackArgs, xctx: XContext) -> Result<()> {
     let hakari_builder = xctx.core().hakari_builder()?;
     let &hakari_package = hakari_builder
         .hakari_package()

--- a/devtools/x/src/lint/mod.rs
+++ b/devtools/x/src/lint/mod.rs
@@ -3,7 +3,7 @@
 
 use crate::context::XContext;
 use anyhow::anyhow;
-use structopt::StructOpt;
+use clap::Args;
 use x_lint::prelude::*;
 
 mod allowed_paths;
@@ -15,13 +15,13 @@ mod whitespace;
 mod workspace_classify;
 mod workspace_hack;
 
-#[derive(Debug, StructOpt)]
-pub struct Args {
-    #[structopt(long)]
+#[derive(Debug, Args)]
+pub struct LintArgs {
+    #[clap(long)]
     fail_fast: bool,
 }
 
-pub fn run(args: Args, xctx: XContext) -> crate::Result<()> {
+pub fn run(args: LintArgs, xctx: XContext) -> crate::Result<()> {
     let workspace_config = xctx.config().workspace_config();
 
     let project_linters: &[&dyn ProjectLinter] = &[

--- a/devtools/x/src/nextest.rs
+++ b/devtools/x/src/nextest.rs
@@ -2,12 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    cargo::{build_args::BuildArgs, selected_package::SelectedPackageArgs, CargoCommand},
+    cargo::{build_args::BuildArgsInner, selected_package::SelectedPackageArgs, CargoCommand},
     context::XContext,
     Result,
 };
 use anyhow::{bail, Context};
 use camino::Utf8PathBuf;
+use clap::Args;
 use nextest_config::{NextestConfig, StatusLevel, TestOutputDisplay};
 use nextest_runner::{
     partition::PartitionerBuilder,
@@ -18,57 +19,56 @@ use nextest_runner::{
     SignalHandler,
 };
 use std::{ffi::OsString, io::Cursor};
-use structopt::StructOpt;
 use supports_color::Stream;
 
-#[derive(Debug, StructOpt)]
-pub struct Args {
+#[derive(Debug, Args)]
+pub struct NextestArgs {
     /// Nextest profile to use
-    #[structopt(long, short = "P")]
+    #[clap(long, short = 'P')]
     nextest_profile: Option<String>,
     /// Config file [default: workspace-root/.config/nextest.toml]
     config_file: Option<Utf8PathBuf>,
-    #[structopt(flatten)]
+    #[clap(flatten)]
     pub(crate) package_args: SelectedPackageArgs,
-    #[structopt(long, short)]
+    #[clap(long, short)]
     /// Skip running expensive diem testsuite integration tests
     unit: bool,
-    #[structopt(flatten)]
-    pub(crate) build_args: BuildArgs,
-    #[structopt(flatten)]
+    #[clap(flatten)]
+    pub(crate) build_args: BuildArgsInner,
+    #[clap(flatten)]
     pub(crate) runner_opts: TestRunnerOpts,
-    #[structopt(flatten)]
+    #[clap(flatten)]
     reporter_opts: TestReporterOpts,
-    #[structopt(long)]
+    #[clap(long)]
     /// Do not run tests, only compile the test executables
     no_run: bool,
     /// Run ignored tests
-    #[structopt(long, possible_values = &RunIgnored::variants(), default_value, case_insensitive = true)]
+    #[clap(long, possible_values = RunIgnored::variants(), default_value_t, ignore_case = true)]
     run_ignored: RunIgnored,
     /// Test partition, e.g. hash:1/2 or count:2/3
-    #[structopt(long)]
+    #[clap(long)]
     partition: Option<PartitionerBuilder>,
-    #[structopt(name = "FILTERS", last = true)]
+    #[clap(name = "FILTERS", last = true)]
     filters: Vec<String>,
 }
 
 /// Test runner options.
-#[derive(Debug, Default, StructOpt)]
+#[derive(Debug, Default, Args)]
 pub struct TestRunnerOpts {
     /// Number of retries for failing tests [default: from profile]
-    #[structopt(long)]
+    #[clap(long)]
     retries: Option<usize>,
 
     /// Cancel test run on the first failure
-    #[structopt(long)]
+    #[clap(long)]
     fail_fast: bool,
 
     /// Run all tests regardless of failure
-    #[structopt(long, overrides_with = "fail-fast")]
+    #[clap(long, overrides_with = "fail-fast")]
     no_fail_fast: bool,
 
     /// Number of tests to run simultaneously [default: logical CPU count]
-    #[structopt(long)]
+    #[clap(long)]
     test_threads: Option<usize>,
 }
 
@@ -91,17 +91,16 @@ impl TestRunnerOpts {
     }
 }
 
-#[derive(Debug, Default, StructOpt)]
-#[structopt(rename_all = "kebab-case")]
+#[derive(Debug, Default, Args)]
 pub struct TestReporterOpts {
     /// Output stdout and stderr on failure
-    #[structopt(long, possible_values = TestOutputDisplay::variants(), case_insensitive = true)]
+    #[clap(long, possible_values = TestOutputDisplay::variants(), ignore_case = true)]
     failure_output: Option<TestOutputDisplay>,
     /// Output stdout and stderr on success
-    #[structopt(long, possible_values = TestOutputDisplay::variants(), case_insensitive = true)]
+    #[clap(long, possible_values = TestOutputDisplay::variants(), ignore_case = true)]
     success_output: Option<TestOutputDisplay>,
     /// Test statuses to output
-    #[structopt(long, possible_values = StatusLevel::variants(), case_insensitive = true)]
+    #[clap(long, possible_values = StatusLevel::variants(), ignore_case = true)]
     status_level: Option<StatusLevel>,
 }
 
@@ -121,7 +120,7 @@ impl TestReporterOpts {
     }
 }
 
-pub fn run(args: Args, xctx: XContext) -> Result<()> {
+pub fn run(args: NextestArgs, xctx: XContext) -> Result<()> {
     let config = xctx.config();
 
     let mut packages = args.package_args.to_selected_packages(&xctx)?;

--- a/devtools/x/src/playground.rs
+++ b/devtools/x/src/playground.rs
@@ -12,7 +12,7 @@
 
 use crate::context::XContext;
 use anyhow::anyhow;
-use structopt::StructOpt;
+use clap::Args;
 use x_lint::prelude::*;
 
 #[derive(Copy, Clone, Debug)]
@@ -101,14 +101,14 @@ impl ContentLinter for PlaygroundContent {
 
 // ---
 
-#[derive(Debug, StructOpt)]
-pub struct Args {
+#[derive(Debug, Args)]
+pub struct PlaygroundArgs {
     /// Dummy arg that doesn't do anything
-    #[structopt(long)]
+    #[clap(long)]
     dummy: bool,
 }
 
-pub fn run(args: Args, xctx: XContext) -> crate::Result<()> {
+pub fn run(args: PlaygroundArgs, xctx: XContext) -> crate::Result<()> {
     let engine = LintEngineConfig::new(xctx.core())
         .with_project_linters(&[&PlaygroundProject])
         .with_package_linters(&[&PlaygroundPackage])

--- a/devtools/x/src/test.rs
+++ b/devtools/x/src/test.rs
@@ -2,12 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    cargo::{build_args::BuildArgs, selected_package::SelectedPackageArgs, CargoCommand},
+    cargo::{build_args::BuildArgsInner, selected_package::SelectedPackageArgs, CargoCommand},
     context::XContext,
     utils::project_root,
     Result,
 };
 use anyhow::{anyhow, Error};
+use clap::Args;
 use log::info;
 use std::{
     ffi::OsString,
@@ -15,40 +16,39 @@ use std::{
     path::{Path, PathBuf},
     process::{Command, Stdio},
 };
-use structopt::StructOpt;
 
-#[derive(Debug, StructOpt)]
-pub struct Args {
-    #[structopt(flatten)]
+#[derive(Debug, Args)]
+pub struct TestArgs {
+    #[clap(flatten)]
     pub(crate) package_args: SelectedPackageArgs,
-    #[structopt(long, short)]
+    #[clap(long, short)]
     /// Skip running expensive diem testsuite integration tests
     unit: bool,
-    #[structopt(long)]
+    #[clap(long)]
     /// Only run doctests
     doc: bool,
-    #[structopt(flatten)]
-    pub(crate) build_args: BuildArgs,
-    #[structopt(long)]
+    #[clap(flatten)]
+    pub(crate) build_args: BuildArgsInner,
+    #[clap(long)]
     /// Do not fast fail the run if tests (or test executables) fail
     no_fail_fast: bool,
-    #[structopt(long)]
+    #[clap(long)]
     /// Do not run tests, only compile the test executables
     no_run: bool,
-    #[structopt(long, parse(from_os_str))]
+    #[clap(long, parse(from_os_str))]
     /// Directory to output HTML coverage report (using grcov)
     html_cov_dir: Option<PathBuf>,
-    #[structopt(long, parse(from_os_str))]
+    #[clap(long, parse(from_os_str))]
     /// Directory to output lcov coverage html (using grcov -> lcov.info -> html using genhtml).
     /// Only useful if you want the lcov.info file produced in the path.  Requires that lcov be installed and on PATH.
     html_lcov_dir: Option<PathBuf>,
-    #[structopt(name = "TESTNAME", parse(from_os_str))]
+    #[clap(name = "TESTNAME", parse(from_os_str))]
     testname: Option<OsString>,
-    #[structopt(name = "ARGS", parse(from_os_str), last = true)]
+    #[clap(name = "ARGS", parse(from_os_str), last = true)]
     args: Vec<OsString>,
 }
 
-pub fn run(mut args: Args, xctx: XContext) -> Result<()> {
+pub fn run(mut args: TestArgs, xctx: XContext) -> Result<()> {
     let config = xctx.config();
 
     let mut packages = args.package_args.to_selected_packages(&xctx)?;

--- a/devtools/x/src/tools.rs
+++ b/devtools/x/src/tools.rs
@@ -3,16 +3,16 @@
 
 use crate::{context::XContext, Result};
 use anyhow::anyhow;
-use structopt::StructOpt;
+use clap::Args;
 
-#[derive(Debug, StructOpt)]
-pub struct Args {
-    #[structopt(long)]
+#[derive(Debug, Args)]
+pub struct ToolsArgs {
+    #[clap(long)]
     /// Run in 'check' mode. Exits with 0 if all tools installed. Exits with 1 and if not, printing failed
     check: bool,
 }
 
-pub fn run(args: Args, xctx: XContext) -> Result<()> {
+pub fn run(args: ToolsArgs, xctx: XContext) -> Result<()> {
     let success = match args.check {
         false => xctx.installer().install_all(),
         true => xctx.installer().check_all(),

--- a/language/evm/move-to-yul/Cargo.toml
+++ b/language/evm/move-to-yul/Cargo.toml
@@ -23,7 +23,7 @@ workspace-hack = { version = "0.1", path = "../../../crates/workspace-hack" }
 async-trait = "0.1.42"
 anyhow = "1.0.38"
 atty = "0.2.14"
-clap = "2.33.3"
+clap = { version = "3.1", features = ["derive"] }
 codespan = "0.11.1"
 codespan-reporting = "0.11.1"
 ethnum = "1.0.4"
@@ -44,7 +44,6 @@ once_cell = "1.7.2"
 tera = "1.7.1"
 tokio = { version = "1.8.1", features = ["full"] }
 toml = "0.5.8"
-structopt = "0.3.21"
 evm = "0.33.1"
 primitive-types = "0.10.1"
 

--- a/language/evm/move-to-yul/src/main.rs
+++ b/language/evm/move-to-yul/src/main.rs
@@ -5,7 +5,7 @@
 
 use codespan_reporting::term::termcolor::{ColorChoice, StandardStream};
 use move_to_yul::{options::Options, run_to_yul};
-use structopt::StructOpt;
+use clap::Parser;
 
 fn main() {
     if let Err(e) = run() {
@@ -20,7 +20,7 @@ fn main() {
 }
 
 fn run() -> anyhow::Result<()> {
-    let options = Options::from_args();
+    let options = Options::parse();
     let color = if atty::is(atty::Stream::Stderr) && atty::is(atty::Stream::Stdout) {
         ColorChoice::Auto
     } else {

--- a/language/evm/move-to-yul/src/options.rs
+++ b/language/evm/move-to-yul/src/options.rs
@@ -3,26 +3,27 @@
 
 use codespan_reporting::diagnostic::Severity;
 use move_command_line_common::env::read_env_var;
-use structopt::StructOpt;
+use clap::Parser;
 
-#[derive(StructOpt, Debug)]
-#[structopt(name = "move-to-yul", about = "Move Solidity Generator")]
+/// Move Solidity Generator
+#[derive(Parser, Debug)]
+#[clap(version, name = "move-to-yul")]
 pub struct Options {
     /// Directories where to lookup dependencies.
-    #[structopt(short)]
+    #[clap(short)]
     pub dependencies: Vec<String>,
     /// Named address mapping.
-    #[structopt(short)]
+    #[clap(short)]
     pub named_address_mapping: Vec<String>,
     /// Output file name.
-    #[structopt(short)]
-    #[structopt(long)]
+    #[clap(short)]
+    #[clap(long)]
     pub output: String,
     /// Solc executable
-    #[structopt(long)]
+    #[clap(long)]
     pub solc_exe: String,
     /// Whether to dump bytecode to a file.
-    #[structopt(long = "dump-bytecode")]
+    #[clap(long = "dump-bytecode")]
     pub dump_bytecode: bool,
     /// Sources to compile (positional arg)
     pub sources: Vec<String>,

--- a/language/move-analyzer/Cargo.toml
+++ b/language/move-analyzer/Cargo.toml
@@ -10,10 +10,10 @@ publish = false
 edition = "2018"
 
 [dependencies]
+clap = { version = "3.1", features = ["derive"] }
 lsp-server = "0.5.1"
 lsp-types = "0.90.1"
 serde_json = "1.0.64"
-structopt = "0.3.21"
 move-command-line-common = { path = "../move-command-line-common" }
 move-compiler = { path = "../move-compiler" }
 workspace-hack = { version = "0.1", path = "../../crates/workspace-hack" }

--- a/language/move-analyzer/src/bin/move-analyzer.rs
+++ b/language/move-analyzer/src/bin/move-analyzer.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use clap::Parser;
+
 use lsp_server::{Connection, Message, Notification, Request, Response};
 use lsp_types::{
     notification::Notification as _, request::Request as _, CompletionOptions, SaveOptions,
@@ -12,16 +14,16 @@ use move_analyzer::{
     context::Context,
     vfs::{on_text_document_sync_notification, VirtualFileSystem},
 };
-use structopt::StructOpt;
 
-#[derive(StructOpt)]
-#[structopt(name = "move-analyzer", about = "A language server for Move")]
+/// A language server for Move
+#[derive(Parser)]
+#[clap(version, name = "move-analyzer")]
 struct Options {}
 
 fn main() {
-    // For now, move-analyzer only responds to options built-in to structopt,
+    // For now, move-analyzer only responds to options built-in to clap,
     // such as `--help` or `--version`.
-    Options::from_args();
+    Options::parse();
 
     // stdio is used to communicate Language Server Protocol requests and responses.
     // stderr is used for logging (and, when Visual Studio Code is used to communicate with this

--- a/language/move-compiler/Cargo.toml
+++ b/language/move-compiler/Cargo.toml
@@ -11,7 +11,7 @@ anyhow = "1.0.52"
 codespan-reporting = "0.11.1"
 hex = "0.4.3"
 regex = "1.4.3"
-structopt = "0.3.21"
+clap = { version = "3.1", features = ["derive"] }
 difference = "2.0.0"
 petgraph = "0.5.1"
 walkdir = "2.3.1"

--- a/language/move-compiler/src/bin/move-build.rs
+++ b/language/move-compiler/src/bin/move-build.rs
@@ -3,22 +3,24 @@
 
 #![forbid(unsafe_code)]
 
+use clap::Parser;
+
 use move_command_line_common::files::verify_and_create_named_address_mapping;
 use move_compiler::{
     command_line::{self as cli},
     shared::{self, Flags, NumericalAddress},
 };
-use structopt::*;
 
-#[derive(Debug, StructOpt)]
-#[structopt(name = "Move Build", about = "Compile Move source to Move bytecode.")]
+/// Compile Move source to Move bytecode.
+#[derive(Debug, Parser)]
+#[clap(version, name = "Move Build")]
 pub struct Options {
     /// The source files to check and compile
-    #[structopt(name = "PATH_TO_SOURCE_FILE")]
+    #[clap(name = "PATH_TO_SOURCE_FILE")]
     pub source_files: Vec<String>,
 
     /// The library files needed as dependencies
-    #[structopt(
+    #[clap(
         name = "PATH_TO_DEPENDENCY_FILE",
         short = cli::DEPENDENCY_SHORT,
         long = cli::DEPENDENCY,
@@ -26,7 +28,7 @@ pub struct Options {
     pub dependencies: Vec<String>,
 
     /// The Move bytecode output directory
-    #[structopt(
+    #[clap(
         name = "PATH_TO_OUTPUT_DIRECTORY",
         short = cli::OUT_DIR_SHORT,
         long = cli::OUT_DIR,
@@ -35,7 +37,7 @@ pub struct Options {
     pub out_dir: String,
 
     /// Save bytecode source map to disk
-    #[structopt(
+    #[clap(
         name = "",
         short = cli::SOURCE_MAP_SHORT,
         long = cli::SOURCE_MAP,
@@ -43,15 +45,15 @@ pub struct Options {
     pub emit_source_map: bool,
 
     /// Named address mapping
-    #[structopt(
+    #[clap(
         name = "NAMED_ADDRESSES",
-        short = "a",
+        short = 'a',
         long = "addresses",
         parse(try_from_str = shared::parse_named_address)
     )]
     pub named_addresses: Vec<(String, NumericalAddress)>,
 
-    #[structopt(flatten)]
+    #[clap(flatten)]
     pub flags: Flags,
 }
 
@@ -63,7 +65,7 @@ pub fn main() -> anyhow::Result<()> {
         emit_source_map,
         flags,
         named_addresses,
-    } = Options::from_args();
+    } = Options::parse();
 
     let interface_files_dir = format!("{}/generated_interface_files", out_dir);
     let named_addr_map = verify_and_create_named_address_mapping(named_addresses)?;

--- a/language/move-compiler/src/bin/move-check.rs
+++ b/language/move-compiler/src/bin/move-check.rs
@@ -3,25 +3,24 @@
 
 #![forbid(unsafe_code)]
 
+use clap::Parser;
+
 use move_command_line_common::files::verify_and_create_named_address_mapping;
 use move_compiler::{
     command_line::{self as cli},
     shared::{self, Flags, NumericalAddress},
 };
-use structopt::*;
 
-#[derive(Debug, StructOpt)]
-#[structopt(
-    name = "Move Check",
-    about = "Check Move source code, without compiling to bytecode."
-)]
+/// Check Move source code, without compiling to bytecode.
+#[derive(Debug, Parser)]
+#[clap(version, name = "Move Check")]
 pub struct Options {
     /// The source files to check
-    #[structopt(name = "PATH_TO_SOURCE_FILE")]
+    #[clap(name = "PATH_TO_SOURCE_FILE")]
     pub source_files: Vec<String>,
 
     /// The library files needed as dependencies
-    #[structopt(
+    #[clap(
         name = "PATH_TO_DEPENDENCY_FILE",
         short = cli::DEPENDENCY_SHORT,
         long = cli::DEPENDENCY,
@@ -30,7 +29,7 @@ pub struct Options {
 
     /// The output directory for saved artifacts, namely any 'move' interface files generated from
     /// 'mv' files
-    #[structopt(
+    #[clap(
         name = "PATH_TO_OUTPUT_DIRECTORY",
         short = cli::OUT_DIR_SHORT,
         long = cli::OUT_DIR,
@@ -38,15 +37,15 @@ pub struct Options {
     pub out_dir: Option<String>,
 
     /// Named address mapping
-    #[structopt(
+    #[clap(
         name = "NAMED_ADDRESSES",
-        short = "a",
+        short = 'a',
         long = "addresses",
         parse(try_from_str = shared::parse_named_address)
     )]
     pub named_addresses: Vec<(String, NumericalAddress)>,
 
-    #[structopt(flatten)]
+    #[clap(flatten)]
     pub flags: Flags,
 }
 
@@ -57,7 +56,7 @@ pub fn main() -> anyhow::Result<()> {
         out_dir,
         flags,
         named_addresses,
-    } = Options::from_args();
+    } = Options::parse();
     let named_addr_map = verify_and_create_named_address_mapping(named_addresses)?;
     let _files = move_compiler::Compiler::new(
         vec![(source_files, named_addr_map.clone())],

--- a/language/move-compiler/src/command_line/mod.rs
+++ b/language/move-compiler/src/command_line/mod.rs
@@ -4,23 +4,23 @@
 pub mod compiler;
 
 pub const DEPENDENCY: &str = "dependency";
-pub const DEPENDENCY_SHORT: &str = "d";
+pub const DEPENDENCY_SHORT: char = 'd';
 
 pub const SENDER: &str = "sender";
-pub const SENDER_SHORT: &str = "s";
+pub const SENDER_SHORT: char = 's';
 
 pub const OUT_DIR: &str = "out-dir";
-pub const OUT_DIR_SHORT: &str = "o";
+pub const OUT_DIR_SHORT: char = 'o';
 pub const DEFAULT_OUTPUT_DIR: &str = "build";
 
 pub const NO_SHADOW: &str = "no-shadow";
-pub const NO_SHADOW_SHORT: &str = "S";
+pub const NO_SHADOW_SHORT: char = 'S';
 
 pub const SOURCE_MAP: &str = "source-map";
-pub const SOURCE_MAP_SHORT: &str = "m";
+pub const SOURCE_MAP_SHORT: char = 'm';
 
 pub const TEST: &str = "test";
-pub const TEST_SHORT: &str = "t";
+pub const TEST_SHORT: char = 't';
 
 pub const COLOR_MODE_ENV_VAR: &str = "COLOR_MODE";
 

--- a/language/move-compiler/src/shared/mod.rs
+++ b/language/move-compiler/src/shared/mod.rs
@@ -5,6 +5,7 @@ use crate::{
     command_line as cli,
     diagnostics::{codes::Severity, Diagnostic, Diagnostics},
 };
+use clap::Args;
 use move_core_types::account_address::AccountAddress;
 use move_ir_types::location::*;
 use move_symbol_pool::Symbol;
@@ -17,7 +18,6 @@ use std::{
     num::ParseIntError,
     sync::atomic::{AtomicUsize, Ordering as AtomicOrdering},
 };
-use structopt::*;
 
 pub mod ast_debug;
 pub mod remembering_unique_map;
@@ -430,10 +430,10 @@ pub fn format_comma<T: fmt::Display, I: IntoIterator<Item = T>>(items: I) -> Str
 // Flags
 //**************************************************************************************************
 
-#[derive(Clone, Debug, Eq, PartialEq, StructOpt)]
+#[derive(Clone, Debug, Eq, PartialEq, Args)]
 pub struct Flags {
     /// Compile in test mode
-    #[structopt(
+    #[clap(
         short = cli::TEST_SHORT,
         long = cli::TEST,
     )]
@@ -441,7 +441,7 @@ pub struct Flags {
 
     /// If set, do not allow modules defined in source_files to shadow modules of the same id that
     /// exist in dependencies. Checking will fail in this case.
-    #[structopt(
+    #[clap(
         name = "SOURCES_DO_NOT_SHADOW_DEPS",
         short = cli::NO_SHADOW_SHORT,
         long = cli::NO_SHADOW,

--- a/language/move-ir-compiler/Cargo.toml
+++ b/language/move-ir-compiler/Cargo.toml
@@ -20,7 +20,7 @@ move-core-types = { path = "../move-core/types" }
 move-binary-format = { path = "../move-binary-format" }
 move-symbol-pool = { path = "../move-symbol-pool" }
 bcs = "0.1.2"
-structopt = "0.3.21"
+clap = { version = "3.1", features = ["derive"] }
 serde_json = "1.0.64"
 workspace-hack = { version = "0.1", path = "../../crates/workspace-hack" }
 

--- a/language/move-ir-compiler/src/main.rs
+++ b/language/move-ir-compiler/src/main.rs
@@ -4,6 +4,7 @@
 #![forbid(unsafe_code)]
 
 use anyhow::Context;
+use clap::Parser;
 use move_binary_format::{
     errors::VMError,
     file_format::{CompiledModule, CompiledScript},
@@ -19,28 +20,28 @@ use std::{
     io::Write,
     path::{Path, PathBuf},
 };
-use structopt::StructOpt;
 
-#[derive(Debug, StructOpt)]
-#[structopt(name = "IR Compiler", about = "Move IR to bytecode compiler.")]
+/// Move IR to bytecode compiler.
+#[derive(Debug, Parser)]
+#[clap(version, name = "IR Compiler")]
 struct Args {
     /// Treat input file as a module (default is to treat file as a script)
-    #[structopt(short = "m", long = "module")]
+    #[clap(short = 'm', long = "module")]
     pub module_input: bool,
     /// Do not automatically run the bytecode verifier
-    #[structopt(long = "no-verify")]
+    #[clap(long = "no-verify")]
     pub no_verify: bool,
     /// Path to the Move IR source to compile
-    #[structopt(parse(from_os_str))]
+    #[clap(parse(from_os_str))]
     pub source_path: PathBuf,
     /// Instead of compiling the source, emit a dependency list of the compiled source
-    #[structopt(short = "l", long = "list-dependencies")]
+    #[clap(short = 'l', long = "list-dependencies")]
     pub list_dependencies: bool,
     /// Path to the list of modules that we want to link with
-    #[structopt(short = "d", long = "deps")]
+    #[clap(short = 'd', long = "deps")]
     pub deps_path: Option<String>,
 
-    #[structopt(long = "src-map")]
+    #[clap(long = "src-map")]
     pub output_source_maps: bool,
 }
 
@@ -74,7 +75,7 @@ fn write_output(path: &Path, buf: &[u8]) {
 }
 
 fn main() {
-    let args = Args::from_args();
+    let args = Args::parse();
 
     let source_path = Path::new(&args.source_path);
     let mvir_extension = MOVE_IR_EXTENSION;

--- a/language/move-prover/interpreter/Cargo.toml
+++ b/language/move-prover/interpreter/Cargo.toml
@@ -21,7 +21,7 @@ codespan-reporting = "0.11.1"
 itertools = "0.10.0"
 num = "0.4.0"
 serde = { version = "1.0.124", features = ["derive"] }
-structopt = "0.3.21"
+clap = { version = "3.1", features = ["derive"] }
 workspace-hack = { version = "0.1", path = "../../../crates/workspace-hack" }
 
 [dev-dependencies]

--- a/language/move-prover/interpreter/src/lib.rs
+++ b/language/move-prover/interpreter/src/lib.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::{bail, Result};
+use clap::Args;
 use codespan_reporting::{diagnostic::Severity, term::termcolor::Buffer};
-use structopt::StructOpt;
 
 use move_binary_format::errors::{Location, PartialVMError, PartialVMResult, VMResult};
 use move_core_types::{
@@ -39,28 +39,28 @@ use crate::concrete::{
 };
 
 /// Options passed into the interpreter generator.
-#[derive(StructOpt)]
+#[derive(Args)]
 pub struct InterpreterOptions {
     /// The function to be executed, specified in the format of `addr::module_name::function_name`
-    #[structopt(long = "entry", parse(try_from_str = parse_entrypoint))]
+    #[clap(long = "entry", parse(try_from_str = parse_entrypoint))]
     pub entrypoint: (ModuleId, Identifier),
 
     /// Possibly-empty list of signers for the execution
-    #[structopt(long = "signers", parse(try_from_str = AccountAddress::from_hex_literal))]
+    #[clap(long = "signers", parse(try_from_str = AccountAddress::from_hex_literal))]
     pub signers: Vec<AccountAddress>,
     /// Possibly-empty list of arguments passed to the transaction
-    #[structopt(long = "args", parse(try_from_str = parse_transaction_argument))]
+    #[clap(long = "args", parse(try_from_str = parse_transaction_argument))]
     pub args: Vec<TransactionArgument>,
     /// Possibly-empty list of type arguments passed to the transaction (e.g., `T` in
     /// `main<T>()`). Must match the type arguments kinds expected by `script_file`.
-    #[structopt(long = "ty-args", parse(try_from_str = parse_type_tag))]
+    #[clap(long = "ty-args", parse(try_from_str = parse_type_tag))]
     pub ty_args: Vec<TypeTag>,
 
     /// Skip checking of expressions
-    #[structopt(long = "no-expr-check")]
+    #[clap(long = "no-expr-check")]
     pub no_expr_check: bool,
     /// Level of verbosity
-    #[structopt(short = "v", long = "verbose")]
+    #[clap(short = 'v', long = "verbose")]
     pub verbose: Option<u64>,
 }
 

--- a/language/move-prover/tools/spec-flatten/Cargo.toml
+++ b/language/move-prover/tools/spec-flatten/Cargo.toml
@@ -16,7 +16,7 @@ move-prover = { path = "../.." }
 
 # external dependencies
 anyhow = "1.0.52"
+clap = { version = "3.1", features = ["derive"] }
 itertools = "0.10.1"
 pretty = "0.10.0"
-structopt = "0.3.21"
 workspace-hack = { version = "0.1", path = "../../../../crates/workspace-hack" }

--- a/language/move-prover/tools/spec-flatten/src/lib.rs
+++ b/language/move-prover/tools/spec-flatten/src/lib.rs
@@ -1,9 +1,10 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::BTreeMap;
+
 use anyhow::{anyhow, Result};
-use std::{collections::BTreeMap, str::FromStr};
-use structopt::StructOpt;
+use clap::{ArgEnum, Parser};
 
 use move_model::ast::SpecBlockTarget;
 use move_stackless_bytecode::function_target_pipeline::{FunctionVariant, VerificationFlavor};
@@ -18,40 +19,30 @@ use ast_print::SpecPrinter;
 use workflow::WorkflowOptions;
 
 /// List of simplification passes available
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, ArgEnum)]
+#[clap(rename_all = "snake_case")]
 pub enum FlattenPass {
     TrimAbortsIf,
 }
 
-impl FromStr for FlattenPass {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let r = match s {
-            "trim_aborts_if" => FlattenPass::TrimAbortsIf,
-            _ => return Err(s.to_string()),
-        };
-        Ok(r)
-    }
-}
-
-/// Options passed into the specification flattening tool.
-#[derive(StructOpt, Clone)]
+// Options passed into the specification flattening tool.
+#[derive(Parser, Clone)]
+#[clap(version)]
 pub struct FlattenOptions {
     /// Options common and shared by the proving workflow and all passes
-    #[structopt(flatten)]
+    #[clap(flatten)]
     pub workflow: WorkflowOptions,
 
     /// Spec flattening pipeline
-    #[structopt(short = "f", long = "flatten")]
+    #[clap(short = 'f', long = "flatten", arg_enum)]
     pub flattening_pipeline: Vec<FlattenPass>,
 
     /// Dump stepwise result
-    #[structopt(long = "dump-stepwise")]
+    #[clap(long = "dump-stepwise")]
     pub dump_stepwise: bool,
 
     /// Dump stepwise result in raw exp printing format
-    #[structopt(long = "dump-stepwise-raw", requires = "dump-stepwise")]
+    #[clap(long = "dump-stepwise-raw", requires = "dump-stepwise")]
     pub dump_stepwise_raw: bool,
 }
 

--- a/language/move-prover/tools/spec-flatten/src/main.rs
+++ b/language/move-prover/tools/spec-flatten/src/main.rs
@@ -2,11 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
-use structopt::StructOpt;
+use clap::Parser;
 
 use spec_flatten::{run, FlattenOptions};
 
 fn main() -> Result<()> {
-    let options = FlattenOptions::from_args();
+    let options = FlattenOptions::parse();
     run(&options)
 }

--- a/language/move-prover/tools/spec-flatten/src/workflow.rs
+++ b/language/move-prover/tools/spec-flatten/src/workflow.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::{anyhow, Result};
+use clap::Args;
 use std::collections::BTreeMap;
-use structopt::StructOpt;
 
 use move_compiler::shared::{parse_named_address, NumericalAddress};
 use move_model::{
@@ -19,34 +19,34 @@ use move_stackless_bytecode::{
     pipeline_factory::default_pipeline_with_options,
 };
 
-/// Options passed into the workflow pipeline.
-#[derive(StructOpt, Clone)]
+// Options passed into the workflow pipeline.
+#[derive(Args, Clone)]
 pub struct WorkflowOptions {
     /// Sources of the target modules
     pub srcs: Vec<String>,
 
     /// Dependencies
-    #[structopt(short = "d", long = "dependency")]
+    #[clap(short = 'd', long = "dependency")]
     pub deps: Vec<String>,
 
     /// Target function
-    #[structopt(short, long)]
+    #[clap(short, long)]
     pub target: Option<String>,
 
     /// Do not include default named address
-    #[structopt(long = "no-default-named-addresses")]
+    #[clap(long = "no-default-named-addresses")]
     pub no_default_named_addresses: bool,
 
     /// Extra mappings for named address
-    #[structopt(short = "a", long = "address", parse(try_from_str = parse_named_address))]
+    #[clap(short = 'a', long = "address", parse(try_from_str = parse_named_address))]
     pub named_addresses_extra: Option<Vec<(String, NumericalAddress)>>,
 
     /// Simplification pipeline at the Move model end
-    #[structopt(short = "s", long = "simplify")]
+    #[clap(short = 's', long = "simplify")]
     pub simplification_pipeline: Vec<SimplificationPass>,
 
     /// Verbose mode
-    #[structopt(short, long)]
+    #[clap(short, long)]
     pub verbose: bool,
 }
 

--- a/language/testing-infra/test-generation/Cargo.toml
+++ b/language/testing-infra/test-generation/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 rand = "0.8.3"
 num_cpus = "1.13.0"
 mirai-annotations = "1.10.1"
-structopt = "0.3.21"
+clap = { version = "3.1", features = ["derive"] }
 itertools = "0.10.0"
 hex = "0.4.3"
 getrandom = "0.2.2"

--- a/language/testing-infra/test-generation/src/config.rs
+++ b/language/testing-infra/test-generation/src/config.rs
@@ -1,8 +1,8 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use clap::Parser;
 use module_generation::ModuleGeneratorOptions;
-use structopt::StructOpt;
 
 /// This defines how tolerant the generator will be about deviating from
 /// the starting stack height.
@@ -81,8 +81,9 @@ pub fn module_generation_settings() -> ModuleGeneratorOptions {
 }
 
 /// Command line arguments for the tool
-#[derive(Debug, StructOpt)]
-#[structopt(
+#[derive(Debug, Parser)]
+#[clap(
+    version,
     name = "Bytecode Test Generator",
     author = "Diem",
     about = "Tool for generating tests for the bytecode verifier and Move VM runtime."
@@ -90,19 +91,19 @@ pub fn module_generation_settings() -> ModuleGeneratorOptions {
 pub struct Args {
     /// The optional number of programs that will be generated. If not specified, program
     /// generation will run infinitely.
-    #[structopt(short = "i", long = "iterations")]
+    #[clap(short = 'i', long = "iterations")]
     pub num_iterations: Option<u64>,
 
     /// Path where a serialized module should be saved.
     /// If `None`, then the module will just be printed out.
-    #[structopt(short = "o", long = "output")]
+    #[clap(short = 'o', long = "output")]
     pub output_path: Option<String>,
 
     /// The optional seed used for test generation.
-    #[structopt(short = "s", long = "seed")]
+    #[clap(short = 's', long = "seed")]
     pub seed: Option<String>,
 
     /// The optional number of threads to use for test generation.
-    #[structopt(short = "t", long = "threads")]
+    #[clap(short = 't', long = "threads")]
     pub num_threads: Option<u64>,
 }

--- a/language/testing-infra/test-generation/src/main.rs
+++ b/language/testing-infra/test-generation/src/main.rs
@@ -3,7 +3,7 @@
 
 #![forbid(unsafe_code)]
 
-use structopt::StructOpt;
+use clap::Parser;
 use test_generation::{config::Args, run_generation};
 
 fn setup_log() {
@@ -12,6 +12,6 @@ fn setup_log() {
 
 pub fn main() {
     setup_log();
-    let args = Args::from_args();
+    let args = Args::parse();
     run_generation(args);
 }

--- a/language/tools/mirai-dataflow-analysis/Cargo.toml
+++ b/language/tools/mirai-dataflow-analysis/Cargo.toml
@@ -10,10 +10,10 @@ publish = false
 edition = "2018"
 
 [dependencies]
+clap = { version = "3.1", features = ["derive"] }
 csv = "1.1"
 mirai-annotations = "1.12"
 regex = "1.4.3"
 serde = {version="1.0", features=["derive"]}
 serde_json = "1.0"
-structopt = "0.3"
 workspace-hack = { version = "0.1", path = "../../../crates/workspace-hack" }

--- a/language/tools/mirai-dataflow-analysis/src/main.rs
+++ b/language/tools/mirai-dataflow-analysis/src/main.rs
@@ -1,6 +1,7 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use clap::Parser;
 use mirai_annotations::unrecoverable;
 use regex::Regex;
 use std::{
@@ -9,7 +10,6 @@ use std::{
     path::{Path, PathBuf},
     process::Command,
 };
-use structopt::StructOpt;
 
 mod configuration;
 mod datalog;
@@ -187,44 +187,42 @@ pub fn parse_node_types(
     Ok(node_types)
 }
 
-#[derive(Debug, StructOpt)]
-#[structopt(
-    name = "mirai-dataflow",
-    about = "Rust dataflow analyzer built on MIRAI."
-)]
+/// Rust dataflow analyzer built on MIRAI.
+#[derive(Debug, Parser)]
+#[clap(version, name = "mirai-dataflow")]
 struct Opt {
     /// Path to the crate to analyze
-    #[structopt(parse(from_os_str))]
+    #[clap(parse(from_os_str))]
     crate_path: PathBuf,
 
     /// Path to configuration file
-    #[structopt(parse(from_os_str))]
+    #[clap(parse(from_os_str))]
     config_path: PathBuf,
 
     /// Only produce a call graph (no analysis)
-    #[structopt(long)]
+    #[clap(long)]
     call_graph_only: bool,
 
     /// Datalog backend to use (DifferentialDatalog | Souffle)
-    #[structopt(short, long)]
+    #[clap(short, long)]
     datalog_backend: Option<DatalogBackend>,
 
     /// Path to input type relations
-    #[structopt(short, long, parse(from_os_str))]
+    #[clap(short, long, parse(from_os_str))]
     type_relations_path: Option<PathBuf>,
 
     /// Do not rebuild the crate before analysis
-    #[structopt(short, long)]
+    #[clap(short, long)]
     no_rebuild: bool,
 
     /// Rerun the Datalog analysis without running MIRAI
-    #[structopt(short, long)]
+    #[clap(short, long)]
     reanalyze: bool,
 }
 
 fn main() {
     // Process command line arguments
-    let opt = Opt::from_args();
+    let opt = Opt::parse();
     // Canonicalize the crate path
     let crate_path = match fs::canonicalize(opt.crate_path) {
         Ok(crate_path) => crate_path,

--- a/language/tools/move-bytecode-viewer/Cargo.toml
+++ b/language/tools/move-bytecode-viewer/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 edition = "2018"
 
 [dependencies]
-structopt = "0.3.21"
+clap = { version = "3.1", features = ["derive"] }
 anyhow = "1.0.52"
 regex = "1.1.9"
 termion = "1.5"

--- a/language/tools/move-bytecode-viewer/src/lib.rs
+++ b/language/tools/move-bytecode-viewer/src/lib.rs
@@ -5,13 +5,13 @@ use crate::{
     bytecode_viewer::BytecodeViewer, source_viewer::ModuleViewer,
     tui::tui_interface::start_tui_with_interface, viewer::Viewer,
 };
+use clap::Parser;
 use move_binary_format::file_format::CompiledModule;
 use move_bytecode_source_map::{source_map::SourceMap, utils::source_map_from_file};
 use std::{
     fs,
     path::{Path, PathBuf},
 };
-use structopt::StructOpt;
 
 pub mod bytecode_viewer;
 pub mod interfaces;
@@ -19,22 +19,20 @@ pub mod source_viewer;
 pub mod tui;
 pub mod viewer;
 
-#[derive(Debug, StructOpt)]
-#[structopt(
-    name = "Move Bytecode Explorer",
-    about = "Explore Move bytecode and how the source code compiles to it"
-)]
+/// Explore Move bytecode and how the source code compiles to it
+#[derive(Debug, Parser)]
+#[clap(version, name = "Move Bytecode Explorer")]
 pub struct BytecodeViewerConfig {
     /// The path to the module binary
-    #[structopt(long = "module-path", short = "b")]
+    #[clap(long = "module-path", short = 'b')]
     pub module_binary_path: PathBuf,
 
     /// The path to the source map for the module binary
-    #[structopt(long = "source-map-path")]
+    #[clap(long = "source-map-path")]
     pub module_sourcemap_path: PathBuf,
 
     /// The path to the source file
-    #[structopt(long = "source-path", short = "s")]
+    #[clap(long = "source-path", short = 's')]
     pub source_file_path: PathBuf,
 }
 

--- a/language/tools/move-bytecode-viewer/src/main.rs
+++ b/language/tools/move-bytecode-viewer/src/main.rs
@@ -3,9 +3,9 @@
 
 #![forbid(unsafe_code)]
 
+use clap::Parser;
 use move_bytecode_viewer::BytecodeViewerConfig;
-use structopt::StructOpt;
 
 fn main() {
-    BytecodeViewerConfig::from_args().start_viewer()
+    BytecodeViewerConfig::parse().start_viewer()
 }

--- a/language/tools/move-cli/Cargo.toml
+++ b/language/tools/move-cli/Cargo.toml
@@ -11,13 +11,13 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0.52"
+clap = { version = "3.1", features = ["derive"] }
 colored = "2.0.0"
 difference = "2.0.0"
 include_dir = { version = "0.6.0", features = ["search"] }
 once_cell = "1.7.2"
 serde = { version = "1.0.124", default-features = false }
 serde_yaml = "0.8.17"
-structopt = "0.3.21"
 tempfile = "3.2.0"
 walkdir = "2.3.1"
 codespan-reporting = "0.11.1"

--- a/language/tools/move-cli/src/experimental/cli.rs
+++ b/language/tools/move-cli/src/experimental/cli.rs
@@ -5,50 +5,46 @@ use std::path::PathBuf;
 
 use crate::{experimental, sandbox::utils::PackageContext, Move};
 use anyhow::Result;
+use clap::{ArgEnum, Subcommand};
 use move_core_types::{
     language_storage::TypeTag, parser, transaction_argument::TransactionArgument,
 };
 use std::path::Path;
 
-use structopt::{clap::arg_enum, StructOpt};
-
-#[derive(StructOpt)]
+#[derive(Subcommand)]
 pub enum ExperimentalCommand {
     /// Perform a read/write set analysis and print the results for
     /// `module_file`::`script_name`.
-    #[structopt(name = "read-write-set")]
+    #[clap(name = "read-write-set")]
     ReadWriteSet {
         /// Path to .mv file containing module bytecode.
-        #[structopt(name = "module", parse(from_os_str))]
+        #[clap(name = "module", parse(from_os_str))]
         module_file: PathBuf,
         /// A function inside `module_file`.
-        #[structopt(name = "function")]
+        #[clap(name = "function")]
         fun_name: String,
-        #[structopt(long = "signers")]
+        #[clap(long = "signers")]
         signers: Vec<String>,
-        #[structopt(long = "args", parse(try_from_str = parser::parse_transaction_argument))]
+        #[clap(long = "args", parse(try_from_str = parser::parse_transaction_argument))]
         args: Vec<TransactionArgument>,
-        #[structopt(long = "type-args", parse(try_from_str = parser::parse_type_tag))]
+        #[clap(long = "type-args", parse(try_from_str = parser::parse_type_tag))]
         type_args: Vec<TypeTag>,
-        #[structopt(long = "concretize", possible_values = &ConcretizeMode::variants(), case_insensitive = true, default_value = "dont")]
+        #[clap(long = "concretize", arg_enum, ignore_case = true, default_value_t = ConcretizeMode::Dont)]
         concretize: ConcretizeMode,
     },
 }
 
 // Specify if/how the analysis should concretize and filter the static analysis summary
-arg_enum! {
-    // Specify if/how the analysis should concretize and filter the static analysis summary
-    #[derive(Debug, Clone, Copy)]
-    pub enum ConcretizeMode {
-        // Show the full concretized access paths read or written (e.g. 0xA/0x1::M::S/f/g)
-        Paths,
-        // Show only the concrete resource keys that are read (e.g. 0xA/0x1::M::S)
-        Reads,
-        // Show only the concrete resource keys that are written (e.g. 0xA/0x1::M::S)
-        Writes,
-        // Do not concretize; show the results from the static analysis
-        Dont,
-    }
+#[derive(ArgEnum, Debug, Clone, Copy)]
+pub enum ConcretizeMode {
+    // Show the full concretized access paths read or written (e.g. 0xA/0x1::M::S/f/g)
+    Paths,
+    // Show only the concrete resource keys that are read (e.g. 0xA/0x1::M::S)
+    Reads,
+    // Show only the concrete resource keys that are written (e.g. 0xA/0x1::M::S)
+    Writes,
+    // Do not concretize; show the results from the static analysis
+    Dont,
 }
 
 impl ExperimentalCommand {

--- a/language/tools/move-cli/src/lib.rs
+++ b/language/tools/move-cli/src/lib.rs
@@ -18,27 +18,22 @@ pub const DEFAULT_BUILD_DIR: &str = ".";
 const BCS_EXTENSION: &str = "bcs";
 
 use anyhow::Result;
+use clap::{Args, Parser, Subcommand};
 use move_core_types::{
     account_address::AccountAddress, errmap::ErrorMapping, gas_schedule::CostTable,
     identifier::Identifier,
 };
 use move_vm_runtime::native_functions::NativeFunction;
 use std::path::PathBuf;
-use structopt::StructOpt;
 
 type NativeFunctionRecord = (AccountAddress, Identifier, Identifier, NativeFunction);
 
-#[derive(StructOpt)]
-#[structopt(
-    name = "move",
-    about = "CLI frontend for Move compiler and VM",
-    rename_all = "kebab-case"
-)]
+#[derive(Args)]
 pub struct Move {
     /// Path to a package which the command should be run with respect to.
-    #[structopt(
+    #[clap(
         long = "path",
-        short = "p",
+        short = 'p',
         global = true,
         parse(from_os_str),
         default_value = "."
@@ -46,53 +41,58 @@ pub struct Move {
     package_path: PathBuf,
 
     /// Print additional diagnostics if available.
-    #[structopt(short = "v", global = true)]
+    #[clap(short = 'v', global = true)]
     verbose: bool,
 
     /// Package build options
-    #[structopt(flatten)]
+    #[clap(flatten)]
     build_config: BuildConfig,
 }
 
-/// MoveCLI is the CLI that will be executed by the `move-cli` command
-/// The `cmd` argument is added here rather than in `Move` to make it
-/// easier for other crates to extend `move-cli`
-#[derive(StructOpt)]
+// MoveCLI is the CLI that will be executed by the `move-cli` command
+// The `cmd` argument is added here rather than in `Move` to make it
+// easier for other crates to extend `move-cli`
+#[derive(Parser)]
+#[clap(
+    version,
+    name = "move",
+    about = "CLI frontend for Move compiler and VM"
+)]
 pub struct MoveCLI {
-    #[structopt(flatten)]
+    #[clap(flatten)]
     move_args: Move,
 
-    #[structopt(subcommand)]
+    #[clap(subcommand)]
     cmd: Command,
 }
 
-#[derive(StructOpt)]
+#[derive(Subcommand)]
 pub enum Command {
     /// Execute a package command. Executed in the current directory or the closest containing Move
     /// package.
-    #[structopt(name = "package")]
+    #[clap(name = "package")]
     Package {
-        #[structopt(subcommand)]
+        #[clap(subcommand)]
         cmd: package::cli::PackageCommand,
     },
     /// Execute a sandbox command.
-    #[structopt(name = "sandbox")]
+    #[clap(name = "sandbox")]
     Sandbox {
         /// Directory storing Move resources, events, and module bytecodes produced by module publishing
         /// and script execution.
-        #[structopt(long, default_value = DEFAULT_STORAGE_DIR, parse(from_os_str))]
+        #[clap(long, default_value = DEFAULT_STORAGE_DIR, parse(from_os_str))]
         storage_dir: PathBuf,
-        #[structopt(subcommand)]
+        #[clap(subcommand)]
         cmd: sandbox::cli::SandboxCommand,
     },
     /// (Experimental) Run static analyses on Move source or bytecode.
-    #[structopt(name = "experimental")]
+    #[clap(name = "experimental")]
     Experimental {
         /// Directory storing Move resources, events, and module bytecodes produced by module publishing
         /// and script execution.
-        #[structopt(long, default_value = DEFAULT_STORAGE_DIR, parse(from_os_str))]
+        #[clap(long, default_value = DEFAULT_STORAGE_DIR, parse(from_os_str))]
         storage_dir: PathBuf,
-        #[structopt(subcommand)]
+        #[clap(subcommand)]
         cmd: experimental::cli::ExperimentalCommand,
     },
 }
@@ -127,7 +127,7 @@ pub fn move_cli(
     cost_table: &CostTable,
     error_descriptions: &ErrorMapping,
 ) -> Result<()> {
-    let args = MoveCLI::from_args();
+    let args = MoveCLI::parse();
     run_cli(
         natives,
         cost_table,

--- a/language/tools/move-cli/src/package/cli.rs
+++ b/language/tools/move-cli/src/package/cli.rs
@@ -12,6 +12,7 @@ use std::{
 };
 
 use anyhow::{bail, Result};
+use clap::Subcommand;
 
 use move_command_line_common::files::{FileHash, MOVE_COVERAGE_MAP_EXTENSION};
 use move_compiler::{
@@ -33,147 +34,146 @@ use move_package::{
     ModelConfig,
 };
 use move_unit_test::UnitTestingConfig;
-use structopt::StructOpt;
 
 use crate::{package::prover::run_move_prover, NativeFunctionRecord};
 
-#[derive(StructOpt)]
+#[derive(Subcommand)]
 pub enum CoverageSummaryOptions {
     /// Display a coverage summary for all modules in this package
-    #[structopt(name = "summary")]
+    #[clap(name = "summary")]
     Summary {
         /// Whether function coverage summaries should be displayed
-        #[structopt(long = "summarize-functions")]
+        #[clap(long = "summarize-functions")]
         functions: bool,
         /// Output CSV data of coverage
-        #[structopt(long = "csv")]
+        #[clap(long = "csv")]
         output_csv: bool,
     },
     /// Display coverage information about the module against source code
-    #[structopt(name = "source")]
+    #[clap(name = "source")]
     Source {
-        #[structopt(long = "module")]
+        #[clap(long = "module")]
         module_name: String,
     },
     /// Display coverage information about the module against disassembled bytecode
-    #[structopt(name = "bytecode")]
+    #[clap(name = "bytecode")]
     Bytecode {
-        #[structopt(long = "module")]
+        #[clap(long = "module")]
         module_name: String,
     },
 }
 
-#[derive(StructOpt)]
+#[derive(Subcommand)]
 pub enum PackageCommand {
     /// Create a new Move package with name `name` at `path`. If `path` is not provided the package
     /// will be created in the directory `name`.
-    #[structopt(name = "new")]
+    #[clap(name = "new")]
     New {
         /// The name of the package to be created.
         name: String,
     },
     /// Build the package at `path`. If no path is provided defaults to current directory.
-    #[structopt(name = "build")]
+    #[clap(name = "build")]
     Build,
     /// Print address information.
-    #[structopt(name = "info")]
+    #[clap(name = "info")]
     Info,
     /// Generate error map for the package and its dependencies at `path` for use by the Move
     /// explanation tool.
-    #[structopt(name = "errmap")]
+    #[clap(name = "errmap")]
     ErrMapGen {
         /// The prefix that all error reasons within modules will be prefixed with, e.g., "E" if
         /// all error reasons are "E_CANNOT_PERFORM_OPERATION", "E_CANNOT_ACCESS", etc.
-        #[structopt(long)]
+        #[clap(long)]
         error_prefix: Option<String>,
         /// The file to serialize the generated error map to.
-        #[structopt(long, default_value = "error_map", parse(from_os_str))]
+        #[clap(long, default_value = "error_map", parse(from_os_str))]
         output_file: PathBuf,
     },
     /// Run the Move Prover on the package at `path`. If no path is provided defaults to current
     /// directory. Use `.. prove .. -- <options>` to pass on options to the prover.
-    #[structopt(name = "prove")]
+    #[clap(name = "prove")]
     Prove {
         /// The target filter used to prune the modules to verify. Modules with a name that contains
         /// this string will be part of verification.
-        #[structopt(short = "t", long = "target")]
+        #[clap(short = 't', long = "target")]
         target_filter: Option<String>,
         /// Internal field indicating that this prover run is for a test.
-        #[structopt(skip)]
+        #[clap(skip)]
         for_test: bool,
         /// Any options passed to the prover.
-        #[structopt(subcommand)]
+        #[clap(subcommand)]
         options: Option<ProverOptions>,
     },
     /// Inspect test coverage for this package. A previous test run with the `--coverage` flag must
     /// have previously been run.
-    #[structopt(name = "coverage")]
+    #[clap(name = "coverage")]
     CoverageReport {
-        #[structopt(subcommand)]
+        #[clap(subcommand)]
         options: CoverageSummaryOptions,
     },
     /// Run Move unit tests in this package.
-    #[structopt(name = "test")]
+    #[clap(name = "test")]
     UnitTest {
         /// Bound the number of instructions that can be executed by any one test.
-        #[structopt(
+        #[clap(
             name = "instructions",
-            default_value = "5000",
-            short = "i",
+            default_value_t = 5000,
+            short = 'i',
             long = "instructions"
         )]
         instruction_execution_bound: u64,
         /// A filter string to determine which unit tests to run. A unit test will be run only if it
         /// contains this string in its fully qualified (<addr>::<module_name>::<fn_name>) name.
-        #[structopt(name = "filter", short = "f", long = "filter")]
+        #[clap(name = "filter", short = 'f', long = "filter")]
         filter: Option<String>,
         /// List all tests
-        #[structopt(name = "list", short = "l", long = "list")]
+        #[clap(name = "list", short = 'l', long = "list")]
         list: bool,
         /// Number of threads to use for running tests.
-        #[structopt(
+        #[clap(
             name = "num_threads",
-            default_value = "8",
-            short = "t",
+            default_value_t = 8,
+            short = 't',
             long = "threads"
         )]
         num_threads: usize,
         /// Report test statistics at the end of testing
-        #[structopt(name = "report_statistics", short = "s", long = "statistics")]
+        #[clap(name = "report_statistics", short = 's', long = "statistics")]
         report_statistics: bool,
         /// Show the storage state at the end of execution of a failing test
-        #[structopt(name = "global_state_on_error", short = "g", long = "state_on_error")]
+        #[clap(name = "global_state_on_error", short = 'g', long = "state_on_error")]
         report_storage_on_error: bool,
         /// Use the stackless bytecode interpreter to run the tests and cross check its results with
         /// the execution result from Move VM.
-        #[structopt(long = "stackless")]
+        #[clap(long = "stackless")]
         check_stackless_vm: bool,
         /// Verbose mode
-        #[structopt(long = "verbose")]
+        #[clap(long = "verbose")]
         verbose_mode: bool,
         /// Collect coverage information for later use with the various `package coverage` subcommands
-        #[structopt(long = "coverage")]
+        #[clap(long = "coverage")]
         compute_coverage: bool,
     },
     /// Disassemble the Move bytecode pointed to
-    #[structopt(name = "disassemble")]
+    #[clap(name = "disassemble")]
     BytecodeView {
         /// Start a disassembled bytecode-to-source explorer
-        #[structopt(long = "interactive")]
+        #[clap(long = "interactive")]
         interactive: bool,
         /// The package name. If not provided defaults to current package modules only
-        #[structopt(long = "package")]
+        #[clap(long = "package")]
         package_name: Option<String>,
         /// The name of the module or script in the package to disassemble
-        #[structopt(long = "name")]
+        #[clap(long = "name")]
         module_or_script_name: String,
     },
 }
 
-#[derive(StructOpt, Debug)]
+#[derive(Subcommand, Debug)]
 pub enum ProverOptions {
     // Pass through unknown commands to the prover Clap parser
-    #[structopt(external_subcommand)]
+    #[clap(external_subcommand)]
     Options(Vec<String>),
 }
 

--- a/language/tools/move-cli/src/sandbox/cli.rs
+++ b/language/tools/move-cli/src/sandbox/cli.rs
@@ -9,6 +9,7 @@ use crate::{
     Move, NativeFunctionRecord, DEFAULT_BUILD_DIR,
 };
 use anyhow::Result;
+use clap::{Args, Subcommand};
 use move_core_types::{
     errmap::ErrorMapping, gas_schedule::CostTable, language_storage::TypeTag, parser,
     transaction_argument::TransactionArgument,
@@ -18,41 +19,40 @@ use std::{
     fs,
     path::{Path, PathBuf},
 };
-use structopt::StructOpt;
 
-#[derive(StructOpt)]
+#[derive(Subcommand)]
 pub enum SandboxCommand {
     /// Compile the modules in this package and its dependencies and publish the resulting bytecodes in global storage.
-    #[structopt(name = "publish")]
+    #[clap(name = "publish")]
     Publish {
         /// If set, fail when attempting to publish a module that already
         /// exists in global storage.
-        #[structopt(long = "no-republish")]
+        #[clap(long = "no-republish")]
         no_republish: bool,
         /// By default, code that might cause breaking changes for bytecode
         /// linking or data layout compatibility checks will not be published.
         /// Set this flag to ignore breaking changes checks and publish anyway.
-        #[structopt(long = "ignore-breaking-changes")]
+        #[clap(long = "ignore-breaking-changes")]
         ignore_breaking_changes: bool,
         /// Manually specify the publishing order of modules.
-        #[structopt(long = "override-ordering")]
+        #[clap(long = "override-ordering")]
         override_ordering: Option<Vec<String>>,
     },
     /// Run a Move script that reads/writes resources stored on disk in `storage-dir`.
     /// The script must be defined in the package.
-    #[structopt(name = "run")]
+    #[clap(name = "run")]
     Run {
         /// Path to .mv file containing either script or module bytecodes. If the file is a module, the
         /// `script_name` parameter must be set.
-        #[structopt(name = "script", parse(from_os_str))]
+        #[clap(name = "script", parse(from_os_str))]
         script_file: PathBuf,
         /// Name of the script function inside `script_file` to call. Should only be set if `script_file`
         /// points to a module.
-        #[structopt(name = "name")]
+        #[clap(name = "name")]
         script_name: Option<String>,
         /// Possibly-empty list of signers for the current transaction (e.g., `account` in
         /// `main(&account: signer)`). Must match the number of signers expected by `script_file`.
-        #[structopt(long = "signers")]
+        #[clap(long = "signers")]
         signers: Vec<String>,
         /// Possibly-empty list of arguments passed to the transaction (e.g., `i` in
         /// `main(i: u64)`). Must match the arguments types expected by `script_file`.
@@ -62,81 +62,81 @@ pub enum SandboxCommand {
         /// address literals (e.g., 0x12, 0x0000000000000000000000000000000f),
         /// hexadecimal strings (e.g., x"0012" will parse as the vector<u8> value [00, 12]), and
         /// ASCII strings (e.g., 'b"hi" will parse as the vector<u8> value [68, 69]).
-        #[structopt(long = "args", parse(try_from_str = parser::parse_transaction_argument))]
+        #[clap(long = "args", parse(try_from_str = parser::parse_transaction_argument))]
         args: Vec<TransactionArgument>,
         /// Possibly-empty list of type arguments passed to the transaction (e.g., `T` in
         /// `main<T>()`). Must match the type arguments kinds expected by `script_file`.
-        #[structopt(long = "type-args", parse(try_from_str = parser::parse_type_tag))]
+        #[clap(long = "type-args", parse(try_from_str = parser::parse_type_tag))]
         type_args: Vec<TypeTag>,
         /// Maximum number of gas units to be consumed by execution.
         /// When the budget is exhaused, execution will abort.
         /// By default, no `gas-budget` is specified and gas metering is disabled.
-        #[structopt(long = "gas-budget", short = "g")]
+        #[clap(long = "gas-budget", short = 'g')]
         gas_budget: Option<u64>,
         /// If set, the effects of executing `script_file` (i.e., published, updated, and
         /// deleted resources) will NOT be committed to disk.
-        #[structopt(long = "dry-run", short = "n")]
+        #[clap(long = "dry-run", short = 'n')]
         dry_run: bool,
     },
     /// Run expected value tests using the given batch file.
-    #[structopt(name = "exp-test")]
+    #[clap(name = "exp-test")]
     Test {
         /// Use an ephemeral directory to serve as the testing workspace.
         /// By default, the directory containing the `args.txt` will be the workspace.
-        #[structopt(long = "use-temp-dir")]
+        #[clap(long = "use-temp-dir")]
         use_temp_dir: bool,
         /// Show coverage information after tests are done.
         /// By default, coverage will not be tracked nor shown.
-        #[structopt(long = "track-cov")]
+        #[clap(long = "track-cov")]
         track_cov: bool,
     },
     /// View Move resources, events files, and modules stored on disk.
-    #[structopt(name = "view")]
+    #[clap(name = "view")]
     View {
         /// Path to a resource, events file, or module stored on disk.
-        #[structopt(name = "file", parse(from_os_str))]
+        #[clap(name = "file", parse(from_os_str))]
         file: PathBuf,
     },
     /// Delete all resources, events, and modules stored on disk under `storage-dir`.
     /// Does *not* delete anything in `src`.
     Clean {},
     /// Run well-formedness checks on the `storage-dir` and `install-dir` directories.
-    #[structopt(name = "doctor")]
+    #[clap(name = "doctor")]
     Doctor {},
     /// Generate struct layout bindings for the modules stored on disk under `storage-dir`
     // TODO: expand this to generate script bindings, etc.?.
-    #[structopt(name = "generate")]
+    #[clap(name = "generate")]
     Generate {
-        #[structopt(subcommand)]
+        #[clap(subcommand)]
         cmd: GenerateCommand,
     },
 }
 
-#[derive(StructOpt)]
+#[derive(Subcommand)]
 pub enum GenerateCommand {
     /// Generate struct layout bindings for the modules stored on disk under `storage-dir`.
-    #[structopt(name = "struct-layouts")]
+    #[clap(name = "struct-layouts")]
     StructLayouts {
         /// Path to a module stored on disk.
-        #[structopt(long, parse(from_os_str))]
+        #[clap(long, parse(from_os_str))]
         module: PathBuf,
         /// If set, generate bindings for the specified struct and type arguments. If unset,
         /// generate bindings for all closed struct definitions.
-        #[structopt(flatten)]
+        #[clap(flatten)]
         options: StructLayoutOptions,
     },
 }
-#[derive(StructOpt)]
+#[derive(Args)]
 pub struct StructLayoutOptions {
     /// Generate layout bindings for this struct.
-    #[structopt(long = "struct")]
+    #[clap(long = "struct")]
     struct_: Option<String>,
     /// Generate layout bindings for `struct` bound to these type arguments.
-    #[structopt(long = "type-args", parse(try_from_str = parser::parse_type_tag), requires="struct")]
+    #[clap(long = "type-args", parse(try_from_str = parser::parse_type_tag), requires="struct")]
     type_args: Option<Vec<TypeTag>>,
     /// If set, generate bindings only for the struct passed in.
     /// When unset, generates bindings for the struct and all of its transitive dependencies.
-    #[structopt(long = "shallow")]
+    #[clap(long = "shallow")]
     shallow: bool,
 }
 

--- a/language/tools/move-coverage/Cargo.toml
+++ b/language/tools/move-coverage/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 [dependencies]
 once_cell = "1.7.2"
 petgraph = "0.5.1"
-structopt = "0.3.21"
+clap = { version = "3.1", features = ["derive"] }
 serde = { version = "1.0.124", default-features = false }
 anyhow = "1.0.52"
 codespan = { version = "0.11.1", features = ["serialization"] }

--- a/language/tools/move-coverage/src/bin/coverage-summaries.rs
+++ b/language/tools/move-coverage/src/bin/coverage-summaries.rs
@@ -3,6 +3,7 @@
 
 #![forbid(unsafe_code)]
 
+use clap::Parser;
 use move_binary_format::file_format::CompiledModule;
 use move_coverage::{
     coverage_map::{CoverageMap, TraceMap},
@@ -13,37 +14,34 @@ use std::{
     io::{self, Write},
     path::Path,
 };
-use structopt::StructOpt;
 
-#[derive(Debug, StructOpt)]
-#[structopt(
-    name = "Move VM Coverage Summary",
-    about = "Creates a coverage summary from the trace data collected from the Move VM"
-)]
+/// Creates a coverage summary from the trace data collected from the Move VM
+#[derive(Debug, Parser)]
+#[clap(version, name = "Move VM Coverage Summary")]
 struct Args {
     /// The path to the coverage map or trace file
-    #[structopt(long = "input-trace-path", short = "t")]
+    #[clap(long = "input-trace-path", short = 't')]
     pub input_trace_path: String,
     /// Whether the passed-in file is a raw trace file or a serialized coverage map
-    #[structopt(long = "is-raw-trace", short = "r")]
+    #[clap(long = "is-raw-trace", short = 'r')]
     pub is_raw_trace_file: bool,
     /// The path to the module binary
-    #[structopt(long = "module-path", short = "b")]
+    #[clap(long = "module-path", short = 'b')]
     pub module_binary_path: Option<String>,
     /// Optional path for summaries. Printed to stdout if not present.
-    #[structopt(long = "summary-path", short = "o")]
+    #[clap(long = "summary-path", short = 'o')]
     pub summary_path: Option<String>,
     /// Whether function coverage summaries should be displayed
-    #[structopt(long = "summarize-functions", short = "f")]
+    #[clap(long = "summarize-functions", short = 'f')]
     pub summarize_functions: bool,
     /// The path to the standard library binary directory for Move
-    #[structopt(long = "stdlib-path", short = "s")]
+    #[clap(long = "stdlib-path", short = 's')]
     pub stdlib_path: Option<String>,
     /// Whether path coverage should be derived (default is instruction coverage)
-    #[structopt(long = "derive-path-coverage", short = "p")]
+    #[clap(long = "derive-path-coverage", short = 'p')]
     pub derive_path_coverage: bool,
     /// Output CSV data of coverage
-    #[structopt(long = "csv", short = "c")]
+    #[clap(long = "csv", short = 'c')]
     pub csv_output: bool,
 }
 
@@ -72,7 +70,7 @@ fn get_modules(args: &Args) -> Vec<CompiledModule> {
 }
 
 fn main() {
-    let args = Args::from_args();
+    let args = Args::parse();
     let input_trace_path = Path::new(&args.input_trace_path);
 
     let mut summary_writer: Box<dyn Write> = match &args.summary_path {

--- a/language/tools/move-coverage/src/bin/move-trace-conversion.rs
+++ b/language/tools/move-coverage/src/bin/move-trace-conversion.rs
@@ -3,32 +3,30 @@
 
 #![forbid(unsafe_code)]
 
+use clap::Parser;
 use move_coverage::coverage_map::{output_map_to_file, CoverageMap, TraceMap};
 use std::path::Path;
-use structopt::StructOpt;
 
-#[derive(Debug, StructOpt)]
-#[structopt(
-    name = "Move VM Coverage",
-    about = "Creates a coverage map from the raw data collected from the Move VM"
-)]
+/// Creates a coverage map from the raw data collected from the Move VM
+#[derive(Debug, Parser)]
+#[clap(version, name = "Move VM Coverage")]
 struct Args {
     /// The path to the input file
-    #[structopt(long = "input-file-path", short = "f")]
+    #[clap(long = "input-file-path", short = 'f')]
     pub input_file_path: String,
     /// The path to the output file location
-    #[structopt(long = "output-file-path", short = "o")]
+    #[clap(long = "output-file-path", short = 'o')]
     pub output_file_path: String,
     /// Add traces from `input_file_path` to an existing coverage map at `update_coverage_map`
-    #[structopt(long = "update", short = "u")]
+    #[clap(long = "update", short = 'u')]
     pub update: Option<String>,
     /// Collect structured trace instead of aggregated coverage information
-    #[structopt(long = "use-trace-map", short = "t")]
+    #[clap(long = "use-trace-map", short = 't')]
     pub use_trace_map: bool,
 }
 
 fn main() {
-    let args = Args::from_args();
+    let args = Args::parse();
     let input_path = Path::new(&args.input_file_path);
     let output_path = Path::new(&args.output_file_path);
 

--- a/language/tools/move-coverage/src/bin/source-coverage.rs
+++ b/language/tools/move-coverage/src/bin/source-coverage.rs
@@ -3,6 +3,7 @@
 
 #![forbid(unsafe_code)]
 
+use clap::Parser;
 use move_binary_format::file_format::CompiledModule;
 use move_bytecode_source_map::utils::source_map_from_file;
 use move_command_line_common::files::SOURCE_MAP_EXTENSION;
@@ -13,33 +14,30 @@ use std::{
     io::{self, Write},
     path::Path,
 };
-use structopt::StructOpt;
 
-#[derive(Debug, StructOpt)]
-#[structopt(
-    name = "Move Source Coverage",
-    about = "Annotate Move Source Code with Coverage Information"
-)]
+/// Annotate Move Source Code with Coverage Information
+#[derive(Debug, Parser)]
+#[clap(version, name = "Move Source Coverage")]
 struct Args {
     /// The path to the coverage map or trace file
-    #[structopt(long = "input-trace-path", short = "t")]
+    #[clap(long = "input-trace-path", short = 't')]
     pub input_trace_path: String,
     /// Whether the passed-in file is a raw trace file or a serialized coverage map
-    #[structopt(long = "is-raw-trace", short = "r")]
+    #[clap(long = "is-raw-trace", short = 'r')]
     pub is_raw_trace_file: bool,
     /// The path to the module binary
-    #[structopt(long = "module-path", short = "b")]
+    #[clap(long = "module-path", short = 'b')]
     pub module_binary_path: String,
     /// The path to the source file
-    #[structopt(long = "source-path", short = "s")]
+    #[clap(long = "source-path", short = 's')]
     pub source_file_path: String,
     /// Optional path to save coverage. Printed to stdout if not present.
-    #[structopt(long = "coverage-path", short = "o")]
+    #[clap(long = "coverage-path", short = 'o')]
     pub coverage_path: Option<String>,
 }
 
 fn main() {
-    let args = Args::from_args();
+    let args = Args::parse();
     let source_map_extension = SOURCE_MAP_EXTENSION;
     let coverage_map = if args.is_raw_trace_file {
         CoverageMap::from_trace_file(&args.input_trace_path)

--- a/language/tools/move-disassembler/Cargo.toml
+++ b/language/tools/move-disassembler/Cargo.toml
@@ -19,7 +19,7 @@ move-binary-format = { path = "../../move-binary-format" }
 move-coverage = { path = "../move-coverage" }
 move-compiler = { path = "../../move-compiler" }
 
-structopt = "0.3.21"
+clap = { version = "3.1", features = ["derive"] }
 workspace-hack = { version = "0.1", path = "../../../crates/workspace-hack" }
 
 [features]

--- a/language/tools/move-disassembler/src/disassembler.rs
+++ b/language/tools/move-disassembler/src/disassembler.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::{bail, format_err, Error, Result};
+use clap::Args;
 use colored::*;
 use move_binary_format::{
     binary_views::BinaryIndexedView,
@@ -21,25 +22,24 @@ use move_compiler::compiled_unit::{CompiledUnit, NamedCompiledModule, NamedCompi
 use move_core_types::identifier::IdentStr;
 use move_coverage::coverage_map::{ExecCoverageMap, FunctionCoverage};
 use move_ir_types::location::Loc;
-use structopt::StructOpt;
 
 /// Holds the various options that we support while disassembling code.
-#[derive(Debug, Default, StructOpt)]
+#[derive(Debug, Default, Args)]
 pub struct DisassemblerOptions {
     /// Only print non-private functions
-    #[structopt(long = "only-public")]
+    #[clap(long = "only-public")]
     pub only_externally_visible: bool,
 
     /// Print the bytecode for the instructions within the function.
-    #[structopt(long = "print-code")]
+    #[clap(long = "print-code")]
     pub print_code: bool,
 
     /// Print the basic blocks of the bytecode.
-    #[structopt(long = "print-basic-blocks")]
+    #[clap(long = "print-basic-blocks")]
     pub print_basic_blocks: bool,
 
     /// Print the locals inside each function body.
-    #[structopt(long = "print-locals")]
+    #[clap(long = "print-locals")]
     pub print_locals: bool,
 }
 

--- a/language/tools/move-disassembler/src/main.rs
+++ b/language/tools/move-disassembler/src/main.rs
@@ -3,6 +3,7 @@
 
 #![forbid(unsafe_code)]
 
+use clap::Parser;
 use move_binary_format::{
     binary_views::BinaryIndexedView,
     file_format::{CompiledModule, CompiledScript},
@@ -15,48 +16,45 @@ use move_coverage::coverage_map::CoverageMap;
 use move_disassembler::disassembler::{Disassembler, DisassemblerOptions};
 use move_ir_types::location::Spanned;
 use std::{fs, path::Path};
-use structopt::StructOpt;
 
-#[derive(Debug, StructOpt)]
-#[structopt(
-    name = "Move Bytecode Disassembler",
-    about = "Print a human-readable version of Move bytecode (.mv files)"
-)]
+/// Print a human-readable version of Move bytecode (.mv files)
+#[derive(Debug, Parser)]
+#[clap(version, name = "Move Bytecode Disassembler")]
 struct Args {
     /// Skip printing of private functions.
-    #[structopt(long = "skip-private")]
+    #[clap(long = "skip-private")]
     pub skip_private: bool,
 
     /// Do not print the disassembled bytecodes of each function.
-    #[structopt(long = "skip-code")]
+    #[clap(long = "skip-code")]
     pub skip_code: bool,
 
     /// Do not print locals of each function.
-    #[structopt(long = "skip-locals")]
+    #[clap(long = "skip-locals")]
     pub skip_locals: bool,
 
     /// Do not print the basic blocks of each function.
-    #[structopt(long = "skip-basic-blocks")]
+    #[clap(long = "skip-basic-blocks")]
     pub skip_basic_blocks: bool,
 
     /// Treat input file as a script (default is to treat file as a module)
-    #[structopt(short = "s", long = "script")]
+    #[clap(short = 's', long = "script")]
     pub is_script: bool,
 
     /// The path to the bytecode file to disassemble; let's call it file.mv. We assume that two
     /// other files reside under the same directory: a source map file.mvsm (possibly) and the Move
     /// source code file.move.
-    #[structopt(short = "b", long = "bytecode")]
+    #[clap(short = 'b', long = "bytecode")]
     pub bytecode_file_path: String,
 
     /// (Optional) Path to a coverage file for the VM in order to print trace information in the
     /// disassembled output.
-    #[structopt(short = "c", long = "move-coverage-path")]
+    #[clap(short = 'c', long = "move-coverage-path")]
     pub code_coverage_path: Option<String>,
 }
 
 fn main() {
-    let args = Args::from_args();
+    let args = Args::parse();
 
     let move_extension = MOVE_EXTENSION;
     let mv_bytecode_extension = MOVE_COMPILED_EXTENSION;

--- a/language/tools/move-explain/Cargo.toml
+++ b/language/tools/move-explain/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 edition = "2018"
 
 [dependencies]
-structopt = "0.3.21"
+clap = { version = "3.1", features = ["derive"] }
 move-command-line-common = { path = "../../move-command-line-common" }
 move-core-types = { path = "../../move-core/types" }
 bcs = "0.1.2"

--- a/language/tools/move-explain/src/main.rs
+++ b/language/tools/move-explain/src/main.rs
@@ -1,31 +1,31 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use clap::Parser;
 use move_command_line_common::files::MOVE_ERROR_DESC_EXTENSION;
 use move_core_types::{
     account_address::AccountAddress, errmap::ErrorMapping, identifier::Identifier,
     language_storage::ModuleId,
 };
-use structopt::StructOpt;
-#[derive(Debug, StructOpt)]
-#[structopt(
-    name = "Move Explain",
-    about = "Explain Move abort codes. Errors are defined as a global category + module-specific reason for the error."
-)]
+
+/// Explain Move abort codes.
+/// Errors are defined as a global category + module-specific reason for the error.
+#[derive(Debug, Parser)]
+#[clap(version, name = "Move Explain")]
 struct Args {
     /// The location (module id) returned with a `MoveAbort` error
-    #[structopt(long = "location", short = "l")]
+    #[clap(long = "location", short = 'l')]
     location: String,
     /// The abort code returned with a `MoveAbort` error
-    #[structopt(long = "abort-code", short = "a")]
+    #[clap(long = "abort-code", short = 'a')]
     abort_code: u64,
     /// Path to the error code mapping file
-    #[structopt(long = MOVE_ERROR_DESC_EXTENSION, short = "e")]
+    #[clap(long = MOVE_ERROR_DESC_EXTENSION, short = 'e')]
     errmap_path: String,
 }
 
 fn main() {
-    let args = Args::from_args();
+    let args = Args::parse();
 
     let mut location = args.location.trim().split("::");
     let mut address_literal = location.next().expect("Could not find address").to_string();

--- a/language/tools/move-package/Cargo.toml
+++ b/language/tools/move-package/Cargo.toml
@@ -12,7 +12,7 @@ serde = { version = "1.0", features = ["derive"] }
 petgraph = "0.5.1"
 anyhow = "1.0.52"
 walkdir = "2.3.1"
-structopt = "0.3.21"
+clap = { version = "3.1", features = ["derive"] }
 bcs = "0.1.2"
 colored = "2.0.0"
 serde_yaml = "0.8.17"

--- a/language/tools/move-package/src/lib.rs
+++ b/language/tools/move-package/src/lib.rs
@@ -7,6 +7,7 @@ pub mod resolution;
 pub mod source_package;
 
 use anyhow::Result;
+use clap::Args;
 use compilation::compiled_package::CompilationCachingStatus;
 use move_core_types::account_address::AccountAddress;
 use move_model::model::GlobalEnv;
@@ -17,7 +18,6 @@ use std::{
     io::Write,
     path::{Path, PathBuf},
 };
-use structopt::*;
 
 use crate::{
     compilation::{
@@ -28,41 +28,38 @@ use crate::{
     source_package::{layout, manifest_parser},
 };
 
-#[derive(Debug, StructOpt, Clone, Serialize, Deserialize, Eq, PartialEq, PartialOrd)]
-#[structopt(
-    name = "Move Package",
-    about = "Package and build system for Move code."
-)]
+// Package and build system for Move code.
+#[derive(Debug, Args, Clone, Serialize, Deserialize, Eq, PartialEq, PartialOrd)]
 pub struct BuildConfig {
     /// Compile in 'dev' mode. The 'dev-addresses' and 'dev-dependencies' fields will be used if
     /// this flag is set. This flag is useful for development of packages that expose named
     /// addresses that are not set to a specific value.
-    #[structopt(name = "dev-mode", short = "d", long = "dev", global = true)]
+    #[clap(name = "dev-mode", short = 'd', long = "dev", global = true)]
     pub dev_mode: bool,
 
     /// Compile in 'test' mode. The 'dev-addresses' and 'dev-dependencies' fields will be used
     /// along with any code in the 'test' directory.
-    #[structopt(name = "test-mode", long = "test", global = true)]
+    #[clap(name = "test-mode", long = "test", global = true)]
     pub test_mode: bool,
 
     /// Generate documentation for packages
-    #[structopt(name = "generate-docs", long = "doc", global = true)]
+    #[clap(name = "generate-docs", long = "doc", global = true)]
     pub generate_docs: bool,
 
     /// Generate ABIs for packages
-    #[structopt(name = "generate-abis", long = "abi", global = true)]
+    #[clap(name = "generate-abis", long = "abi", global = true)]
     pub generate_abis: bool,
 
     /// Installation directory for compiled artifacts. Defaults to current directory.
-    #[structopt(long = "install-dir", parse(from_os_str), global = true)]
+    #[clap(long = "install-dir", parse(from_os_str), global = true)]
     pub install_dir: Option<PathBuf>,
 
     /// Force recompilation of all packages
-    #[structopt(name = "force-recompilation", long = "force", global = true)]
+    #[clap(name = "force-recompilation", long = "force", global = true)]
     pub force_recompilation: bool,
 
     /// Additional named address mapping. Useful for tools in rust
-    #[structopt(skip)]
+    #[clap(skip)]
     pub additional_named_addresses: BTreeMap<String, AccountAddress>,
 }
 

--- a/language/tools/move-unit-test/Cargo.toml
+++ b/language/tools/move-unit-test/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0.52"
-structopt = "0.3.21"
+clap = { version = "3.1", features = ["derive"] }
 colored = "2.0.0"
 rayon = "1.5.0"
 

--- a/language/tools/move-unit-test/src/lib.rs
+++ b/language/tools/move-unit-test/src/lib.rs
@@ -4,7 +4,9 @@
 pub mod cargo_runner;
 pub mod test_reporter;
 pub mod test_runner;
+
 use crate::test_runner::TestRunner;
+use clap::Parser;
 use move_command_line_common::files::verify_and_create_named_address_mapping;
 use move_compiler::{
     self,
@@ -21,69 +23,69 @@ use std::{
     marker::Send,
     sync::Mutex,
 };
-use structopt::*;
 
-#[derive(Debug, StructOpt, Clone)]
-#[structopt(name = "Move Unit Test", about = "Unit testing for Move code.")]
+/// Unit testing for Move code.
+#[derive(Debug, Parser, Clone)]
+#[clap(version, name = "Move Unit Test")]
 pub struct UnitTestingConfig {
     /// Bound the number of instructions that can be executed by any one test.
-    #[structopt(
+    #[clap(
         name = "instructions",
         default_value = "5000",
-        short = "i",
+        short = 'i',
         long = "instructions"
     )]
     pub instruction_execution_bound: u64,
 
     /// A filter string to determine which unit tests to run
-    #[structopt(name = "filter", short = "f", long = "filter")]
+    #[clap(name = "filter", short = 'f', long = "filter")]
     pub filter: Option<String>,
 
     /// List all tests
-    #[structopt(name = "list", short = "l", long = "list")]
+    #[clap(name = "list", short = 'l', long = "list")]
     pub list: bool,
 
     /// Number of threads to use for running tests.
-    #[structopt(
+    #[clap(
         name = "num_threads",
-        default_value = "8",
-        short = "t",
+        default_value_t = 8,
+        short = 't',
         long = "threads"
     )]
     pub num_threads: usize,
 
     /// Dependency files
-    #[structopt(name = "dependencies", long = "dependencies", short = "d")]
+    #[clap(name = "dependencies", long = "dependencies", short = 'd')]
     pub dep_files: Vec<String>,
 
     /// Report test statistics at the end of testing
-    #[structopt(name = "report_statistics", short = "s", long = "statistics")]
+    #[clap(name = "report_statistics", short = 's', long = "statistics")]
     pub report_statistics: bool,
 
     /// Show the storage state at the end of execution of a failing test
-    #[structopt(name = "global_state_on_error", short = "g", long = "state_on_error")]
+    #[clap(name = "global_state_on_error", short = 'g', long = "state_on_error")]
     pub report_storage_on_error: bool,
 
     /// Named address mapping
-    #[structopt(
+    #[clap(
         name = "NAMED_ADDRESSES",
-        short = "a",
+        short = 'a',
         long = "addresses",
         parse(try_from_str = shared::parse_named_address)
     )]
     pub named_address_values: Vec<(String, NumericalAddress)>,
 
     /// Source files
-    #[structopt(name = "sources")]
+    #[clap(name = "sources")]
     pub source_files: Vec<String>,
 
     /// Use the stackless bytecode interpreter to run the tests and cross check its results with
     /// the execution result from Move VM.
-    #[structopt(long = "stackless")]
+    #[clap(long = "stackless")]
     pub check_stackless_vm: bool,
 
     /// Verbose mode
-    #[structopt(short = "v", long = "verbose")]
+    #[clap(short = 'v', long = "verbose")]
     pub verbose: bool,
 }
 

--- a/language/tools/move-unit-test/src/main.rs
+++ b/language/tools/move-unit-test/src/main.rs
@@ -1,11 +1,11 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use clap::Parser;
 use move_unit_test::UnitTestingConfig;
-use structopt::*;
 
 pub fn main() {
-    let args = UnitTestingConfig::from_args();
+    let args = UnitTestingConfig::parse();
 
     let test_plan = args.build_test_plan();
     if let Some(test_plan) = test_plan {


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Modernizes CLI argument parsing by switching from `structopt` to `clap` 3 with the newly added `derive` feature.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes
