### PR TITLE
[move-compiler] Improve CFG traversal

### DIFF
--- a/language/move-compiler/src/cfgir/liveness/mod.rs
+++ b/language/move-compiler/src/cfgir/liveness/mod.rs
@@ -175,7 +175,9 @@ pub fn last_usage(
 ) {
     let (final_invariants, per_command_states) = analyze(cfg, infinite_loop_starts);
     for (lbl, block) in cfg.blocks_mut() {
-        let final_invariant = final_invariants.get(lbl).unwrap();
+        let final_invariant = final_invariants
+            .get(lbl)
+            .unwrap_or_else(|| panic!("ICE no liveness states for {}", lbl));
         let command_states = per_command_states.get(lbl).unwrap();
         last_usage::block(
             compilation_env,

--- a/language/move-compiler/tests/move_check/borrows/borrow_field_combo_invalid.exp
+++ b/language/move-compiler/tests/move_check/borrows/borrow_field_combo_invalid.exp
@@ -42,7 +42,7 @@ error[E07001]: referential transparency violated
    ┌─ tests/move_check/borrows/borrow_field_combo_invalid.move:67:18
    │
 66 │         let c; if (cond) c = id_mut(&mut inner.f1) else c = &mut inner.f1;
-   │                                                             ------------- Field 'f1' is still being mutably borrowed by this reference
+   │                              --------------------- Field 'f1' is still being mutably borrowed by this reference
 67 │         let f1 = &inner.f1;
    │                  ^^^^^^^^^ Invalid immutable borrow at field 'f1'.
 

--- a/language/move-compiler/tests/move_check/locals/use_after_move_if_else.exp
+++ b/language/move-compiler/tests/move_check/locals/use_after_move_if_else.exp
@@ -2,10 +2,10 @@ error[E06002]: use of unassigned variable
   ┌─ tests/move_check/locals/use_after_move_if_else.move:5:17
   │
 4 │         if (cond) { _ = move x } else { _ = move x };
-  │                                             ------
-  │                                             │
-  │                                             The value of 'x' was previously moved here.
-  │                                             Suggestion: use 'copy x' to avoid the move.
+  │                         ------
+  │                         │
+  │                         The value of 'x' was previously moved here.
+  │                         Suggestion: use 'copy x' to avoid the move.
 5 │         let _ = move x + 1;
   │                 ^^^^^^ Invalid usage of previously moved variable 'x'.
 
@@ -24,10 +24,10 @@ error[E06002]: use of unassigned variable
    ┌─ tests/move_check/locals/use_after_move_if_else.move:17:17
    │
 16 │         if (cond) { _ = move x } else { _ = move x };
-   │                                             ------
-   │                                             │
-   │                                             The value of 'x' was previously moved here.
-   │                                             Suggestion: use 'copy x' to avoid the move.
+   │                         ------
+   │                         │
+   │                         The value of 'x' was previously moved here.
+   │                         Suggestion: use 'copy x' to avoid the move.
 17 │         let _ = x + 1;
    │                 ^ Invalid usage of previously moved variable 'x'.
 
@@ -46,10 +46,10 @@ error[E06002]: use of unassigned variable
    ┌─ tests/move_check/locals/use_after_move_if_else.move:30:17
    │
 29 │         if (cond) { _ = move x } else { _ = move x };
-   │                                             ------
-   │                                             │
-   │                                             The value of 'x' was previously moved here.
-   │                                             Suggestion: use 'copy x' to avoid the move.
+   │                         ------
+   │                         │
+   │                         The value of 'x' was previously moved here.
+   │                         Suggestion: use 'copy x' to avoid the move.
 30 │         let _ = &x;
    │                 ^^ Invalid usage of previously moved variable 'x'.
 


### PR DESCRIPTION
- Use reverse post-order traversal for source language CFG
- Will allow for warnings in the future on type-system checks that require fix-point iteration

## Motivation

- We want to change the rules of the bytecode verifier to not require fix-point iteration for its rules
- This refactor will allow for these sorts of constraints to exist for the source language too

## Test Plan

- internal only change
- ran the tests