### PR TITLE
[move-tools] Serde-friendly type layout generation from modules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1715,6 +1715,7 @@ dependencies = [
  "move-binary-format",
  "move-core-types",
  "petgraph 0.5.1",
+ "serde-reflection",
  "workspace-hack",
 ]
 
@@ -3560,6 +3561,17 @@ dependencies = [
  "num-traits 0.1.43",
  "regex",
  "serde 0.8.23",
+]
+
+[[package]]
+name = "serde-reflection"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "167450ba550f903a2b35a81ba3ca387585189e2430e3df6b94b95f3bec2f26bd"
+dependencies = [
+ "once_cell",
+ "serde 1.0.130",
+ "thiserror",
 ]
 
 [[package]]

--- a/language/move-binary-format/src/access.rs
+++ b/language/move-binary-format/src/access.rs
@@ -199,6 +199,13 @@ pub trait ModuleAccess: Sync {
     fn find_struct_def(&self, idx: StructHandleIndex) -> Option<&StructDefinition> {
         self.struct_defs().iter().find(|d| d.struct_handle == idx)
     }
+
+    fn find_struct_def_by_name(&self, name: &IdentStr) -> Option<&StructDefinition> {
+        self.struct_defs().iter().find(|def| {
+            let handle = self.struct_handle_at(def.struct_handle);
+            name == self.identifier_at(handle.name)
+        })
+    }
 }
 
 /// Represents accessors for a compiled script.

--- a/language/tools/move-bytecode-utils/Cargo.toml
+++ b/language/tools/move-bytecode-utils/Cargo.toml
@@ -14,4 +14,5 @@ anyhow = "1.0.52"
 move-binary-format = { path = "../../move-binary-format" }
 move-core-types = { path = "../../move-core/types" }
 petgraph = "0.5.1"
+serde-reflection = "0.3.2"
 workspace-hack = { version = "0.1", path = "../../../crates/workspace-hack" }

--- a/language/tools/move-bytecode-utils/src/layout.rs
+++ b/language/tools/move-bytecode-utils/src/layout.rs
@@ -2,18 +2,217 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::module_cache::GetModule;
-use anyhow::{anyhow, bail, Result};
+use anyhow::{bail, Result};
 use move_binary_format::{
     access::ModuleAccess,
     file_format::{SignatureToken, StructDefinition, StructFieldInformation, StructHandleIndex},
+    normalized::{Struct, Type},
     CompiledModule,
 };
 use move_core_types::{
-    identifier::IdentStr,
+    account_address::AccountAddress,
+    identifier::{IdentStr, Identifier},
     language_storage::{ModuleId, StructTag, TypeTag},
     value::{MoveFieldLayout, MoveStructLayout, MoveTypeLayout},
 };
