### PR TITLE
[utils] make normalized module serializable

### DIFF
--- a/language/move-binary-format/src/file_format.rs
+++ b/language/move-binary-format/src/file_format.rs
@@ -45,6 +45,7 @@ use proptest::{collection::vec, prelude::*, strategy::BoxedStrategy};
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
 use ref_cast::RefCast;
+use serde::{Deserialize, Serialize};
 use std::ops::BitOr;
 use variant_count::VariantCount;
 
@@ -259,7 +260,7 @@ impl StructHandle {
 }
 
 /// A type parameter used in the declaration of a struct.
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize, Deserialize)]
 #[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 #[cfg_attr(any(test, feature = "fuzzing"), proptest(no_params))]
 pub struct StructTypeParameter {
@@ -399,7 +400,7 @@ pub struct FieldDefinition {
 
 /// `Visibility` restricts the accessibility of the associated entity.
 /// - For function visibility, it restricts who may call into the associated function.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord, Serialize, Deserialize)]
 #[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 #[cfg_attr(any(test, feature = "fuzzing"), proptest(no_params))]
 #[repr(u8)]
@@ -594,7 +595,7 @@ impl Ability {
 }
 
 /// A set of `Ability`s
-#[derive(Clone, Eq, Copy, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Eq, Copy, Hash, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
 pub struct AbilitySet(u8);
 
 impl AbilitySet {

--- a/language/move-binary-format/src/normalized.rs
+++ b/language/move-binary-format/src/normalized.rs
@@ -29,11 +29,17 @@ use std::collections::BTreeMap;
 /// compared.
 #[derive(Clone, Debug, Ord, PartialOrd, Eq, PartialEq, Serialize, Deserialize)]
 pub enum Type {
+    #[serde(rename = "bool")]
     Bool,
+    #[serde(rename = "u8")]
     U8,
+    #[serde(rename = "u64")]
     U64,
+    #[serde(rename = "u128")]
     U128,
+    #[serde(rename = "address")]
     Address,
+    #[serde(rename = "signer")]
     Signer,
     Struct {
         address: AccountAddress,
@@ -41,6 +47,7 @@ pub enum Type {
         name: Identifier,
         type_arguments: Vec<Type>,
     },
+    #[serde(rename = "vector")]
     Vector(Box<Type>),
     TypeParameter(TypeParameterIndex),
     Reference(Box<Type>),
@@ -51,7 +58,7 @@ pub enum Type {
 /// metadata that it is ignored by the VM. The reason: names are important to clients. We would
 /// want a change from `Account { bal: u64, seq: u64 }` to `Account { seq: u64, bal: u64 }` to be
 /// marked as incompatible. Not safe to compare without an enclosing `Struct`.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct Field {
     pub name: Identifier,
     pub type_: Type,
@@ -59,7 +66,7 @@ pub struct Field {
 
 /// Normalized version of a `StructDefinition`. Not safe to compare without an associated
 /// `ModuleId` or `Module`.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct Struct {
     pub abilities: AbilitySet,
     pub type_parameters: Vec<StructTypeParameter>,
@@ -68,7 +75,7 @@ pub struct Struct {
 
 /// Normalized version of a `FunctionDefinition`. Not safe to compare without an associated
 /// `ModuleId` or `Module`.
-#[derive(Clone, Debug, Ord, PartialOrd, Eq, PartialEq)]
+#[derive(Clone, Debug, Ord, PartialOrd, Eq, PartialEq, Serialize, Deserialize)]
 pub struct Function {
     pub visibility: Visibility,
     pub type_parameters: Vec<AbilitySet>,
@@ -78,7 +85,7 @@ pub struct Function {
 
 /// Normalized version of a `CompiledModule`: its address, name, struct declarations, and public
 /// function declarations.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct Module {
     pub address: AccountAddress,
     pub name: Identifier,
@@ -366,16 +373,16 @@ impl std::fmt::Display for Type {
                 }
                 Ok(())
             }
-            Type::Vector(ty) => write!(f, "Vector<{}>", ty),
-            Type::U8 => write!(f, "U8"),
-            Type::U64 => write!(f, "U64"),
-            Type::U128 => write!(f, "U128"),
-            Type::Address => write!(f, "Address"),
-            Type::Signer => write!(f, "Signer"),
-            Type::Bool => write!(f, "Bool"),
+            Type::Vector(ty) => write!(f, "vector<{}>", ty),
+            Type::U8 => write!(f, "u8"),
+            Type::U64 => write!(f, "u64"),
+            Type::U128 => write!(f, "u128"),
+            Type::Address => write!(f, "address"),
+            Type::Signer => write!(f, "signer"),
+            Type::Bool => write!(f, "bool"),
             Type::Reference(r) => write!(f, "&{}", r),
             Type::MutableReference(r) => write!(f, "&mut {}", r),
-            Type::TypeParameter(i) => write!(f, "#{:?}", i),
+            Type::TypeParameter(i) => write!(f, "T{:?}", i),
         }
     }
 }


### PR DESCRIPTION
This is useful for turning key parts of on-chain module bytecode into a structured format that can be used by clients. For example: a validator or indexing service might expose an API that returns a JSON representation of a normalized module that a client can use to discover types/public functions in that module.
