### PR TITLE
Expose read to event store from NativeContext

### DIFF
--- a/language/move-vm/runtime/src/data_cache.rs
+++ b/language/move-vm/runtime/src/data_cache.rs
@@ -264,4 +264,8 @@ impl<'r, 'l, S: MoveResolver> DataStore for TransactionDataCache<'r, 'l, S> {
         let ty_layout = self.loader.type_to_type_layout(&ty)?;
         Ok(self.event_data.push((guid, seq_num, ty, ty_layout, val)))
     }
+
+    fn events(&self) -> &Vec<(Vec<u8>, u64, Type, MoveTypeLayout, Value)> {
+        &self.event_data
+    }
 }

--- a/language/move-vm/runtime/src/native_functions.rs
+++ b/language/move-vm/runtime/src/native_functions.rs
@@ -104,6 +104,10 @@ impl<'a> NativeContext<'a> {
         }
     }
 
+    pub fn events(&self) -> &Vec<(Vec<u8>, u64, Type, MoveTypeLayout, Value)> {
+        self.data_store.events()
+    }
+
     pub fn type_to_type_layout(&self, ty: &Type) -> PartialVMResult<Option<MoveTypeLayout>> {
         match self.resolver.type_to_type_layout(ty) {
             Ok(ty_layout) => Ok(Some(ty_layout)),

--- a/language/move-vm/types/src/data_store.rs
+++ b/language/move-vm/types/src/data_store.rs
@@ -6,7 +6,9 @@ use crate::{
     values::{GlobalValue, Value},
 };
 use move_binary_format::errors::{PartialVMResult, VMResult};
-use move_core_types::{account_address::AccountAddress, language_storage::ModuleId};
+use move_core_types::{
+    account_address::AccountAddress, language_storage::ModuleId, value::MoveTypeLayout,
+};
 
 /// Provide an implementation for bytecodes related to data with a given data store.
 ///
@@ -48,4 +50,6 @@ pub trait DataStore {
         ty: Type,
         val: Value,
     ) -> PartialVMResult<()>;
+
+    fn events(&self) -> &Vec<(Vec<u8>, u64, Type, MoveTypeLayout, Value)>;
 }


### PR DESCRIPTION
This will allow us to read past events when processing native functions calls.
Doing so will allow us to be able to test custom Move events in our repo.
There are also many other useful ways of using this for testing.