### PR TITLE
[evm] Generalizing placeholder definitions & memory guard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2302,6 +2302,7 @@ dependencies = [
  "hex",
  "itertools 0.10.1",
  "log",
+ "maplit",
  "move-binary-format",
  "move-command-line-common",
  "move-core-types",

--- a/language/evm/move-to-yul/Cargo.toml
+++ b/language/evm/move-to-yul/Cargo.toml
@@ -29,6 +29,7 @@ futures = "0.3.12"
 hex = "0.4.3"
 itertools = "0.10.0"
 log = { version = "0.4.14", features = ["serde"] }
+maplit = "1.0.2"
 num = "0.4.0"
 pretty = "0.10.0"
 regex = "1.4.3"

--- a/language/evm/move-to-yul/src/yul_functions.rs
+++ b/language/evm/move-to-yul/src/yul_functions.rs
@@ -1,8 +1,58 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use maplit::btreemap;
 use once_cell::sync::Lazy;
 use regex::Regex;
+use std::collections::BTreeMap;
+
+/// A lazy constant which defines placeholders which can be referenced as `${NAME}`
+/// in emitted code. All emitted strings have those placeholders substituted.
+static PLACEHOLDERS: Lazy<BTreeMap<&'static str, &'static str>> = Lazy::new(|| {
+    btreemap! {
+        // ---------------------------------
+        // Numerical constants
+        "MAX_U8" => "0xff",
+        "MAX_U64" => "0xffffffffffffffff",
+        "MAX_U128" => "0xffffffffffffffffffffffffffffffff",
+
+        // ---------------------------------
+        // Memory
+        // The size of the memory used by the compilation scheme. This must be the
+        // sum of the sizes required by the locations defined below.
+        "USED_MEM" => "4",
+
+        // Location where the current size of the used memory is stored. New memory will
+        // be allocated from there.
+        "MEM_SIZE_LOC" => "0",
+    }
+});
+
+/// Substitutes placeholders in the given string.
+pub fn substitute_placeholders(s: &str) -> Option<String> {
+    static REX: Lazy<Regex> = Lazy::new(|| Regex::new(r"(?m)(\$\{(?P<var>[A-Z0-9_]+)\})").unwrap());
+    let mut at = 0;
+    let mut changes = false;
+    let mut res = "".to_string();
+    while let Some(cap) = (*REX).captures(&s[at..]) {
+        let m = cap.get(0).unwrap();
+        let v = cap.name("var").unwrap();
+        res.push_str(&s[at..at + m.start()]);
+        if let Some(repl) = PLACEHOLDERS.get(v.as_str()) {
+            changes = true;
+            res.push_str(repl)
+        } else {
+            res.push_str(m.as_str())
+        }
+        at += m.end();
+    }
+    if changes {
+        res.push_str(&s[at..]);
+        Some(res)
+    } else {
+        None
+    }
+}
 
 /// A macro which allows to define Yul functions together with their definitions.
 /// This generates an enum `YulFunction` and functions `yule_name`, `yul_def`,
@@ -51,27 +101,7 @@ fn make_yule_name(name: &str) -> String {
 
 /// Helper to create definition of a Yule function.
 fn make_yule_def(name: &str, body: &str) -> String {
-    format!("function ${}{}", name, substitute(body))
-}
-
-/// Helper to substitute `$XXX` placeholders in the body of a Yul function.
-fn substitute(s: &str) -> String {
-    static REX: Lazy<Regex> = Lazy::new(|| Regex::new(r"(?m)(?P<var>\$[A-Z0-9_]+)").unwrap());
-    let mut at = 0;
-    let mut res = "".to_string();
-    while let Some(cap) = (*REX).captures(&s[at..]) {
-        let m = cap.name("var").unwrap();
-        res.push_str(&s[at..at + m.start()]);
-        match m.as_str() {
-            "$MAX_U8" => res.push_str("0xff"),
-            "$MAX_U64" => res.push_str("0xffffffffffffffff"),
-            "$MAX_U128" => res.push_str("0xffffffffffffffffffffffffffffffff"),
-            _ => res.push_str(m.as_str()),
-        }
-        at += m.end();
-    }
-    res.push_str(&s[at..]);
-    res
+    format!("function ${}{}", name, body)
 }
 
 // The Yul functions supporting the compilation scheme.
@@ -83,27 +113,27 @@ AbortBuiltin: "() {
     $Abort(sub(0, 1))
 }" dep Abort,
 AddU64: "(x, y) -> r {
-    if lt(sub($MAX_U64, x), y) { $AbortBuiltin() }
+    if lt(sub(${MAX_U64}, x), y) { $AbortBuiltin() }
     r := add(x, y)
 }" dep AbortBuiltin,
 MulU64: "(x, y) -> r {
-    if gt(y, div($MAX_U64, x)) { $AbortBuiltin() }
+    if gt(y, div(${MAX_U64}, x)) { $AbortBuiltin() }
     r := mul(x, y)
 }" dep AbortBuiltin,
 AddU8: "(x, y) -> r {
-    if lt(sub($MAX_U8, x), y) { $AbortBuiltin() }
+    if lt(sub(${MAX_U8}, x), y) { $AbortBuiltin() }
     r := add(x, y)
 }" dep AbortBuiltin,
 MulU8: "(x, y) -> r {
-    if gt(y, div($MAX_U8, x)) { $AbortBuiltin() }
+    if gt(y, div(${MAX_U8}, x)) { $AbortBuiltin() }
     r := mul(x, y)
 }" dep AbortBuiltin,
 AddU128: "(x, y) -> r {
-    if lt(sub($MAX_U128, x), y) { $AbortBuiltin() }
+    if lt(sub(${MAX_U128}, x), y) { $AbortBuiltin() }
     r := add(x, y)
 }" dep AbortBuiltin,
 MulU128: "(x, y) -> r {
-    if gt(y, div($MAX_U128, x)) { $AbortBuiltin() }
+    if gt(y, div(${MAX_U128}, x)) { $AbortBuiltin() }
     r := mul(x, y)
 }" dep AbortBuiltin,
 Sub: "(x, y) -> r {
@@ -122,13 +152,13 @@ Shr: "(x, y) -> r {
     r := shr(x, y)
 }",
 ShlU8: "(x, y) -> r {
-    r := and(shl(x, y), $MAX_U8)
+    r := and(shl(x, y), ${MAX_U8})
 }",
 ShlU64: "(x, y) -> r {
-    r := and(shl(x, y), $MAX_U64)
+    r := and(shl(x, y), ${MAX_U64})
 }",
 ShlU128: "(x, y) -> r {
-    r := and(shl(x, y), $MAX_U128)
+    r := and(shl(x, y), ${MAX_U128})
 }",
 Gt: "(x, y) -> r {
     r := gt(x, y)
@@ -170,15 +200,15 @@ BitNot: "(x) -> r {
     r := not(x)
 }",
 CastU8: "(x) -> r {
-    if gt(x, $MAX_U8) { $AbortBuiltin() }
+    if gt(x, ${MAX_U8}) { $AbortBuiltin() }
     r := x
 }" dep AbortBuiltin,
 CastU64: "(x) -> r {
-    if gt(x, $MAX_U64) { $AbortBuiltin() }
+    if gt(x, ${MAX_U64}) { $AbortBuiltin() }
     r := x
 }" dep AbortBuiltin,
 CastU128: "(x) -> r {
-    if gt(x, $MAX_U128) { $AbortBuiltin() }
+    if gt(x, ${MAX_U128}) { $AbortBuiltin() }
     r := x
 }" dep AbortBuiltin,
 }

--- a/language/evm/move-to-yul/tests/Arithm.exp
+++ b/language/evm/move-to-yul/tests/Arithm.exp
@@ -21,6 +21,7 @@ object "A2_M" {
     }
     object "A2_M_deployed" {
         code {
+            mstore(0, memoryguard(4))
             function A2_M_add_two_number(x, y) -> $result0, $result1 {
                 let res, z, $t4, $t5
                 /// @src 2:309:310

--- a/language/evm/move-to-yul/tests/ControlStructures.exp
+++ b/language/evm/move-to-yul/tests/ControlStructures.exp
@@ -11,6 +11,7 @@ object "A2_M" {
     }
     object "A2_M_deployed" {
         code {
+            mstore(0, memoryguard(4))
             function A2_M_f(x) {
                 let $t1, $t2, $t3, $t4, $t5, $t6, $t7, $t8
                 let $block := 4

--- a/language/evm/move-to-yul/tests/MoveCalls.exp
+++ b/language/evm/move-to-yul/tests/MoveCalls.exp
@@ -11,6 +11,7 @@ object "A2_M" {
     }
     object "A2_M_deployed" {
         code {
+            mstore(0, memoryguard(4))
             function A2_M_f(x) -> $result {
                 let y, $t2, $t3, $t4, $t5, $t6
                 $t2, $t3 := A2_M_g(x)

--- a/language/evm/move-to-yul/tests/NoGenericCallable.exp
+++ b/language/evm/move-to-yul/tests/NoGenericCallable.exp
@@ -20,6 +20,7 @@ object "A2_M" {
     }
     object "A2_M_deployed" {
         code {
+            mstore(0, memoryguard(4))
             function A2_M_f(x) -> $result {
                 /// @src 2:105:106
                 $result := x


### PR DESCRIPTION
This generalizes the placeholder mechanism (`${MAX_U12}` et. al) to the whole code emission. That is, wherever an `emitln!` or an `emit!` is used, placeholders will be substituted. The definition of placeholders also becomes more declarative. Finally, placeholder syntax now requires braces (`${X}` instead of `$X`).

The first application is to emit the memoryguard instruction.

## Motivation

EVM

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Updated tests