### PR TITLE
ERC20 and ERC1155 implementations with Table

### DIFF
--- a/language/evm/examples/sources/ERC1155.move
+++ b/language/evm/examples/sources/ERC1155.move
@@ -1,0 +1,181 @@
+#[contract]
+/// Another implementation of ERC20 using Table.
+module Evm::ERC1155 {
+    use Evm::Evm::{sender, self, sign, emit};
+    use Evm::Table::{Self, Table};
+    use Std::ASCII::{String};
+    use Std::Errors;
+    use Std::Vector;
+
+    #[event]
+    struct TransferSingle {
+        operator: address,
+        from: address,
+        to: address,
+        id: u128,
+        value: u128,
+    }
+
+    #[event]
+    struct TransferBatch {
+        operator: address,
+        from: address,
+        to: address,
+        ids: vector<u128>,
+        values: vector<u128>,
+    }
+
+    #[event]
+    struct ApprovalForAll {
+        owner: address,
+        operator: address,
+        approved: bool,
+    }
+
+    #[event]
+    struct URI {
+        value: String,
+        id: u128,
+    }
+
+    #[storage]
+    /// Represents the state of this contract. This is located at `borrow_global<State>(self())`.
+    struct State has key {
+        balances: Table<u128, Table<address, u128>>,
+        operatorApprovals: Table<address, Table<address, bool>>,
+        uri: String,
+    }
+
+    #[create]
+    /// Constructor of this contract.
+    public fun create(uri: String) {
+        // Initial state of contract
+        move_to<State>(
+            sign(self()),
+            State {
+                balances: Table::empty<u128, Table<address, u128>>(),
+                operatorApprovals: Table::empty<address, Table<address, bool>>(),
+                uri,
+            }
+        );
+    }
+
+    #[callable, view]
+    /// Returns the name of the token
+    public fun uri(): String acquires State {
+        *&borrow_global<State>(self()).uri
+    }
+
+    #[callable, view]
+    /// Get the balance of an account's token.
+    public fun balanceOf(account: address, id: u128): u128 acquires State {
+        let s = borrow_global_mut<State>(self());
+        *mut_balanceOf(s, id, account)
+    }
+
+    #[callable, view]
+    /// Get the balance of multiple account/token pairs.
+    public fun balanceOfBatch(accounts: vector<address>, ids: vector<u128>): vector<u128> acquires State {
+        assert!(Vector::length(&accounts) == Vector::length(&ids), Errors::invalid_argument(0));
+        let len = Vector::length(&accounts);
+        let i = 0;
+        let balances = Vector::empty<u128>();
+        while(i < len) {
+            Vector::push_back(
+                &mut balances,
+                balanceOf(
+                    *Vector::borrow(&accounts, i),
+                    *Vector::borrow(&ids, i)
+                )
+            );
+            i = i + 1;
+        };
+        balances
+    }
+
+    #[callable, view]
+    /// Enable or disable approval for a third party ("operator") to manage all of the caller's tokens.
+    public fun setApprovalForAll(operator: address, approved: bool) acquires State {
+        let s = borrow_global_mut<State>(self());
+        let operatorApproval = mut_operatorApprovals(s, sender(), operator);
+        *operatorApproval = approved;
+        emit(ApprovalForAll{owner: sender(), operator, approved});
+    }
+
+    #[callable, view]
+    /// Queries the approval status of an operator for a given owner.
+    public fun isApprovalForAll(account: address, operator: address): bool acquires State {
+        let s = borrow_global_mut<State>(self());
+        *mut_operatorApprovals(s, account, operator)
+    }
+
+    #[callable]
+    /// Transfers `_value` amount of an `_id` from the `_from` address to the `_to` address specified (with safety call).
+    public fun safeTransferFrom(from: address, to: address, id: u128, amount: u128, _data: vector<u8>) acquires State {
+        assert!(from == sender() || isApprovalForAll(from, sender()), Errors::invalid_argument(0));
+        let operator = sender();
+        let s = borrow_global_mut<State>(self());
+        let mut_balance_from = mut_balanceOf(s, id, from);
+        assert!(*mut_balance_from >= amount, Errors::invalid_argument(0));
+        *mut_balance_from = *mut_balance_from - amount;
+        let mut_balance_to = mut_balanceOf(s, id, to);
+        *mut_balance_to = *mut_balance_to + amount;
+        emit(TransferSingle{operator, from, to, id, value: amount});
+    }
+
+    #[callable]
+    /// Transfers `_value` amount of an `_id` from the `_from` address to the `_to` address specified (with safety call).
+    public fun safeBatchTransferFrom(from: address, to: address, ids: vector<u128>, amounts: vector<u128>, _data: vector<u8>) acquires State {
+        assert!(from == sender() || isApprovalForAll(from, sender()), Errors::invalid_argument(0));
+        assert!(Vector::length(&amounts) == Vector::length(&ids), Errors::invalid_argument(0));
+        let len = Vector::length(&amounts);
+        let i = 0;
+
+        let operator = sender();
+        let s = borrow_global_mut<State>(self());
+
+        while(i < len) {
+            let id = *Vector::borrow(&ids, i);
+            let amount = *Vector::borrow(&amounts, i);
+
+            let mut_balance_from = mut_balanceOf(s, id, from);
+            assert!(*mut_balance_from >= amount, Errors::invalid_argument(0));
+            *mut_balance_from = *mut_balance_from - amount;
+            let mut_balance_to = mut_balanceOf(s, id, to);
+            *mut_balance_to = *mut_balance_to + amount;
+
+            i = i + 1;
+        };
+
+        emit(TransferBatch{operator, from, to, ids, values: amounts});
+    }
+
+    /// Helper function to return a mut ref to the operatorApproval
+    fun mut_operatorApprovals(s: &mut State, account: address, operator: address): &mut bool {
+        if(!Table::contains(&s.operatorApprovals, &account)) {
+            Table::insert(
+                &mut s.operatorApprovals,
+                account,
+                Table::empty<address, bool>()
+            )
+        };
+        let operatorApproval_account = Table::borrow_mut(
+            &mut s.operatorApprovals,
+            &account
+        );
+        Table::borrow_mut_with_default(operatorApproval_account, operator, false)
+    }
+
+    /// Helper function to return a mut ref to the balance of a owner.
+    fun mut_balanceOf(s: &mut State, id: u128, account: address): &mut u128 {
+        if(!Table::contains(&s.balances, &id)) {
+            Table::insert(
+                &mut s.balances,
+                id,
+                Table::empty<address, u128>()
+            )
+        };
+        let balances_id = Table::borrow_mut(&mut s.balances, &id);
+        Table::borrow_mut_with_default(balances_id, account, 0)
+    }
+}

--- a/language/evm/examples/sources/ERC20.move
+++ b/language/evm/examples/sources/ERC20.move
@@ -1,0 +1,145 @@
+#[contract]
+/// Another implementation of ERC20 using Table.
+module Evm::ERC20_ALT {
+    use Evm::Evm::{sender, self, sign, emit};
+    use Evm::Table::{Self, Table};
+    use Std::ASCII::{String};
+    use Std::Errors;
+
+    #[event]
+    struct Transfer {
+        from: address,
+        to: address,
+        value: u128,
+    }
+
+    #[event]
+    struct Approval {
+        owner: address,
+        spender: address,
+        value: u128,
+    }
+
+    #[storage]
+    /// Represents the state of this contract. This is located at `borrow_global<State>(self())`.
+    struct State has key {
+        balances: Table<address, u128>,
+        allowances: Table<address, Table<address, u128>>,
+        total_supply: u128,
+        name: String,
+        symbol: String,
+    }
+
+    #[create]
+    /// Constructor of this contract.
+    public fun create(name: String, symbol: String) {
+        // Initial state of contract
+        move_to<State>(
+            sign(self()),
+            State {
+                total_supply: 0,
+                balances: Table::empty<address, u128>(),
+                allowances: Table::empty<address, Table<address, u128>>(),
+                name,
+                symbol,
+            }
+        );
+    }
+
+    #[callable, view]
+    /// Returns the name of the token
+    public fun name(): String acquires State {
+        *&borrow_global<State>(self()).name
+    }
+
+    #[callable, view]
+    /// Returns the symbol of the token, usually a shorter version of the name.
+    public fun symbol(): String acquires State {
+        *&borrow_global<State>(self()).symbol
+    }
+
+    #[callable, view]
+    /// Returns the number of decimals used to get its user representation.
+    public fun decimals(): u8 {
+        18
+    }
+
+    #[callable, view]
+    /// Returns the total supply of the token.
+    public fun totalSupply(): u128 acquires State {
+        borrow_global<State>(self()).total_supply
+    }
+
+    #[callable, view]
+    /// Returns the balance of an account.
+    public fun balanceOf(owner: address): u128 acquires State {
+        let s = borrow_global_mut<State>(self());
+        *mut_balanceOf(s, owner)
+    }
+
+    #[callable]
+    /// Transfers the amount from the sending account to the given account
+    public fun transfer(to: address, amount: u128): bool acquires State {
+        assert!(sender() != to, Errors::invalid_argument(0));
+        do_transfer(sender(), to, amount);
+        true
+    }
+
+    #[callable]
+    /// Transfers the amount on behalf of the `from` account to the given account.
+    /// This evaluates and adjusts the allowance.
+    public fun transferFrom(from: address, to: address, amount: u128): bool acquires State {
+        assert!(sender() != to, Errors::invalid_argument(0));
+        let s = borrow_global_mut<State>(self());
+        let allowance_for_sender = mut_allowance(s, from, sender());
+        assert!(*allowance_for_sender >= amount, Errors::limit_exceeded(0));
+        *allowance_for_sender = *allowance_for_sender - amount;
+        do_transfer(from, to, amount);
+        true
+    }
+
+    #[callable]
+    /// Approves that the spender can spent the given amount on behalf of the calling account.
+    public fun approve(spender: address, amount: u128): bool acquires State {
+        let s = borrow_global_mut<State>(self());
+        if(!Table::contains(&s.allowances, &sender())) {
+            Table::insert(&mut s.allowances, sender(), Table::empty<address, u128>())
+        };
+        let a = Table::borrow_mut(&mut s.allowances, &sender());
+        Table::insert(a, spender, amount);
+        emit(Approval{owner: sender(), spender, value: amount});
+        true
+    }
+
+    #[callable, view]
+    /// Returns the allowance an account owner has approved for the given spender.
+    public fun allowance(owner: address, spender: address): u128 acquires State {
+        let s = borrow_global_mut<State>(self());
+        *mut_allowance(s, owner, spender)
+    }
+
+    /// Helper function to perform a transfer of funds.
+    fun do_transfer(from: address, to: address, amount: u128) acquires State {
+        let s = borrow_global_mut<State>(self());
+        let from_bal = mut_balanceOf(s, from);
+        assert!(*from_bal >= amount, Errors::limit_exceeded(0));
+        *from_bal = *from_bal - amount;
+        let to_bal = mut_balanceOf(s, to);
+        *to_bal = *to_bal + amount;
+        emit(Transfer{from, to, value: amount});
+    }
+
+    /// Helper function to return a mut ref to the allowance of a spender.
+    fun mut_allowance(s: &mut State, owner: address, spender: address): &mut u128 {
+        if(!Table::contains(&s.allowances, &owner)) {
+            Table::insert(&mut s.allowances, owner, Table::empty<address, u128>())
+        };
+        let allowance_owner = Table::borrow_mut(&mut s.allowances, &owner);
+        Table::borrow_mut_with_default(allowance_owner, spender, 0)
+    }
+
+    /// Helper function to return a mut ref to the balance of a owner.
+    fun mut_balanceOf(s: &mut State, owner: address): &mut u128 {
+        Table::borrow_mut_with_default(&mut s.balances, owner, 0)
+    }
+}

--- a/language/evm/examples/sources/Table.move
+++ b/language/evm/examples/sources/Table.move
@@ -1,0 +1,35 @@
+/// This module defines Table for EVM.
+module Evm::Table {
+    native struct Table<K, V> has store;
+
+    /// Create an empty Table.
+    native public fun empty<K, V>(): Table<K, V>;
+
+    /// Acquire an immutable reference to the value which `key` maps to.
+    /// Aborts if there is no entry for `key`.
+    native public fun borrow<K, V>(table: &Table<K, V>, key: &K): &V;
+
+    /// Acquire a mutable reference to the value which `key` maps to.
+    /// Aborts if there is no entry for `key`.
+    native public fun borrow_mut<K, V>(table: &mut Table<K, V>, key: &K): &mut V;
+
+    /// Acquire a mutable reference to the value which `key` maps to.
+    /// Insert the pair (`key`, `default`) first if there is no entry for `key`.
+    public fun borrow_mut_with_default<K: copy + drop, V: drop>(table: &mut Table<K, V>, key: K, default: V): &mut V {
+        if (!contains(table, &key)) {
+            insert(table, copy key, default)
+        };
+        borrow_mut(table, &key)
+    }
+
+    /// Remove from `table` and return the value which `key` maps to.
+    /// Aborts if there is no entry for `key`.
+    native public fun remove<K, V>(table: &mut Table<K, V>, key: &K): (K, V);
+
+    /// Returns true iff `table` contains an entry for `key`.
+    native public fun contains<K, V>(table: &Table<K, V>, key: &K): bool;
+
+    /// Insert the pair (`key`, `val`) to `table`.
+    /// Aborts if there is already an entry for `key`.
+    native public fun insert<K, V>(table: &mut Table<K, V>, key: K, val: V);
+}

