### PR TITLE
Fix typo in AST printing for shift right

### DIFF
--- a/language/move-prover/bytecode/src/stackless_bytecode.rs
+++ b/language/move-prover/bytecode/src/stackless_bytecode.rs
@@ -1033,7 +1033,7 @@ impl<'env> fmt::Display for OperationDisplay<'env> {
             BitAnd => write!(f, "&")?,
             Xor => write!(f, "^")?,
             Shl => write!(f, "<<")?,
-            Shr => write!(f, "<<")?,
+            Shr => write!(f, ">>")?,
             Lt => write!(f, "<")?,
             Gt => write!(f, ">")?,
             Le => write!(f, "<=")?,


### PR DESCRIPTION
## Motivation

Fixing AST printing for shift right operation to print ">>" instead of "<<".

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes
