### PR TITLE
bug fix when executing command 'move sandbox run'

### DIFF
--- a/language/tools/move-cli/src/sandbox/commands/run.rs
+++ b/language/tools/move-cli/src/sandbox/commands/run.rs
@@ -52,9 +52,10 @@ move run` must be applied to a module inside `storage/`",
         fs::read(script_path)?
     } else {
         // TODO(tzakian): support calling scripts in transitive deps
+        let file_contents = std::fs::read_to_string(script_path)?;
         let script_opt = package
             .scripts()
-            .find(|unit| unit.source_path.file_stem() == script_path.file_stem());
+            .find(|unit| unit.unit.source_map().check(&file_contents));
         // script source file; package is already compiled so load it up
         match script_opt {
             Some(unit) => unit.unit.serialize(),


### PR DESCRIPTION
fix the logical bug when executing command 'move sandbox run'

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Sometimes when executing command 'move sandbox run' in a package, it will prompt the error message such as "Unable to find script in file xxxx"
When digging more deeper of the codes, It seems like the logic in the current implementation of the command  'move sandbox run'  is not correct all the time, it just compares the filename between the compiled packages and the user inputted script name, but move-compiler has done some renaming when compiling the source codes. It would be better to compare the FileHash other than the file name to determine the correct compiled script to execute 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/diem/diem/tree/main/developers.diem.com, and link to your PR here.)

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