--- a/language/evm/examples/sources/Token.move
+++ b/language/evm/examples/sources/Token.move
@@ -36,7 +36,7 @@ module Evm::ERC20 {
         move_to<State>(sign(self()), State{decimals, total_supply: initial_amount});
 
         // Initialize senders balance with initial amount
-        move_to<Account>(sign(sender()), Account{value: initial_amount, allowances: vector[]});
+        move_to<Account>(sign(sender()), Account{value: initial_amount, allowances: Vector::empty()});
     }
 
     #[callable, view]
@@ -127,7 +127,7 @@ module Evm::ERC20 {
     /// Helper function to create an account with a zero balance and no allowances.
     fun create_account_if_not_present(owner: address) {
         if (!exists<Account>(owner)) {
-            move_to<Account>(sign(owner), Account{value: 0, allowances: vector[]})
+            move_to<Account>(sign(owner), Account{value: 0, allowances: Vector::empty()})
         }
     }
 


### PR DESCRIPTION
This PR adds the Table module and ERC20 and ERC1155 implementations using Table.

Most of the functions in the Table module are declared to be native. They may be compiled into the Solidity-like maps by the Move-to-EVM compiler. Moreover, although it is slow, it's possible to run them on MoveVM today because they can be easily implemented using vector in Move. It can become faster in the future once Move supports an efficient map type.

As for the ERC20 contract, the differences from the original implementation (Token.move) are as follows:
- Table is used
- All data structures go to the single struct called `State` (which correspond to the contract state in Solidity)
  - State is published when the contract is deployed and the constructor is called.
  - signers are not required for adding entries to the tables
- In order to make the names compatible, the camel case is used instead of the snake case.
- events are emitted accordingly.

## Motivation

To add the Table module, and to rewrite the ERC20 contract using Table

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

cargo test