-use std::{borrow::Borrow, fmt::Debug};
+use serde_reflection::{ContainerFormat, Format, Named, Registry};
+use std::{borrow::Borrow, collections::BTreeMap, fmt::Debug};
+
+/// Name of the Move `address` type in the serde registry
+const ADDRESS: &str = "AccountAddress";
+
+/// Name of the Move `signer` type in the serde registry
+const SIGNER: &str = "Signer";
+
+/// Type for building a registry of serde-reflection friendly struct layouts for Move types.
+/// The layouts created by this type are intended to be passed to the serde-generate tool to create
+/// struct bindings for Move types in source languages that use Move-based services.
+/// The LayoutBuilder can operate in two modes: "deep" and "shallow".
+/// In shallow mode, it will generate a single layout for the struct or type passed in by the user
+/// (under the assumption that layouts for dependencies have been generated previously).
+/// In deep mode, it will generate layouts for all of the (transitive) dependencies of the type passed
+/// in, as well as layouts for the Move ground types like `address` and `signer`. The result is a
+/// self-contained registry with no unbound typenames
+pub struct SerdeLayoutBuilder<T> {
+    registry: Registry,
+    module_resolver: T,
+    /// If true, operate in shallow mode; else, operate in deep mode
+    shallow: bool,
+}
+
+impl<T: GetModule> SerdeLayoutBuilder<T> {
+    /// Create a `LayoutBuilder` with an empty registry and deep layout resolution
+    pub fn new(module_resolver: T) -> Self {
+        Self {
+            registry: Self::default_registry(),
+            module_resolver,
+            shallow: false,
+        }
+    }
+
+    /// Create a `LayoutBuilder` with an empty registry and shallow layout resolution
+    pub fn new_shallow(module_resolver: T) -> Self {
+        Self {
+            registry: BTreeMap::new(),
+            module_resolver,
+            shallow: true,
+        }
+    }
+
+    /// Return a registry containing layouts for all the Move ground types (e.g., address)
+    pub fn default_registry() -> Registry {
+        let mut registry = BTreeMap::new();
+        // add Move ground types to registry (address, signer)
+        let address_layout = Box::new(Format::TupleArray {
+            content: Box::new(Format::U8),
+            size: AccountAddress::LENGTH,
+        });
+        registry.insert(
+            ADDRESS.to_string(),
+            ContainerFormat::NewTypeStruct(address_layout.clone()),
+        );
+        registry.insert(
+            SIGNER.to_string(),
+            ContainerFormat::NewTypeStruct(address_layout),
+        );
+
+        registry
+    }
+
+    /// Get the registry of layouts generated so far
+    pub fn registry(&self) -> &Registry {
+        &self.registry
+    }
+
+    /// Get the registry of layouts generated so far
+    pub fn into_registry(self) -> Registry {
+        self.registry
+    }
+
+    /// Add layouts for all types used in `t` to the registry
+    pub fn build_type_layout(&mut self, t: TypeTag) -> Result<Format, T::Error> {
+        self.build_normalized_type_layout(&Type::from(t), &Vec::new())
+    }
+
+    /// Add layouts for all types used in `t` to the registry
+    pub fn build_struct_layout(&mut self, s: &StructTag) -> Result<Format, T::Error> {
+        let serde_type_args = s
+            .type_params
+            .iter()
+            .map(|t| self.build_type_layout(t.clone()))
+            .collect::<Result<Vec<Format>, T::Error>>()?;
+        let shallow = false;
+        self.build_struct_layout_(&s.module_id(), &s.name, &serde_type_args, shallow)
+    }
+
+    fn build_normalized_type_layout(
+        &mut self,
+        t: &Type,
+        input_type_args: &[Format],
+    ) -> Result<Format, T::Error> {
+        use Type::*;
+        Ok(match t {
+            Bool => Format::Bool,
+            U8 => Format::U8,
+            U64 => Format::U64,
+            U128 => Format::U128,
+            Address => Format::TypeName(ADDRESS.to_string()),
+            Signer => Format::TypeName(SIGNER.to_string()),
+            Struct {
+                address,
+                module,
+                name,
+                type_arguments,
+            } => {
+                let serde_type_args = type_arguments
+                    .iter()
+                    .map(|t| self.build_normalized_type_layout(t, input_type_args))
+                    .collect::<Result<Vec<Format>, T::Error>>()?;
+                let declaring_module = ModuleId::new(*address, module.clone());
+                self.build_struct_layout_(&declaring_module, name, &serde_type_args, self.shallow)?
+            }
+            Vector(inner_t) => {
+                if matches!(inner_t.as_ref(), U8) {
+                    // specialize vector<u8> as bytes
+                    Format::Bytes
+                } else {
+                    Format::Seq(Box::new(
+                        self.build_normalized_type_layout(inner_t, input_type_args)?,
+                    ))
+                }
+            }
+            TypeParameter(i) => input_type_args[*i as usize].clone(),
+            Reference(_) | MutableReference(_) => unreachable!(), // structs cannot store references
+        })
+    }
+
+    fn build_struct_layout_(
+        &mut self,
+        module_id: &ModuleId,
+        name: &Identifier,
+        type_arguments: &[Format],
+        shallow: bool,
+    ) -> Result<Format, T::Error> {
+        // build a human-readable name for the struct type. this should do the same thing as
+        // StructTag::display(), but it's not easy to use that code here
+        let generics: Vec<String> = type_arguments
+            .iter()
+            .map(|t| Self::print_format_type(t))
+            .collect();
+        let struct_key = format!("{}::{}<{}>", module_id, name, generics.join(","));
+        if !shallow && !self.registry.contains_key(&struct_key) {
+            let declaring_module = self
+                .module_resolver
+                .get_module_by_id(module_id)?
+                .expect("Failed to resolve module");
+            let def = declaring_module
+                .borrow()
+                .find_struct_def_by_name(name)
+                .unwrap_or_else(|| {
+                    panic!(
+                        "Could not find struct named {} in module {}",
+                        name,
+                        declaring_module.borrow().name()
+                    )
+                });
+            let normalized_struct = Struct::new(declaring_module.borrow(), def).1;
+            assert_eq!(
+                normalized_struct.type_parameters.len(),
+                type_arguments.len(),
+                "Wrong number of type arguments for struct"
+            );
+            let fields = normalized_struct
+                .fields
+                .iter()
+                .map(|f| {
+                    self.build_normalized_type_layout(&f.type_, type_arguments)
+                        .map(|value| Named {
+                            name: f.name.to_string(),
+                            value,
+                        })
+                })
+                .collect::<Result<Vec<Named<Format>>, T::Error>>()?;
+
+            let serde_struct = ContainerFormat::Struct(fields);
+            // update cache
+            self.registry.insert(struct_key.clone(), serde_struct);
+        } // else, it's shallow mode or we already generated a layout for the type
+        Ok(Format::TypeName(struct_key))
+    }
+
+    fn print_format_type(t: &Format) -> String {
+        match t {
+            Format::TypeName(s) => s.to_string(),
+            Format::Bool => "bool".to_string(),
+            Format::U8 => "u8".to_string(),
+            Format::U64 => "u64".to_string(),
+            Format::U128 => "u128".to_string(),
+            Format::Bytes => "vector<u8>".to_string(),
+            Format::Seq(inner) => format!("vector<{}>", Self::print_format_type(inner)),
+            v => unimplemented!("Printing format value {:?}", v),
+        }
+    }
+}
 
 pub enum TypeLayoutBuilder {}
 pub enum StructLayoutBuilder {}
@@ -201,24 +400,18 @@ impl StructLayoutBuilder {
     ) -> Result<MoveStructLayout> {
         let module = resolver
             .get_module_by_id(declaring_module)
-            .map_err(|_| anyhow!("Error while resolving module {}", declaring_module))?
-            .ok_or_else(|| anyhow!("Failed to get module {}", declaring_module))?;
-        let m = module.borrow();
-        let def = m
-            .struct_defs
-            .iter()
-            .find(|def| {
-                let handle = m.struct_handle_at(def.struct_handle);
-                name == m.identifier_at(handle.name)
-            })
-            .ok_or_else(|| {
-                anyhow!(
+            .unwrap_or_else(|_| panic!("Error while resolving module {}", declaring_module))
+            .unwrap();
+        let def = module
+            .borrow()
+            .find_struct_def_by_name(name)
+            .unwrap_or_else(|| {
+                panic!(
                     "Could not find struct named {} in module {}",
-                    name,
-                    declaring_module
+                    name, declaring_module
                 )
-            })?;
-        Self::build_from_definition(m, def, type_arguments, resolver, layout_type)
+            });
+        Self::build_from_definition(module.borrow(), def, type_arguments, resolver, layout_type)
     }
 
     fn build_from_handle_idx(

--- a/language/tools/move-cli/src/sandbox/cli.rs
+++ b/language/tools/move-cli/src/sandbox/cli.rs
@@ -134,6 +134,10 @@ pub struct StructLayoutOptions {
     /// Generate layout bindings for `struct` bound to these type arguments.
     #[structopt(long = "type-args", parse(try_from_str = parser::parse_type_tag), requires="struct")]
     type_args: Option<Vec<TypeTag>>,
+    /// If set, generate bindings only for the struct passed in.
+    /// When unset, generates bindings for the struct and all of its transitive dependencies.
+    #[structopt(long = "shallow")]
+    shallow: bool,
 }
 
 impl SandboxCommand {
@@ -249,6 +253,7 @@ fn handle_generate_commands(cmd: &GenerateCommand, state: &OnDiskStateView) -> R
                 module,
                 &options.struct_,
                 &options.type_args,
+                options.shallow,
                 state,
             )
         }

--- a/language/tools/move-cli/tests/testsuite/generate_struct_layout/args.exp
+++ b/language/tools/move-cli/tests/testsuite/generate_struct_layout/args.exp
@@ -1,15 +1,220 @@
 Command `sandbox publish`:
 Command `sandbox generate struct-layouts --module storage/0x00000000000000000000000000000001/modules/M2.mv --struct C --type-args u64`:
-{ t: u64, b: bool, }
+---
+"00000000000000000000000000000001::M2::C<u64>":
+  STRUCT:
+    - t: U64
+    - b: BOOL
+AccountAddress:
+  NEWTYPESTRUCT:
+    TUPLEARRAY:
+      CONTENT: U8
+      SIZE: 16
+Signer:
+  NEWTYPESTRUCT:
+    TUPLEARRAY:
+      CONTENT: U8
+      SIZE: 16
+
 Command `sandbox generate struct-layouts --module storage/0x00000000000000000000000000000001/modules/M2.mv --struct C --type-args address`:
-{ t: address, b: bool, }
+---
+"00000000000000000000000000000001::M2::C<AccountAddress>":
+  STRUCT:
+    - t:
+        TYPENAME: AccountAddress
+    - b: BOOL
+AccountAddress:
+  NEWTYPESTRUCT:
+    TUPLEARRAY:
+      CONTENT: U8
+      SIZE: 16
+Signer:
+  NEWTYPESTRUCT:
+    TUPLEARRAY:
+      CONTENT: U8
+      SIZE: 16
+
 Command `sandbox generate struct-layouts --module storage/0x00000000000000000000000000000001/modules/M2.mv --struct C --type-args vector<u8>`:
-{ t: vector<u8>, b: bool, }
+---
+"00000000000000000000000000000001::M2::C<vector<u8>>":
+  STRUCT:
+    - t: BYTES
+    - b: BOOL
+AccountAddress:
+  NEWTYPESTRUCT:
+    TUPLEARRAY:
+      CONTENT: U8
+      SIZE: 16
+Signer:
+  NEWTYPESTRUCT:
+    TUPLEARRAY:
+      CONTENT: U8
+      SIZE: 16
+
 Command `sandbox generate struct-layouts --module storage/0x00000000000000000000000000000001/modules/M1.mv --struct B --type-args bool`:
-{ a: address, c: { t: bool, b: bool, }, t: bool, }
+---
+"00000000000000000000000000000001::M1::B<bool>":
+  STRUCT:
+    - a:
+        TYPENAME: AccountAddress
+    - c:
+        TYPENAME: "00000000000000000000000000000001::M2::C<bool>"
+    - t: BOOL
+"00000000000000000000000000000001::M2::C<bool>":
+  STRUCT:
+    - t: BOOL
+    - b: BOOL
+AccountAddress:
+  NEWTYPESTRUCT:
+    TUPLEARRAY:
+      CONTENT: U8
+      SIZE: 16
+Signer:
+  NEWTYPESTRUCT:
+    TUPLEARRAY:
+      CONTENT: U8
+      SIZE: 16
+
+Command `sandbox generate struct-layouts --module storage/0x00000000000000000000000000000001/modules/M1.mv --struct B --type-args bool --shallow`:
+---
+"00000000000000000000000000000001::M1::B<bool>":
+  STRUCT:
+    - a:
+        TYPENAME: AccountAddress
+    - c:
+        TYPENAME: "00000000000000000000000000000001::M2::C<bool>"
+    - t: BOOL
+
 Command `sandbox generate struct-layouts --module storage/0x00000000000000000000000000000001/modules/M1.mv --struct A --type-args 0x1::M1::S<u64>`:
-{ f: u64, v: vector<u8>, b: { a: address, c: { t: { t: u64, }, b: bool, }, t: { t: u64, }, }, }
+---
+"00000000000000000000000000000001::M1::A<00000000000000000000000000000001::M1::S<u64>>":
+  STRUCT:
+    - f: U64
+    - v: BYTES
+    - b:
+        TYPENAME: "00000000000000000000000000000001::M1::B<00000000000000000000000000000001::M1::S<u64>>"
+"00000000000000000000000000000001::M1::B<00000000000000000000000000000001::M1::S<u64>>":
+  STRUCT:
+    - a:
+        TYPENAME: AccountAddress
+    - c:
+        TYPENAME: "00000000000000000000000000000001::M2::C<00000000000000000000000000000001::M1::S<u64>>"
+    - t:
+        TYPENAME: "00000000000000000000000000000001::M1::S<u64>"
+"00000000000000000000000000000001::M1::S<u64>":
+  STRUCT:
+    - t: U64
+"00000000000000000000000000000001::M2::C<00000000000000000000000000000001::M1::S<u64>>":
+  STRUCT:
+    - t:
+        TYPENAME: "00000000000000000000000000000001::M1::S<u64>"
+    - b: BOOL
+AccountAddress:
+  NEWTYPESTRUCT:
+    TUPLEARRAY:
+      CONTENT: U8
+      SIZE: 16
+Signer:
+  NEWTYPESTRUCT:
+    TUPLEARRAY:
+      CONTENT: U8
+      SIZE: 16
+
 Command `sandbox generate struct-layouts --module storage/0x00000000000000000000000000000001/modules/M1.mv --struct A --type-args vector<0x1::M1::S<u64>>`:
-{ f: u64, v: vector<u8>, b: { a: address, c: { t: vector<{ t: u64, }>, b: bool, }, t: vector<{ t: u64, }>, }, }
+---
+"00000000000000000000000000000001::M1::A<vector<00000000000000000000000000000001::M1::S<u64>>>":
+  STRUCT:
+    - f: U64
+    - v: BYTES
+    - b:
+        TYPENAME: "00000000000000000000000000000001::M1::B<vector<00000000000000000000000000000001::M1::S<u64>>>"
+"00000000000000000000000000000001::M1::B<vector<00000000000000000000000000000001::M1::S<u64>>>":
+  STRUCT:
+    - a:
+        TYPENAME: AccountAddress
+    - c:
+        TYPENAME: "00000000000000000000000000000001::M2::C<vector<00000000000000000000000000000001::M1::S<u64>>>"
+    - t:
+        SEQ:
+          TYPENAME: "00000000000000000000000000000001::M1::S<u64>"
+"00000000000000000000000000000001::M1::S<u64>":
+  STRUCT:
+    - t: U64
+"00000000000000000000000000000001::M2::C<vector<00000000000000000000000000000001::M1::S<u64>>>":
+  STRUCT:
+    - t:
+        SEQ:
+          TYPENAME: "00000000000000000000000000000001::M1::S<u64>"
+    - b: BOOL
+AccountAddress:
+  NEWTYPESTRUCT:
+    TUPLEARRAY:
+      CONTENT: U8
+      SIZE: 16
+Signer:
+  NEWTYPESTRUCT:
+    TUPLEARRAY:
+      CONTENT: U8
+      SIZE: 16
+
+Command `sandbox generate struct-layouts --module storage/0x00000000000000000000000000000001/modules/M1.mv --struct A --type-args 0x1::M1::S<u64> --shallow`:
+---
+"00000000000000000000000000000001::M1::A<00000000000000000000000000000001::M1::S<u64>>":
+  STRUCT:
+    - f: U64
+    - v: BYTES
+    - b:
+        TYPENAME: "00000000000000000000000000000001::M1::B<00000000000000000000000000000001::M1::S<u64>>"
+
+Command `sandbox generate struct-layouts --module storage/0x00000000000000000000000000000001/modules/M1.mv --struct A --type-args vector<0x1::M1::S<u64>> --shallow`:
+---
+"00000000000000000000000000000001::M1::A<vector<00000000000000000000000000000001::M1::S<u64>>>":
+  STRUCT:
+    - f: U64
+    - v: BYTES
+    - b:
+        TYPENAME: "00000000000000000000000000000001::M1::B<vector<00000000000000000000000000000001::M1::S<u64>>>"
+
 Command `sandbox generate struct-layouts --module storage/0x00000000000000000000000000000001/modules/M2.mv --struct C --type-args 0x1::M2::C<u64>`:
-{ t: { t: u64, b: bool, }, b: bool, }
+---
+"00000000000000000000000000000001::M2::C<00000000000000000000000000000001::M2::C<u64>>":
+  STRUCT:
+    - t:
+        TYPENAME: "00000000000000000000000000000001::M2::C<u64>"
+    - b: BOOL
+"00000000000000000000000000000001::M2::C<u64>":
+  STRUCT:
+    - t: U64
+    - b: BOOL
+AccountAddress:
+  NEWTYPESTRUCT:
+    TUPLEARRAY:
+      CONTENT: U8
+      SIZE: 16
+Signer:
+  NEWTYPESTRUCT:
+    TUPLEARRAY:
+      CONTENT: U8
+      SIZE: 16
+
+Command `sandbox generate struct-layouts --module storage/0x00000000000000000000000000000001/modules/M1.mv --struct G`:
+---
+"00000000000000000000000000000001::M1::G<>":
+  STRUCT:
+    - x: U64
+    - s:
+        TYPENAME: "00000000000000000000000000000001::M1::S<bool>"
+"00000000000000000000000000000001::M1::S<bool>":
+  STRUCT:
+    - t: BOOL
+AccountAddress:
+  NEWTYPESTRUCT:
+    TUPLEARRAY:
+      CONTENT: U8
+      SIZE: 16
+Signer:
+  NEWTYPESTRUCT:
+    TUPLEARRAY:
+      CONTENT: U8
+      SIZE: 16
+

--- a/language/tools/move-cli/tests/testsuite/generate_struct_layout/args.txt
+++ b/language/tools/move-cli/tests/testsuite/generate_struct_layout/args.txt
@@ -5,12 +5,20 @@ sandbox generate struct-layouts --module storage/0x00000000000000000000000000000
 sandbox generate struct-layouts --module storage/0x00000000000000000000000000000001/modules/M2.mv --struct C --type-args address
 sandbox generate struct-layouts --module storage/0x00000000000000000000000000000001/modules/M2.mv --struct C --type-args vector<u8>
 
-# across modules
+# across modules deep
 sandbox generate struct-layouts --module storage/0x00000000000000000000000000000001/modules/M1.mv --struct B --type-args bool
+# across modules shallow
+sandbox generate struct-layouts --module storage/0x00000000000000000000000000000001/modules/M1.mv --struct B --type-args bool --shallow
 
 # with fancy type parameters
 sandbox generate struct-layouts --module storage/0x00000000000000000000000000000001/modules/M1.mv --struct A --type-args 0x1::M1::S<u64>
 sandbox generate struct-layouts --module storage/0x00000000000000000000000000000001/modules/M1.mv --struct A --type-args vector<0x1::M1::S<u64>>
+# same thing, but shallow
+sandbox generate struct-layouts --module storage/0x00000000000000000000000000000001/modules/M1.mv --struct A --type-args 0x1::M1::S<u64> --shallow
+sandbox generate struct-layouts --module storage/0x00000000000000000000000000000001/modules/M1.mv --struct A --type-args vector<0x1::M1::S<u64>> --shallow
 
 # recursive type definition
 sandbox generate struct-layouts --module storage/0x00000000000000000000000000000001/modules/M2.mv --struct C --type-args 0x1::M2::C<u64>
+
+# without --type-args
+sandbox generate struct-layouts --module storage/0x00000000000000000000000000000001/modules/M1.mv --struct G

--- a/language/tools/move-cli/tests/testsuite/generate_struct_layout/sources/M1.move
+++ b/language/tools/move-cli/tests/testsuite/generate_struct_layout/sources/M1.move
@@ -6,4 +6,6 @@ module 0x1::M1 {
     struct B<T> { a: address, c: C<T>, t: T }
 
     struct S<T> { t: T }
+
+    struct G { x: u64, s: S<bool> }
 }


### PR DESCRIPTION
This PR resurrects an earlier [PR](https://github.com/diem/diem/pull/9424) by @sblackshear and at this point it mainly adapts the older implementation to the updated Move codebase with the same functionality. 

## Motivation

It's the same as before, that is for this change to be combined with serde-generate to codegen type definitions for Move structs in a variety of languages.

- Add logic for generating serde-friendly layout YAML for Move struct definitions. Only works for closed types (i.e., no unbound type parameters).
- The generation works in two modes: deep (recursively generate layout YAML for given struct and all its deps) or shallow (given struct only, leave deps as typenames).
- Exposed generation in both modes via CLI + added tests.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Additional tests verifying the new layout format have been added.