### PR TITLE
Allow to pass explicit `CostTable` for the custom native functions

### DIFF
--- a/language/move-vm/types/src/natives/function.rs
+++ b/language/move-vm/types/src/natives/function.rs
@@ -16,7 +16,7 @@
 //! This module contains the declarations and utilities to implement a native
 //! function.
 
-use crate::{gas_schedule::NativeCostIndex, values::Value};
+use crate::values::Value;
 use move_core_types::gas_schedule::{
     AbstractMemorySize, CostTable, GasAlgebra, GasCarrier, InternalGasUnits,
 };
@@ -108,10 +108,10 @@ impl NativeResult {
 /// The key is the specific native function index known to `CostTable`.
 pub fn native_gas(
     table: &CostTable,
-    key: NativeCostIndex,
+    native_table_idx: impl Into<u8>,
     size: usize,
 ) -> InternalGasUnits<GasCarrier> {
-    let gas_amt = table.native_cost(key as u8);
+    let gas_amt = table.native_cost(native_table_idx.into());
     let memory_size = AbstractMemorySize::new(std::cmp::max(1, size) as GasCarrier);
     debug_assert!(memory_size.get() > 0);
     gas_amt.total().mul(memory_size)

--- a/language/testing-infra/transactional-test-runner/src/vm_test_harness.rs
+++ b/language/testing-infra/transactional-test-runner/src/vm_test_harness.rs
@@ -266,7 +266,11 @@ impl<'a> SimpleVMTestAdapter<'a> {
         // start session
         let vm = MoveVM::new(move_stdlib::natives::all_natives(STD_ADDR)).unwrap();
         let (mut session, mut gas_status) = {
-            let gas_status = move_cli::sandbox::utils::get_gas_status(gas_budget).unwrap();
+            let gas_status = move_cli::sandbox::utils::get_gas_status(
+                &move_vm_types::gas_schedule::INITIAL_COST_SCHEDULE,
+                gas_budget,
+            )
+            .unwrap();
             let session = vm.new_session(&self.storage);
             (session, gas_status)
         };

--- a/language/tools/move-cli/src/lib.rs
+++ b/language/tools/move-cli/src/lib.rs
@@ -19,7 +19,8 @@ const BCS_EXTENSION: &str = "bcs";
 
 use anyhow::Result;
 use move_core_types::{
-    account_address::AccountAddress, errmap::ErrorMapping, identifier::Identifier,
+    account_address::AccountAddress, errmap::ErrorMapping, gas_schedule::CostTable,
+    identifier::Identifier,
 };
 use move_vm_runtime::native_functions::NativeFunction;
 use std::path::PathBuf;
@@ -98,14 +99,19 @@ pub enum Command {
 
 pub fn run_cli(
     natives: Vec<NativeFunctionRecord>,
+    cost_table: &CostTable,
     error_descriptions: &ErrorMapping,
     move_args: &Move,
     cmd: &Command,
 ) -> Result<()> {
     match cmd {
-        Command::Sandbox { storage_dir, cmd } => {
-            cmd.handle_command(natives, error_descriptions, move_args, storage_dir)
-        }
+        Command::Sandbox { storage_dir, cmd } => cmd.handle_command(
+            natives,
+            cost_table,
+            error_descriptions,
+            move_args,
+            storage_dir,
+        ),
         Command::Experimental { storage_dir, cmd } => cmd.handle_command(move_args, storage_dir),
         Command::Package { cmd } => package::cli::handle_package_commands(
             &move_args.package_path,
@@ -118,8 +124,15 @@ pub fn run_cli(
 
 pub fn move_cli(
     natives: Vec<NativeFunctionRecord>,
+    cost_table: &CostTable,
     error_descriptions: &ErrorMapping,
 ) -> Result<()> {
     let args = MoveCLI::from_args();
-    run_cli(natives, error_descriptions, &args.move_args, &args.cmd)
+    run_cli(
+        natives,
+        cost_table,
+        error_descriptions,
+        &args.move_args,
+        &args.cmd,
+    )
 }

--- a/language/tools/move-cli/src/main.rs
+++ b/language/tools/move-cli/src/main.rs
@@ -6,8 +6,10 @@ use move_core_types::{account_address::AccountAddress, errmap::ErrorMapping};
 
 fn main() -> Result<()> {
     let error_descriptions: ErrorMapping = bcs::from_bytes(move_stdlib::error_descriptions())?;
+    let cost_table = &move_vm_types::gas_schedule::INITIAL_COST_SCHEDULE;
     move_cli::move_cli(
         move_stdlib::natives::all_natives(AccountAddress::from_hex_literal("0x1").unwrap()),
+        cost_table,
         &error_descriptions,
     )
 }

--- a/language/tools/move-cli/src/sandbox/cli.rs
+++ b/language/tools/move-cli/src/sandbox/cli.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 use anyhow::Result;
 use move_core_types::{
-    errmap::ErrorMapping, language_storage::TypeTag, parser,
+    errmap::ErrorMapping, gas_schedule::CostTable, language_storage::TypeTag, parser,
     transaction_argument::TransactionArgument,
 };
 use move_package::compilation::package_layout::CompiledPackageLayout;
@@ -140,6 +140,7 @@ impl SandboxCommand {
     pub fn handle_command(
         &self,
         natives: Vec<NativeFunctionRecord>,
+        cost_table: &CostTable,
         error_descriptions: &ErrorMapping,
         move_args: &Move,
         storage_dir: &Path,
@@ -155,6 +156,7 @@ impl SandboxCommand {
                 let state = context.prepare_state(storage_dir)?;
                 sandbox::commands::publish(
                     natives,
+                    cost_table,
                     &state,
                     context.package(),
                     *no_republish,
@@ -177,6 +179,7 @@ impl SandboxCommand {
                 let state = context.prepare_state(storage_dir)?;
                 sandbox::commands::run(
                     natives,
+                    cost_table,
                     error_descriptions,
                     &state,
                     context.package(),

--- a/language/tools/move-cli/src/sandbox/commands/publish.rs
+++ b/language/tools/move-cli/src/sandbox/commands/publish.rs
@@ -9,12 +9,14 @@ use crate::{
     NativeFunctionRecord,
 };
 use anyhow::{bail, Result};
+use move_core_types::gas_schedule::CostTable;
 use move_package::compilation::compiled_package::CompiledPackage;
 use move_vm_runtime::move_vm::MoveVM;
 use std::collections::BTreeMap;
 
 pub fn publish(
     natives: impl IntoIterator<Item = NativeFunctionRecord>,
+    cost_table: &CostTable,
     state: &OnDiskStateView,
     package: &CompiledPackage,
     no_republish: bool,
@@ -52,7 +54,7 @@ pub fn publish(
     // use the the publish_module API from the VM if we do not allow breaking changes
     if !ignore_breaking_changes {
         let vm = MoveVM::new(natives).unwrap();
-        let mut gas_status = get_gas_status(None)?;
+        let mut gas_status = get_gas_status(cost_table, None)?;
         let mut session = vm.new_session(state);
 
         let mut has_error = false;

--- a/language/tools/move-cli/src/sandbox/commands/run.rs
+++ b/language/tools/move-cli/src/sandbox/commands/run.rs
@@ -13,6 +13,7 @@ use move_binary_format::file_format::CompiledModule;
 use move_core_types::{
     account_address::AccountAddress,
     errmap::ErrorMapping,
+    gas_schedule::CostTable,
     identifier::IdentStr,
     language_storage::TypeTag,
     transaction_argument::{convert_txn_args, TransactionArgument},
@@ -23,6 +24,7 @@ use std::{fs, path::Path};
 
 pub fn run(
     natives: impl IntoIterator<Item = NativeFunctionRecord>,
+    cost_table: &CostTable,
     error_descriptions: &ErrorMapping,
     state: &OnDiskStateView,
     package: &CompiledPackage,
@@ -68,7 +70,7 @@ move run` must be applied to a module inside `storage/`",
     let vm_args: Vec<Vec<u8>> = convert_txn_args(txn_args);
 
     let vm = MoveVM::new(natives).unwrap();
-    let mut gas_status = get_gas_status(gas_budget)?;
+    let mut gas_status = get_gas_status(cost_table, gas_budget)?;
     let mut session = vm.new_session(state);
 
     let script_type_parameters = vec![];

--- a/language/tools/move-unit-test/src/test_runner.rs
+++ b/language/tools/move-unit-test/src/test_runner.rs
@@ -58,8 +58,8 @@ pub struct TestRunner {
 
 /// A gas schedule where every instruction has a cost of "1". This is used to bound execution of a
 /// test to a certain number of ticks.
-fn unit_cost_table() -> CostTable {
-    let mut cost_schedule = zero_cost_schedule();
+fn unit_cost_table(num_of_native_funcs: usize) -> CostTable {
+    let mut cost_schedule = zero_cost_schedule(num_of_native_funcs);
     cost_schedule.instruction_table.iter_mut().for_each(|cost| {
         *cost = GasCost::new(1, 1);
     });
@@ -132,13 +132,14 @@ impl TestRunner {
         let native_function_table = native_function_table.unwrap_or_else(|| {
             move_stdlib::natives::all_natives(AccountAddress::from_hex_literal("0x1").unwrap())
         });
+        let num_of_native_funcs = native_function_table.len();
         Ok(Self {
             testing_config: SharedTestingConfig {
                 save_storage_state_on_failure,
                 starting_storage_state,
                 execution_bound,
                 native_function_table,
-                cost_table: unit_cost_table(),
+                cost_table: unit_cost_table(num_of_native_funcs),
                 source_files,
                 check_stackless_vm,
                 verbose,


### PR DESCRIPTION
## Motivation

Allows external users of Move language to extend the set of native functions without forking the repo. 

This implementation is not ideal as one would have to copy `NativeCostIndex` and remember to start with `18` in the enum values. It would be better to make an extensible `NativeCostIndex` enum somehow or replace it, but I've decided it's too big of a change for a first contribution. I can follow up with that later. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes