### PR TITLE
[utils] add logic for serializing Move value with both type and field…

### DIFF
--- a/language/move-binary-format/src/normalized.rs
+++ b/language/move-binary-format/src/normalized.rs
@@ -265,7 +265,7 @@ impl Struct {
     pub fn new(m: &CompiledModule, def: &StructDefinition) -> (Identifier, Self) {
         let handle = m.struct_handle_at(def.struct_handle);
         let fields = match &def.field_information {
-            StructFieldInformation::Native => panic!("Can't extract  for native struct"),
+            StructFieldInformation::Native => panic!("Can't extract for native struct"),
             StructFieldInformation::Declared(fields) => {
                 fields.iter().map(|f| Field::new(m, f)).collect()
             }

--- a/language/move-core/types/src/language_storage.rs
+++ b/language/move-core/types/src/language_storage.rs
@@ -18,13 +18,21 @@ pub const CORE_CODE_ADDRESS: AccountAddress = AccountAddress::ONE;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Hash, Eq, Clone, PartialOrd, Ord)]
 pub enum TypeTag {
+    #[serde(rename = "bool")]
     Bool,
+    #[serde(rename = "u8")]
     U8,
+    #[serde(rename = "u64")]
     U64,
+    #[serde(rename = "u128")]
     U128,
+    #[serde(rename = "address")]
     Address,
+    #[serde(rename = "signer")]
     Signer,
+    #[serde(rename = "vector")]
     Vector(Box<TypeTag>),
+    #[serde(rename = "struct")]
     Struct(StructTag),
 }
 
@@ -34,6 +42,7 @@ pub struct StructTag {
     pub module: Identifier,
     pub name: Identifier,
     // TODO: rename to "type_args" (or better "ty_args"?)
+    #[serde(rename = "type_args")]
     pub type_params: Vec<TypeTag>,
 }
 

--- a/language/move-core/types/src/unit_tests/mod.rs
+++ b/language/move-core/types/src/unit_tests/mod.rs
@@ -3,3 +3,4 @@
 
 mod identifier_test;
 mod language_storage_test;
+mod value_test;

--- a/language/move-core/types/src/unit_tests/value_test.rs
+++ b/language/move-core/types/src/unit_tests/value_test.rs
@@ -1,0 +1,103 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    account_address::AccountAddress,
+    ident_str,
+    identifier::Identifier,
+    language_storage::{StructTag, TypeTag},
+    value::{MoveStruct, MoveValue},
+};
+use serde_json::json;
+
+#[test]
+fn struct_deserialization() {
+    let struct_type = StructTag {
+        address: AccountAddress::ZERO,
+        name: ident_str!("MyStruct").to_owned(),
+        module: ident_str!("MyModule").to_owned(),
+        type_params: vec![],
+    };
+    let values = vec![MoveValue::U64(7), MoveValue::Bool(true)];
+    let fields = vec![ident_str!("f").to_owned(), ident_str!("g").to_owned()];
+    let field_values: Vec<(Identifier, MoveValue)> =
+        fields.into_iter().zip(values.clone()).collect();
+
+    // test each deserialization scheme
+    let runtime_value = MoveStruct::Runtime(values);
+    assert_eq!(
+        serde_json::to_value(&runtime_value).unwrap(),
+        json!([7, true])
+    );
+
+    let fielded_value = MoveStruct::WithFields(field_values.clone());
+    assert_eq!(
+        serde_json::to_value(&fielded_value).unwrap(),
+        json!({ "f": 7, "g": true })
+    );
+
+    let typed_value = MoveStruct::with_types(struct_type, field_values);
+    assert_eq!(
+        serde_json::to_value(&typed_value).unwrap(),
+        json!({
+                "fields": { "f": 7, "g": true },
+                "type": "0x0::MyModule::MyStruct"
+            }
+        )
+    );
+}
+
+#[test]
+fn nested_typed_struct_deserialization() {
+    let struct_type = StructTag {
+        address: AccountAddress::ZERO,
+        name: ident_str!("MyStruct").to_owned(),
+        module: ident_str!("MyModule").to_owned(),
+        type_params: vec![],
+    };
+    let nested_struct_type = StructTag {
+        address: AccountAddress::ZERO,
+        name: ident_str!("NestedStruct").to_owned(),
+        module: ident_str!("NestedModule").to_owned(),
+        type_params: vec![TypeTag::U8],
+    };
+
+    // test each deserialization scheme
+    let nested_runtime_struct = MoveValue::Struct(MoveStruct::Runtime(vec![MoveValue::U64(7)]));
+    let runtime_value = MoveStruct::Runtime(vec![nested_runtime_struct]);
+    assert_eq!(serde_json::to_value(&runtime_value).unwrap(), json!([[7]]));
+
+    let nested_fielded_struct = MoveValue::Struct(MoveStruct::with_fields(vec![(
+        ident_str!("f").to_owned(),
+        MoveValue::U64(7),
+    )]));
+    let fielded_value = MoveStruct::with_fields(vec![(
+        ident_str!("inner").to_owned(),
+        nested_fielded_struct,
+    )]);
+    assert_eq!(
+        serde_json::to_value(&fielded_value).unwrap(),
+        json!({ "inner": { "f": 7 } })
+    );
+
+    let nested_typed_struct = MoveValue::Struct(MoveStruct::with_types(
+        nested_struct_type,
+        vec![(ident_str!("f").to_owned(), MoveValue::U64(7))],
+    ));
+    let typed_value = MoveStruct::with_types(
+        struct_type,
+        vec![(ident_str!("inner").to_owned(), nested_typed_struct)],
+    );
+    assert_eq!(
+        serde_json::to_value(&typed_value).unwrap(),
+        json!({
+            "fields": {
+                "inner": {
+                    "fields": { "f": 7},
+                    "type": "0x0::NestedModule::NestedStruct<u8>",
+                }
+            },
+            "type": "0x0::MyModule::MyStruct"
+        })
+    );
+}

--- a/language/move-core/types/src/value.rs
+++ b/language/move-core/types/src/value.rs
@@ -1,21 +1,42 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{account_address::AccountAddress, identifier::Identifier};
-use anyhow::Result as AResult;
+use crate::{
+    account_address::AccountAddress,
+    identifier::Identifier,
+    language_storage::{StructTag, TypeTag},
+};
+use anyhow::{bail, Result as AResult};
 use serde::{
     de::Error as DeError,
-    ser::{SerializeMap, SerializeSeq, SerializeTuple},
+    ser::{SerializeMap, SerializeSeq, SerializeStruct, SerializeTuple},
     Deserialize, Serialize,
 };
-use std::fmt::{self, Debug};
+use std::{
+    convert::TryInto,
+    fmt::{self, Debug},
+};
+
+/// In the `WithTypes` configuration, a Move struct gets serialized into a Serde struct with this name
+pub const MOVE_STRUCT_NAME: &str = "struct";
+
+/// In the `WithTypes` configuration, a Move struct gets serialized into a Serde struct with this as the first field
+pub const MOVE_STRUCT_TYPE: &str = "type";
+
+/// In the `WithTypes` configuration, a Move struct gets serialized into a Serde struct with this as the second field
+pub const MOVE_STRUCT_FIELDS: &str = "fields";
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum MoveStruct {
     /// The representation used by the MoveVM
     Runtime(Vec<MoveValue>),
-    /// A decorated representation with human-readable field names that can be used by clients
+    /// A decorated representation with human-readable field names
     WithFields(Vec<(Identifier, MoveValue)>),
+    /// An even more decorated representation with both types and human-readable field names
+    WithTypes {
+        type_: StructTag,
+        fields: Vec<(Identifier, MoveValue)>,
+    },
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -49,17 +70,30 @@ pub enum MoveStructLayout {
     Runtime(Vec<MoveTypeLayout>),
     /// A decorated representation with human-readable field names that can be used by clients
     WithFields(Vec<MoveFieldLayout>),
+    /// An even more decorated representation with both types and human-readable field names
+    WithTypes {
+        type_: StructTag,
+        fields: Vec<MoveFieldLayout>,
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum MoveTypeLayout {
+    #[serde(rename = "bool")]
     Bool,
+    #[serde(rename = "u8")]
     U8,
+    #[serde(rename = "u64")]
     U64,
+    #[serde(rename = "u128")]
     U128,
+    #[serde(rename = "address")]
     Address,
+    #[serde(rename = "vector")]
     Vector(Box<MoveTypeLayout>),
+    #[serde(rename = "struct")]
     Struct(MoveStructLayout),
+    #[serde(rename = "signer")]
     Signer,
 }
 
@@ -78,6 +112,16 @@ impl MoveValue {
 
     pub fn vector_address(v: Vec<AccountAddress>) -> Self {
         MoveValue::Vector(v.into_iter().map(MoveValue::Address).collect())
+    }
+
+    pub fn decorate(self, layout: &MoveTypeLayout) -> Self {
+        match (self, layout) {
+            (MoveValue::Struct(s), MoveTypeLayout::Struct(l)) => MoveValue::Struct(s.decorate(l)),
+            (MoveValue::Vector(vals), MoveTypeLayout::Vector(t)) => {
+                MoveValue::Vector(vals.into_iter().map(|v| v.decorate(t)).collect())
+            }
+            (v, _) => v,
+        }
     }
 }
 
@@ -102,15 +146,53 @@ impl MoveStruct {
         Self::WithFields(values)
     }
 
+    pub fn with_types(type_: StructTag, fields: Vec<(Identifier, MoveValue)>) -> Self {
+        Self::WithTypes { type_, fields }
+    }
+
     pub fn simple_deserialize(blob: &[u8], ty: &MoveStructLayout) -> AResult<Self> {
         Ok(bcs::from_bytes_seed(ty, blob)?)
+    }
+
+    pub fn decorate(self, layout: &MoveStructLayout) -> Self {
+        match (self, layout) {
+            (MoveStruct::Runtime(vals), MoveStructLayout::WithFields(layouts)) => {
+                MoveStruct::WithFields(
+                    vals.into_iter()
+                        .zip(layouts)
+                        .map(|(v, l)| (l.name.clone(), v.decorate(&l.layout)))
+                        .collect(),
+                )
+            }
+            (MoveStruct::Runtime(vals), MoveStructLayout::WithTypes { type_, fields }) => {
+                MoveStruct::WithTypes {
+                    type_: type_.clone(),
+                    fields: vals
+                        .into_iter()
+                        .zip(fields)
+                        .map(|(v, l)| (l.name.clone(), v.decorate(&l.layout)))
+                        .collect(),
+                }
+            }
+            (MoveStruct::WithFields(vals), MoveStructLayout::WithTypes { type_, fields }) => {
+                MoveStruct::WithTypes {
+                    type_: type_.clone(),
+                    fields: vals
+                        .into_iter()
+                        .zip(fields)
+                        .map(|((fld, v), l)| (fld, v.decorate(&l.layout)))
+                        .collect(),
+                }
+            }
+            (v, _) => v, // already decorated
+        }
     }
 
     pub fn fields(&self) -> &[MoveValue] {
         match self {
             Self::Runtime(vals) => vals,
-            Self::WithFields(_) => {
-                // It's not possible to implement this without changing the return type, and some
+            Self::WithFields(_) | Self::WithTypes { .. } => {
+                // It's not possible to implement this without changing the return type, and thus
                 // panicking is the best move
                 panic!("Getting fields for decorated representation")
             }
@@ -120,7 +202,9 @@ impl MoveStruct {
     pub fn into_fields(self) -> Vec<MoveValue> {
         match self {
             Self::Runtime(vals) => vals,
-            Self::WithFields(vals) => vals.into_iter().map(|(_, f)| f).collect(),
+            Self::WithFields(fields) | Self::WithTypes { fields, .. } => {
+                fields.into_iter().map(|(_, f)| f).collect()
+            }
         }
     }
 }
@@ -134,10 +218,14 @@ impl MoveStructLayout {
         Self::WithFields(types)
     }
 
+    pub fn with_types(type_: StructTag, fields: Vec<MoveFieldLayout>) -> Self {
+        Self::WithTypes { type_, fields }
+    }
+
     pub fn fields(&self) -> &[MoveTypeLayout] {
         match self {
             Self::Runtime(vals) => vals,
-            Self::WithFields(_) => {
+            Self::WithFields(_) | Self::WithTypes { .. } => {
                 // It's not possible to implement this without changing the return type, and some
                 // performance-critical VM serialization code uses the Runtime case of this.
                 // panicking is the best move
@@ -149,7 +237,9 @@ impl MoveStructLayout {
     pub fn into_fields(self) -> Vec<MoveTypeLayout> {
         match self {
             Self::Runtime(vals) => vals,
-            Self::WithFields(vals) => vals.into_iter().map(|f| f.layout).collect(),
+            Self::WithFields(fields) | Self::WithTypes { fields, .. } => {
+                fields.into_iter().map(|f| f.layout).collect()
+            }
         }
     }
 }
@@ -277,6 +367,17 @@ impl<'d> serde::de::DeserializeSeed<'d> for &MoveStructLayout {
                     .deserialize_tuple(layout.len(), DecoratedStructFieldVisitor(layout))?;
                 Ok(MoveStruct::WithFields(fields))
             }
+            MoveStructLayout::WithTypes {
+                type_,
+                fields: layout,
+            } => {
+                let fields = deserializer
+                    .deserialize_tuple(layout.len(), DecoratedStructFieldVisitor(layout))?;
+                Ok(MoveStruct::WithTypes {
+                    type_: type_.clone(),
+                    fields,
+                })
+            }
         }
     }
 }
@@ -301,6 +402,19 @@ impl serde::Serialize for MoveValue {
         }
     }
 }
+
+struct MoveFields<'a>(&'a [(Identifier, MoveValue)]);
+
+impl<'a> serde::Serialize for MoveFields<'a> {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut t = serializer.serialize_map(Some(self.0.len()))?;
+        for (f, v) in self.0.iter() {
+            t.serialize_entry(f, v)?;
+        }
+        t.end()
+    }
+}
+
 impl serde::Serialize for MoveStruct {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         match self {
@@ -311,11 +425,17 @@ impl serde::Serialize for MoveStruct {
                 }
                 t.end()
             }
-            Self::WithFields(s) => {
-                let mut t = serializer.serialize_map(Some(s.len()))?;
-                for (f, v) in s.iter() {
-                    t.serialize_entry(f, v)?;
-                }
+            Self::WithFields(fields) => MoveFields(fields).serialize(serializer),
+            Self::WithTypes { type_, fields } => {
+                // Serialize a Move struct as Serde struct type named `struct `with two fields named `type` and `fields`.
+                // `fields` will get serialized as a Serde map.
+                // Unfortunately, we can't serialize this in the logical way: as a Serde struct named `type` with a field for
+                // each of `fields` because serde insists that struct and field names be `'static &str`'s
+                let mut t = serializer.serialize_struct(MOVE_STRUCT_NAME, 2)?;
+                // serialize type as string (e.g., 0x0::ModuleName::StructName<TypeArg1,TypeArg2>) instead of (e.g.
+                // { address: 0x0...0, module: ModuleName, name: StructName, type_args: [TypeArg1, TypeArg2]})
+                t.serialize_field(MOVE_STRUCT_TYPE, &type_.to_string())?;
+                t.serialize_field(MOVE_STRUCT_FIELDS, &MoveFields(fields))?;
                 t.end()
             }
         }
@@ -358,7 +478,48 @@ impl fmt::Display for MoveStructLayout {
                     write!(f, "{}, ", layout)?
                 }
             }
+            Self::WithTypes { type_, fields } => {
+                write!(f, "Type: {}", type_)?;
+                write!(f, "Fields:")?;
+                for field in fields {
+                    write!(f, "{}, ", field)?
+                }
+            }
         }
         write!(f, "}}")
+    }
+}
+
+impl TryInto<TypeTag> for &MoveTypeLayout {
+    type Error = anyhow::Error;
+
+    fn try_into(self) -> Result<TypeTag, Self::Error> {
+        Ok(match self {
+            MoveTypeLayout::Address => TypeTag::Address,
+            MoveTypeLayout::Bool => TypeTag::Bool,
+            MoveTypeLayout::U8 => TypeTag::U8,
+            MoveTypeLayout::U64 => TypeTag::U64,
+            MoveTypeLayout::U128 => TypeTag::U128,
+            MoveTypeLayout::Signer => TypeTag::Signer,
+            MoveTypeLayout::Vector(v) => {
+                let inner_type = &**v;
+                TypeTag::Vector(Box::new(inner_type.try_into()?))
+            }
+            MoveTypeLayout::Struct(v) => TypeTag::Struct(v.try_into()?),
+        })
+    }
+}
+
+impl TryInto<StructTag> for &MoveStructLayout {
+    type Error = anyhow::Error;
+
+    fn try_into(self) -> Result<StructTag, Self::Error> {
+        use MoveStructLayout::*;
+        match self {
+            Runtime(..) | WithFields(..) => bail!(
+                "Invalid MoveTypeLayout -> StructTag conversion--needed MoveLayoutType::WithTypes"
+            ),
+            WithTypes { type_, .. } => Ok(type_.clone()),
+        }
     }
 }

--- a/language/tools/move-resource-viewer/src/lib.rs
+++ b/language/tools/move-resource-viewer/src/lib.rs
@@ -134,7 +134,7 @@ impl<'a, T: MoveResolver + ?Sized> MoveValueAnnotator<'a, T> {
                 .into_iter()
                 .zip(runtime.into_iter())
                 .collect(),
-            MoveStruct::WithFields(fields) => fields,
+            MoveStruct::WithFields(fields) | MoveStruct::WithTypes { fields, .. } => fields,
         })
     }
 


### PR DESCRIPTION
… names

This is useful for viewing Move values as tree-structured data in formats that are likely to be consumed by clients (e.g., json).