### PR TITLE
[move-compiler] Allow implicit copies on all copyable types

### DIFF
--- a/language/evm/move-to-yul/tests/Locals.exp
+++ b/language/evm/move-to-yul/tests/Locals.exp
@@ -55,9 +55,9 @@ object "A2_M" {
                 $t13 := $AddU64($t11, $t12)
                 // write_ref($t9, $t13)
                 $StoreU64($t9, $t13)
-                // $t14 := copy($t0)
+                // $t14 := move($t0)
                 $t14 := mload($locals)
-                // $t15 := copy($t3)
+                // $t15 := move($t3)
                 $t15 := mload(add($locals, 32))
                 // return ($t14, $t1, $t15, $t8)
                 $result0 := $t14
@@ -295,7 +295,7 @@ object "test_A2_M_test_call_by_ref" {
                     $t2 := $MakePtr(false, add($locals, 24))
                     // M::call_by_ref($t2)
                     A2_M_call_by_ref($t2)
-                    // $t3 := copy($t0)
+                    // $t3 := move($t0)
                     $t3 := mload($locals)
                     // $t4 := 2
                     $t4 := 2
@@ -539,9 +539,9 @@ object "test_A2_M_test_evaded" {
             $t13 := $AddU64($t11, $t12)
             // write_ref($t9, $t13)
             $StoreU64($t9, $t13)
-            // $t14 := copy($t0)
+            // $t14 := move($t0)
             $t14 := mload($locals)
-            // $t15 := copy($t3)
+            // $t15 := move($t3)
             $t15 := mload(add($locals, 32))
             // return ($t14, $t1, $t15, $t8)
             $result0 := $t14

--- a/language/move-compiler/src/cfgir/borrows/mod.rs
+++ b/language/move-compiler/src/cfgir/borrows/mod.rs
@@ -168,8 +168,9 @@ fn exp(context: &mut Context, parent_e: &Exp) -> Values {
     let eloc = &parent_e.exp.loc;
     let svalue = || vec![Value::NonRef];
     match &parent_e.exp.value {
-        E::Move { var, .. } => {
-            let (diags, value) = context.borrow_state.move_local(*eloc, var);
+        E::Move { var, annotation } => {
+            let last_usage = matches!(annotation, MoveOpAnnotation::InferredLastUsage);
+            let (diags, value) = context.borrow_state.move_local(*eloc, var, last_usage);
             context.add_diags(diags);
             vec![value]
         }

--- a/language/move-compiler/src/diagnostics/codes.rs
+++ b/language/move-compiler/src/diagnostics/codes.rs
@@ -203,6 +203,7 @@ codes!(
         InvalidReturn:
             { msg: "invalid return of locally borrowed state", severity: NonblockingError },
         InvalidTransfer: { msg: "invalid transfer of references", severity: NonblockingError },
+        AmbiguousVariableUsage: { msg: "ambiguous usage of variable", severity: NonblockingError },
     ],
     BytecodeGeneration: [
         UnfoldableConstant: { msg: "cannot compute constant value", severity: NonblockingError },

--- a/language/move-compiler/src/expansion/dependency_ordering.rs
+++ b/language/move-compiler/src/expansion/dependency_ordering.rs
@@ -254,6 +254,7 @@ fn cycle_error(
         cycle_info
             .into_iter()
             .map(|(loc, _dep_type, msg, _node, _neighbor)| (loc, msg)),
+        std::iter::empty::<String>(),
     )
 }
 

--- a/language/move-compiler/src/naming/translate.rs
+++ b/language/move-compiler/src/naming/translate.rs
@@ -1164,8 +1164,8 @@ fn resolve_builtin_function(
             );
             // TODO make this a tip/hint?
             let help_msg = format!(
-                "Replace with '{0}!'. \
-                '{0}' has been replaced with a '{0}!' built-in macro so that arguments are no longer eagerly evaluated",
+                "Replace with '{0}!'. '{0}' has been replaced with a '{0}!' built-in macro so \
+                 that arguments are no longer eagerly evaluated",
                 B::ASSERT_MACRO
             );
             context.env.add_diag(diag!(

--- a/language/move-compiler/src/typing/expand.rs
+++ b/language/move-compiler/src/typing/expand.rs
@@ -6,6 +6,7 @@ use crate::{
     diag,
     expansion::ast::Value_,
     naming::ast::{BuiltinTypeName_, FunctionSignature, Type, TypeName_, Type_},
+    parser::ast::Ability_,
     typing::ast as T,
 };
 use move_ir_types::location::*;
@@ -141,7 +142,8 @@ pub fn exp(context: &mut Context, e: &mut T::Exp) {
         E::Use(v) => {
             let from_user = false;
             let var = *v;
-            e.exp.value = if core::is_implicitly_copyable(&context.subst, &e.ty) {
+            let abs = core::infer_abilities(context, &context.subst, e.ty.clone());
+            e.exp.value = if abs.has_ability_(Ability_::Copy) {
                 E::Copy { from_user, var }
             } else {
                 E::Move { from_user, var }

--- a/language/move-compiler/src/typing/infinite_instantiations.rs
+++ b/language/move-compiler/src/typing/infinite_instantiations.rs
@@ -386,6 +386,7 @@ fn cycle_error(
         TypeSafety::CyclicInstantiation,
         (call_loc, call_msg),
         secondary_labels,
+        std::iter::empty::<String>(),
     )
 }
 

--- a/language/move-compiler/src/typing/translate.rs
+++ b/language/move-compiler/src/typing/translate.rs
@@ -2084,11 +2084,15 @@ fn exp_dotted_to_owned_value(
                 sp!(_, ExpDotted_::Dot(_, name, _)) => *name,
             };
             let eborrow = exp_dotted_to_borrow(context, eloc, false, edot);
-            context.add_implicit_copyable_constraint(
+            context.add_ability_constraint(
                 eloc,
-                format!("Invalid implicit copy of field '{}'.", name),
+                Some(format!(
+                    "Invalid implicit copy of field '{}' without the '{}' ability",
+                    name,
+                    Ability_::COPY,
+                )),
                 inner_ty.clone(),
-                "Try adding '*&' to the front of the field access",
+                Ability_::Copy,
             );
             T::exp(inner_ty, sp(eloc, TE::Dereference(Box::new(eborrow))))
         }

--- a/language/move-compiler/tests/move_check/borrows/assign_local_combo_invalid.exp
+++ b/language/move-compiler/tests/move_check/borrows/assign_local_combo_invalid.exp
@@ -4,7 +4,7 @@ error[E07003]: invalid operation, could create dangling a reference
 13 │         if (cond) f = &s.f else f = &s.g;
    │                                     ---- It is still being borrowed by this reference
 14 │         s = S { f: 0, g: 0 };
-   │         ^ Invalid assignment of local 's'
+   │         ^ Invalid assignment of variable 's'
 
 error[E07003]: invalid operation, could create dangling a reference
    ┌─ tests/move_check/borrows/assign_local_combo_invalid.move:23:9
@@ -12,7 +12,7 @@ error[E07003]: invalid operation, could create dangling a reference
 22 │         if (cond) f = &mut s.f else f = &mut other.f;
    │                       -------- It is still being mutably borrowed by this reference
 23 │         s = S { f: 0, g: 0 };
-   │         ^ Invalid assignment of local 's'
+   │         ^ Invalid assignment of variable 's'
 
 error[E07003]: invalid operation, could create dangling a reference
    ┌─ tests/move_check/borrows/assign_local_combo_invalid.move:32:9
@@ -20,7 +20,7 @@ error[E07003]: invalid operation, could create dangling a reference
 31 │         if (cond) f = &mut s else f = other;
    │                       ------ It is still being mutably borrowed by this reference
 32 │         s = S { f: 0, g: 0 };
-   │         ^ Invalid assignment of local 's'
+   │         ^ Invalid assignment of variable 's'
 
 error[E07003]: invalid operation, could create dangling a reference
    ┌─ tests/move_check/borrows/assign_local_combo_invalid.move:41:9
@@ -28,7 +28,7 @@ error[E07003]: invalid operation, could create dangling a reference
 40 │         if (cond) f = id_mut(&mut s) else f = other;
    │                       -------------- It is still being mutably borrowed by this reference
 41 │         s = S { f: 0, g: 0 };
-   │         ^ Invalid assignment of local 's'
+   │         ^ Invalid assignment of variable 's'
 
 error[E07003]: invalid operation, could create dangling a reference
    ┌─ tests/move_check/borrows/assign_local_combo_invalid.move:49:19
@@ -36,5 +36,5 @@ error[E07003]: invalid operation, could create dangling a reference
 48 │         let f = &s.f;
    │                 ---- It is still being borrowed by this reference
 49 │         if (cond) s = S { f: 0, g: 0 };
-   │                   ^ Invalid assignment of local 's'
+   │                   ^ Invalid assignment of variable 's'
 

--- a/language/move-compiler/tests/move_check/borrows/assign_local_field_invalid.exp
+++ b/language/move-compiler/tests/move_check/borrows/assign_local_field_invalid.exp
@@ -4,7 +4,7 @@ error[E07003]: invalid operation, could create dangling a reference
 12 │         let f = &s.f;
    │                 ---- It is still being borrowed by this reference
 13 │         s = S { f: 0, g: 0 };
-   │         ^ Invalid assignment of local 's'
+   │         ^ Invalid assignment of variable 's'
 
 error[E07003]: invalid operation, could create dangling a reference
    ┌─ tests/move_check/borrows/assign_local_field_invalid.move:19:9
@@ -12,7 +12,7 @@ error[E07003]: invalid operation, could create dangling a reference
 18 │         let f = &mut s.f;
    │                 -------- It is still being mutably borrowed by this reference
 19 │         s = S { f: 0, g: 0 };
-   │         ^ Invalid assignment of local 's'
+   │         ^ Invalid assignment of variable 's'
 
 error[E07003]: invalid operation, could create dangling a reference
    ┌─ tests/move_check/borrows/assign_local_field_invalid.move:25:9
@@ -20,7 +20,7 @@ error[E07003]: invalid operation, could create dangling a reference
 24 │         let f = id(&s.f);
    │                 -------- It is still being borrowed by this reference
 25 │         s = S { f: 0, g: 0 };
-   │         ^ Invalid assignment of local 's'
+   │         ^ Invalid assignment of variable 's'
 
 error[E07003]: invalid operation, could create dangling a reference
    ┌─ tests/move_check/borrows/assign_local_field_invalid.move:31:9
@@ -28,5 +28,5 @@ error[E07003]: invalid operation, could create dangling a reference
 30 │         let f = id_mut(&mut s.f);
    │                 ---------------- It is still being mutably borrowed by this reference
 31 │         s = S { f: 0, g: 0 };
-   │         ^ Invalid assignment of local 's'
+   │         ^ Invalid assignment of variable 's'
 

--- a/language/move-compiler/tests/move_check/borrows/assign_local_full_invalid.exp
+++ b/language/move-compiler/tests/move_check/borrows/assign_local_full_invalid.exp
@@ -4,7 +4,7 @@ error[E07003]: invalid operation, could create dangling a reference
 12 │         let f = &x;
    │                 -- It is still being borrowed by this reference
 13 │         x = 0;
-   │         ^ Invalid assignment of local 'x'
+   │         ^ Invalid assignment of variable 'x'
 
 error[E07003]: invalid operation, could create dangling a reference
    ┌─ tests/move_check/borrows/assign_local_full_invalid.move:19:9
@@ -12,7 +12,7 @@ error[E07003]: invalid operation, could create dangling a reference
 18 │         let f = &mut x;
    │                 ------ It is still being mutably borrowed by this reference
 19 │         x = 0;
-   │         ^ Invalid assignment of local 'x'
+   │         ^ Invalid assignment of variable 'x'
 
 error[E07003]: invalid operation, could create dangling a reference
    ┌─ tests/move_check/borrows/assign_local_full_invalid.move:25:9
@@ -20,7 +20,7 @@ error[E07003]: invalid operation, could create dangling a reference
 24 │         let f = id(&x);
    │                 ------ It is still being borrowed by this reference
 25 │         x = 0;
-   │         ^ Invalid assignment of local 'x'
+   │         ^ Invalid assignment of variable 'x'
 
 error[E07003]: invalid operation, could create dangling a reference
    ┌─ tests/move_check/borrows/assign_local_full_invalid.move:31:9
@@ -28,5 +28,5 @@ error[E07003]: invalid operation, could create dangling a reference
 30 │         let f = id_mut(&mut x);
    │                 -------------- It is still being mutably borrowed by this reference
 31 │         x = 0;
-   │         ^ Invalid assignment of local 'x'
+   │         ^ Invalid assignment of variable 'x'
 

--- a/language/move-compiler/tests/move_check/borrows/borrow_local_combo_invalid.exp
+++ b/language/move-compiler/tests/move_check/borrows/borrow_local_combo_invalid.exp
@@ -4,7 +4,7 @@ error[E07001]: referential transparency violated
 12 │         if (cond) f = &mut s.f else f = &mut other.f;
    │                       -------- It is still being mutably borrowed by this reference
 13 │         let x = &s;
-   │                 ^^ Invalid borrow of local 's'
+   │                 ^^ Invalid borrow of variable 's'
 
 error[E07002]: mutable ownership violated
    ┌─ tests/move_check/borrows/borrow_local_combo_invalid.move:23:9
@@ -21,7 +21,7 @@ error[E07001]: referential transparency violated
 29 │         if (cond) f = &mut s.f else f = &mut s.g;
    │                                         -------- It is still being mutably borrowed by this reference
 30 │         let x = &s;
-   │                 ^^ Invalid borrow of local 's'
+   │                 ^^ Invalid borrow of variable 's'
 
 error[E07001]: referential transparency violated
    ┌─ tests/move_check/borrows/borrow_local_combo_invalid.move:38:17
@@ -29,7 +29,7 @@ error[E07001]: referential transparency violated
 37 │         if (cond) x = &mut s else x = other;
    │                       ------ It is still being mutably borrowed by this reference
 38 │         let y = &s;
-   │                 ^^ Invalid borrow of local 's'
+   │                 ^^ Invalid borrow of variable 's'
 
 error[E07002]: mutable ownership violated
    ┌─ tests/move_check/borrows/borrow_local_combo_invalid.move:48:9

--- a/language/move-compiler/tests/move_check/borrows/borrow_local_field_invalid.exp
+++ b/language/move-compiler/tests/move_check/borrows/borrow_local_field_invalid.exp
@@ -13,5 +13,5 @@ error[E07001]: referential transparency violated
 18 │         let f = &mut v.f;
    │                 -------- It is still being mutably borrowed by this reference
 19 │         let s = &v;
-   │                 ^^ Invalid borrow of local 'v'
+   │                 ^^ Invalid borrow of variable 'v'
 

--- a/language/move-compiler/tests/move_check/borrows/borrow_local_full_invalid.exp
+++ b/language/move-compiler/tests/move_check/borrows/borrow_local_full_invalid.exp
@@ -30,5 +30,5 @@ error[E07001]: referential transparency violated
 32 │         let x = &mut v;
    │                 ------ It is still being mutably borrowed by this reference
 33 │         let y = &v;
-   │                 ^^ Invalid borrow of local 'v'
+   │                 ^^ Invalid borrow of variable 'v'
 

--- a/language/move-compiler/tests/move_check/borrows/borrowed_before_last_usage.exp
+++ b/language/move-compiler/tests/move_check/borrows/borrowed_before_last_usage.exp
@@ -1,0 +1,13 @@
+error[E07006]: ambiguous usage of variable
+  ┌─ tests/move_check/borrows/borrowed_before_last_usage.move:5:13
+  │
+4 │     let r = &x;
+  │             -- It is still being borrowed by this reference
+5 │     let y = x;
+  │             ^
+  │             │
+  │             Ambiguous usage of variable 'x'
+  │             Try an explicit annotation, e.g. 'move x' or 'copy x'
+  │
+  = Ambiguous inference of 'move' or 'copy' for a borrowed variable's last usage: A 'move' would invalidate the borrowing reference, but a 'copy' might not be the expected implicit behavior since this the last direct usage of the variable.
+

--- a/language/move-compiler/tests/move_check/borrows/borrowed_before_last_usage.move
+++ b/language/move-compiler/tests/move_check/borrows/borrowed_before_last_usage.move
@@ -1,0 +1,8 @@
+script {
+fun main() {
+    let x = 0;
+    let r = &x;
+    let y = x;
+    assert!(*r == y, 0);
+}
+}

--- a/language/move-compiler/tests/move_check/borrows/call_transfer_borrows_invalid.exp
+++ b/language/move-compiler/tests/move_check/borrows/call_transfer_borrows_invalid.exp
@@ -4,7 +4,7 @@ error[E07003]: invalid operation, could create dangling a reference
 15 │         let r = take_imm_mut_give_mut(move x_ref, move y_ref);
    │                 --------------------------------------------- It is still being mutably borrowed by this reference
 16 │         move y;
-   │         ^^^^^^ Invalid move of local 'y'
+   │         ^^^^^^ Invalid move of variable 'y'
 
 error[E07003]: invalid operation, could create dangling a reference
    ┌─ tests/move_check/borrows/call_transfer_borrows_invalid.move:26:9
@@ -12,7 +12,7 @@ error[E07003]: invalid operation, could create dangling a reference
 25 │         let r = take_imm_mut_give_imm(move x_ref, move y_ref);
    │                 --------------------------------------------- It is still being borrowed by this reference
 26 │         move x;
-   │         ^^^^^^ Invalid move of local 'x'
+   │         ^^^^^^ Invalid move of variable 'x'
 
 error[E07003]: invalid operation, could create dangling a reference
    ┌─ tests/move_check/borrows/call_transfer_borrows_invalid.move:27:9
@@ -21,5 +21,5 @@ error[E07003]: invalid operation, could create dangling a reference
    │                 --------------------------------------------- It is still being borrowed by this reference
 26 │         move x;
 27 │         move y;
-   │         ^^^^^^ Invalid move of local 'y'
+   │         ^^^^^^ Invalid move of variable 'y'
 

--- a/language/move-compiler/tests/move_check/borrows/copy_combo_invalid.exp
+++ b/language/move-compiler/tests/move_check/borrows/copy_combo_invalid.exp
@@ -4,7 +4,7 @@ error[E07002]: mutable ownership violated
 13 │         if (cond) f = &mut s.f else f = &mut other.f;
    │                       -------- It is still being mutably borrowed by this reference
 14 │         copy s;
-   │         ^^^^^^ Invalid copy of local 's'
+   │         ^^^^^^ Invalid copy of variable 's'
 
 error[E07002]: mutable ownership violated
    ┌─ tests/move_check/borrows/copy_combo_invalid.move:23:9
@@ -12,7 +12,7 @@ error[E07002]: mutable ownership violated
 22 │         if (cond) f = &mut s else f = other;
    │                       ------ It is still being mutably borrowed by this reference
 23 │         copy s;
-   │         ^^^^^^ Invalid copy of local 's'
+   │         ^^^^^^ Invalid copy of variable 's'
 
 error[E07002]: mutable ownership violated
    ┌─ tests/move_check/borrows/copy_combo_invalid.move:32:9
@@ -20,7 +20,7 @@ error[E07002]: mutable ownership violated
 31 │         if (cond) f = id_mut(&mut s) else f = other;
    │                       -------------- It is still being mutably borrowed by this reference
 32 │         copy s;
-   │         ^^^^^^ Invalid copy of local 's'
+   │         ^^^^^^ Invalid copy of variable 's'
 
 error[E07002]: mutable ownership violated
    ┌─ tests/move_check/borrows/copy_combo_invalid.move:40:21
@@ -28,5 +28,5 @@ error[E07002]: mutable ownership violated
 39 │         let f = &mut s.f;
    │                 -------- It is still being mutably borrowed by this reference
 40 │         if (cond) { copy s; };
-   │                     ^^^^^^ Invalid copy of local 's'
+   │                     ^^^^^^ Invalid copy of variable 's'
 

--- a/language/move-compiler/tests/move_check/borrows/copy_field_invalid.exp
+++ b/language/move-compiler/tests/move_check/borrows/copy_field_invalid.exp
@@ -4,7 +4,7 @@ error[E07002]: mutable ownership violated
 12 │         let f = &mut s.f;
    │                 -------- It is still being mutably borrowed by this reference
 13 │         copy s;
-   │         ^^^^^^ Invalid copy of local 's'
+   │         ^^^^^^ Invalid copy of variable 's'
 
 error[E07002]: mutable ownership violated
    ┌─ tests/move_check/borrows/copy_field_invalid.move:19:9
@@ -12,5 +12,5 @@ error[E07002]: mutable ownership violated
 18 │         let f = id_mut(&mut s.f);
    │                 ---------------- It is still being mutably borrowed by this reference
 19 │         copy s;
-   │         ^^^^^^ Invalid copy of local 's'
+   │         ^^^^^^ Invalid copy of variable 's'
 

--- a/language/move-compiler/tests/move_check/borrows/copy_full_invalid.exp
+++ b/language/move-compiler/tests/move_check/borrows/copy_full_invalid.exp
@@ -4,7 +4,7 @@ error[E07002]: mutable ownership violated
 12 │         let f = &mut x;
    │                 ------ It is still being mutably borrowed by this reference
 13 │         x;
-   │         ^ Invalid copy of local 'x'
+   │         ^ Invalid copy of variable 'x'
 
 error[E07002]: mutable ownership violated
    ┌─ tests/move_check/borrows/copy_full_invalid.move:19:9
@@ -12,5 +12,5 @@ error[E07002]: mutable ownership violated
 18 │         let f = id_mut(&mut x);
    │                 -------------- It is still being mutably borrowed by this reference
 19 │         x;
-   │         ^ Invalid copy of local 'x'
+   │         ^ Invalid copy of variable 'x'
 

--- a/language/move-compiler/tests/move_check/borrows/move_combo_invalid.exp
+++ b/language/move-compiler/tests/move_check/borrows/move_combo_invalid.exp
@@ -4,7 +4,7 @@ error[E07003]: invalid operation, could create dangling a reference
 13 │         if (cond) f = &s.f else f = &s.g;
    │                                     ---- It is still being borrowed by this reference
 14 │         move s;
-   │         ^^^^^^ Invalid move of local 's'
+   │         ^^^^^^ Invalid move of variable 's'
 
 error[E07003]: invalid operation, could create dangling a reference
    ┌─ tests/move_check/borrows/move_combo_invalid.move:22:9
@@ -12,7 +12,7 @@ error[E07003]: invalid operation, could create dangling a reference
 21 │         if (cond) f = &mut s.f else f = &mut other.f;
    │                       -------- It is still being mutably borrowed by this reference
 22 │         move s;
-   │         ^^^^^^ Invalid move of local 's'
+   │         ^^^^^^ Invalid move of variable 's'
 
 error[E07003]: invalid operation, could create dangling a reference
    ┌─ tests/move_check/borrows/move_combo_invalid.move:30:9
@@ -20,7 +20,7 @@ error[E07003]: invalid operation, could create dangling a reference
 29 │         if (cond) f = &mut s else f = other;
    │                       ------ It is still being mutably borrowed by this reference
 30 │         move s;
-   │         ^^^^^^ Invalid move of local 's'
+   │         ^^^^^^ Invalid move of variable 's'
 
 error[E07003]: invalid operation, could create dangling a reference
    ┌─ tests/move_check/borrows/move_combo_invalid.move:38:9
@@ -28,7 +28,7 @@ error[E07003]: invalid operation, could create dangling a reference
 37 │         if (cond) f = id_mut(&mut s) else f = other;
    │                       -------------- It is still being mutably borrowed by this reference
 38 │         move s;
-   │         ^^^^^^ Invalid move of local 's'
+   │         ^^^^^^ Invalid move of variable 's'
 
 error[E07003]: invalid operation, could create dangling a reference
    ┌─ tests/move_check/borrows/move_combo_invalid.move:45:21
@@ -36,5 +36,5 @@ error[E07003]: invalid operation, could create dangling a reference
 44 │         let f = &s.f;
    │                 ---- It is still being borrowed by this reference
 45 │         if (cond) { move s; };
-   │                     ^^^^^^ Invalid move of local 's'
+   │                     ^^^^^^ Invalid move of variable 's'
 

--- a/language/move-compiler/tests/move_check/borrows/move_field_invalid.exp
+++ b/language/move-compiler/tests/move_check/borrows/move_field_invalid.exp
@@ -4,7 +4,7 @@ error[E07003]: invalid operation, could create dangling a reference
 12 │         let f = &s.f;
    │                 ---- It is still being borrowed by this reference
 13 │         move s;
-   │         ^^^^^^ Invalid move of local 's'
+   │         ^^^^^^ Invalid move of variable 's'
 
 error[E07003]: invalid operation, could create dangling a reference
    ┌─ tests/move_check/borrows/move_field_invalid.move:18:9
@@ -12,7 +12,7 @@ error[E07003]: invalid operation, could create dangling a reference
 17 │         let f = &mut s.f;
    │                 -------- It is still being mutably borrowed by this reference
 18 │         move s;
-   │         ^^^^^^ Invalid move of local 's'
+   │         ^^^^^^ Invalid move of variable 's'
 
 error[E07003]: invalid operation, could create dangling a reference
    ┌─ tests/move_check/borrows/move_field_invalid.move:23:9
@@ -20,7 +20,7 @@ error[E07003]: invalid operation, could create dangling a reference
 22 │         let f = id(&s.f);
    │                 -------- It is still being borrowed by this reference
 23 │         move s;
-   │         ^^^^^^ Invalid move of local 's'
+   │         ^^^^^^ Invalid move of variable 's'
 
 error[E07003]: invalid operation, could create dangling a reference
    ┌─ tests/move_check/borrows/move_field_invalid.move:28:9
@@ -28,5 +28,5 @@ error[E07003]: invalid operation, could create dangling a reference
 27 │         let f = id_mut(&mut s.f);
    │                 ---------------- It is still being mutably borrowed by this reference
 28 │         move s;
-   │         ^^^^^^ Invalid move of local 's'
+   │         ^^^^^^ Invalid move of variable 's'
 

--- a/language/move-compiler/tests/move_check/borrows/move_full_invalid.exp
+++ b/language/move-compiler/tests/move_check/borrows/move_full_invalid.exp
@@ -4,7 +4,7 @@ error[E07003]: invalid operation, could create dangling a reference
 12 │         let f = &x;
    │                 -- It is still being borrowed by this reference
 13 │         move x;
-   │         ^^^^^^ Invalid move of local 'x'
+   │         ^^^^^^ Invalid move of variable 'x'
 
 error[E07003]: invalid operation, could create dangling a reference
    ┌─ tests/move_check/borrows/move_full_invalid.move:18:9
@@ -12,7 +12,7 @@ error[E07003]: invalid operation, could create dangling a reference
 17 │         let f = &mut x;
    │                 ------ It is still being mutably borrowed by this reference
 18 │         move x;
-   │         ^^^^^^ Invalid move of local 'x'
+   │         ^^^^^^ Invalid move of variable 'x'
 
 error[E07003]: invalid operation, could create dangling a reference
    ┌─ tests/move_check/borrows/move_full_invalid.move:23:9
@@ -20,7 +20,7 @@ error[E07003]: invalid operation, could create dangling a reference
 22 │         let f = id(&x);
    │                 ------ It is still being borrowed by this reference
 23 │         move x;
-   │         ^^^^^^ Invalid move of local 'x'
+   │         ^^^^^^ Invalid move of variable 'x'
 
 error[E07003]: invalid operation, could create dangling a reference
    ┌─ tests/move_check/borrows/move_full_invalid.move:28:9
@@ -28,5 +28,5 @@ error[E07003]: invalid operation, could create dangling a reference
 27 │         let f = id_mut(&mut x);
    │                 -------------- It is still being mutably borrowed by this reference
 28 │         move x;
-   │         ^^^^^^ Invalid move of local 'x'
+   │         ^^^^^^ Invalid move of variable 'x'
 

--- a/language/move-compiler/tests/move_check/liveness/dead_refs_branch_both_invalid.exp
+++ b/language/move-compiler/tests/move_check/liveness/dead_refs_branch_both_invalid.exp
@@ -5,7 +5,7 @@ error[E07002]: mutable ownership violated
    │                     ------ It is still being mutably borrowed by this reference
    ·
 10 │         _ = x;
-   │             ^ Invalid copy of local 'x'
+   │             ^ Invalid copy of variable 'x'
 
 error[E07003]: invalid operation, could create dangling a reference
    ┌─ tests/move_check/liveness/dead_refs_branch_both_invalid.move:11:13
@@ -14,7 +14,7 @@ error[E07003]: invalid operation, could create dangling a reference
    │                     ------ It is still being mutably borrowed by this reference
    ·
 11 │         _ = move x;
-   │             ^^^^^^ Invalid move of local 'x'
+   │             ^^^^^^ Invalid move of variable 'x'
 
 error[E07002]: mutable ownership violated
    ┌─ tests/move_check/liveness/dead_refs_branch_both_invalid.move:23:13
@@ -23,7 +23,7 @@ error[E07002]: mutable ownership violated
    │                     ------ It is still being mutably borrowed by this reference
    ·
 23 │         _ = x;
-   │             ^ Invalid copy of local 'x'
+   │             ^ Invalid copy of variable 'x'
 
 error[E07003]: invalid operation, could create dangling a reference
    ┌─ tests/move_check/liveness/dead_refs_branch_both_invalid.move:24:13
@@ -32,5 +32,5 @@ error[E07003]: invalid operation, could create dangling a reference
    │                     ------ It is still being mutably borrowed by this reference
    ·
 24 │         _ = move x;
-   │             ^^^^^^ Invalid move of local 'x'
+   │             ^^^^^^ Invalid move of variable 'x'
 

--- a/language/move-compiler/tests/move_check/liveness/dead_refs_branch_invalid.exp
+++ b/language/move-compiler/tests/move_check/liveness/dead_refs_branch_invalid.exp
@@ -5,7 +5,7 @@ error[E07002]: mutable ownership violated
   │                     ------ It is still being mutably borrowed by this reference
   ·
 8 │         _ = x;
-  │             ^ Invalid copy of local 'x'
+  │             ^ Invalid copy of variable 'x'
 
 error[E07003]: invalid operation, could create dangling a reference
   ┌─ tests/move_check/liveness/dead_refs_branch_invalid.move:9:13
@@ -14,7 +14,7 @@ error[E07003]: invalid operation, could create dangling a reference
   │                     ------ It is still being mutably borrowed by this reference
   ·
 9 │         _ = move x;
-  │             ^^^^^^ Invalid move of local 'x'
+  │             ^^^^^^ Invalid move of variable 'x'
 
 error[E07002]: mutable ownership violated
    ┌─ tests/move_check/liveness/dead_refs_branch_invalid.move:20:13
@@ -23,7 +23,7 @@ error[E07002]: mutable ownership violated
    │                     ------ It is still being mutably borrowed by this reference
    ·
 20 │         _ = x;
-   │             ^ Invalid copy of local 'x'
+   │             ^ Invalid copy of variable 'x'
 
 error[E07003]: invalid operation, could create dangling a reference
    ┌─ tests/move_check/liveness/dead_refs_branch_invalid.move:21:13
@@ -32,5 +32,5 @@ error[E07003]: invalid operation, could create dangling a reference
    │                     ------ It is still being mutably borrowed by this reference
    ·
 21 │         _ = move x;
-   │             ^^^^^^ Invalid move of local 'x'
+   │             ^^^^^^ Invalid move of variable 'x'
 

--- a/language/move-compiler/tests/move_check/liveness/dead_refs_loop_invalid.exp
+++ b/language/move-compiler/tests/move_check/liveness/dead_refs_loop_invalid.exp
@@ -5,7 +5,7 @@ error[E07002]: mutable ownership violated
   │                     ------ It is still being mutably borrowed by this reference
 5 │         while (cond) {
 6 │             _ = x;
-  │                 ^ Invalid copy of local 'x'
+  │                 ^ Invalid copy of variable 'x'
 
 error[E07002]: mutable ownership violated
    ┌─ tests/move_check/liveness/dead_refs_loop_invalid.move:16:16
@@ -14,7 +14,7 @@ error[E07002]: mutable ownership violated
    │                     ------ It is still being mutably borrowed by this reference
    ·
 16 │            _ = x;
-   │                ^ Invalid copy of local 'x'
+   │                ^ Invalid copy of variable 'x'
 
 error[E07002]: mutable ownership violated
    ┌─ tests/move_check/liveness/dead_refs_loop_invalid.move:25:17
@@ -23,5 +23,5 @@ error[E07002]: mutable ownership violated
    │                     ------ It is still being mutably borrowed by this reference
    ·
 25 │             _ = x;
-   │                 ^ Invalid copy of local 'x'
+   │                 ^ Invalid copy of variable 'x'
 

--- a/language/move-compiler/tests/move_check/liveness/dead_refs_nested_invalid.exp
+++ b/language/move-compiler/tests/move_check/liveness/dead_refs_nested_invalid.exp
@@ -5,7 +5,7 @@ error[E07002]: mutable ownership violated
   │                     ------ It is still being mutably borrowed by this reference
   ·
 9 │             _ = x;
-  │                 ^ Invalid copy of local 'x'
+  │                 ^ Invalid copy of variable 'x'
 
 error[E07002]: mutable ownership violated
    ┌─ tests/move_check/liveness/dead_refs_nested_invalid.move:19:20
@@ -14,7 +14,7 @@ error[E07002]: mutable ownership violated
    │                     ------ It is still being mutably borrowed by this reference
    ·
 19 │                _ = x;
-   │                    ^ Invalid copy of local 'x'
+   │                    ^ Invalid copy of variable 'x'
 
 error[E07002]: mutable ownership violated
    ┌─ tests/move_check/liveness/dead_refs_nested_invalid.move:29:71
@@ -23,5 +23,5 @@ error[E07002]: mutable ownership violated
    │                     ------ It is still being mutably borrowed by this reference
 28 │         loop {
 29 │             if (cond) { _ = x_ref; break } else { while (!cond) { _ = x } }
-   │                                                                       ^ Invalid copy of local 'x'
+   │                                                                       ^ Invalid copy of variable 'x'
 

--- a/language/move-compiler/tests/move_check/liveness/dead_refs_simple_invalid.exp
+++ b/language/move-compiler/tests/move_check/liveness/dead_refs_simple_invalid.exp
@@ -4,7 +4,7 @@ error[E07002]: mutable ownership violated
 4 │         let x_ref = &mut x;
   │                     ------ It is still being mutably borrowed by this reference
 5 │         _ = x;
-  │             ^ Invalid copy of local 'x'
+  │             ^ Invalid copy of variable 'x'
 
 error[E07003]: invalid operation, could create dangling a reference
   ┌─ tests/move_check/liveness/dead_refs_simple_invalid.move:6:13
@@ -13,7 +13,7 @@ error[E07003]: invalid operation, could create dangling a reference
   │                     ------ It is still being mutably borrowed by this reference
 5 │         _ = x;
 6 │         _ = move x;
-  │             ^^^^^^ Invalid move of local 'x'
+  │             ^^^^^^ Invalid move of variable 'x'
 
 error[E07002]: mutable ownership violated
    ┌─ tests/move_check/liveness/dead_refs_simple_invalid.move:13:13
@@ -21,7 +21,7 @@ error[E07002]: mutable ownership violated
 12 │         let x_ref = &mut x;
    │                     ------ It is still being mutably borrowed by this reference
 13 │         _ = x;
-   │             ^ Invalid copy of local 'x'
+   │             ^ Invalid copy of variable 'x'
 
 error[E07003]: invalid operation, could create dangling a reference
    ┌─ tests/move_check/liveness/dead_refs_simple_invalid.move:14:13
@@ -30,5 +30,5 @@ error[E07003]: invalid operation, could create dangling a reference
    │                     ------ It is still being mutably borrowed by this reference
 13 │         _ = x;
 14 │         _ = move x;
-   │             ^^^^^^ Invalid move of local 'x'
+   │             ^^^^^^ Invalid move of variable 'x'
 

--- a/language/move-compiler/tests/move_check/locals/eliminate_temps.exp
+++ b/language/move-compiler/tests/move_check/locals/eliminate_temps.exp
@@ -2,7 +2,7 @@ error[E07002]: mutable ownership violated
   ┌─ tests/move_check/locals/eliminate_temps.move:7:47
   │
 7 │         let (boom, u): (&u64, u64) = (&mut x, x);
-  │                                       ------  ^ Invalid copy of local 'x'
+  │                                       ------  ^ Invalid copy of variable 'x'
   │                                       │        
   │                                       It is still being mutably borrowed by this reference
 

--- a/language/move-compiler/tests/move_check/locals/use_after_move_simple.exp
+++ b/language/move-compiler/tests/move_check/locals/use_after_move_simple.exp
@@ -10,17 +10,6 @@ error[E06002]: use of unassigned variable
   │                 ^^^^^^ Invalid usage of previously moved variable 'x'.
 
 error[E06002]: use of unassigned variable
-   ┌─ tests/move_check/locals/use_after_move_simple.move:11:19
-   │
-10 │         let _s2 = s;
-   │                   -
-   │                   │
-   │                   The value of 's' was previously moved here.
-   │                   Suggestion: use 'copy s' to avoid the move.
-11 │         let _s3 = s;
-   │                   ^ Invalid usage of previously moved variable 's'.
-
-error[E06002]: use of unassigned variable
    ┌─ tests/move_check/locals/use_after_move_simple.move:17:17
    │
 16 │         move x;
@@ -32,17 +21,6 @@ error[E06002]: use of unassigned variable
    │                 ^ Invalid usage of previously moved variable 'x'.
 
 error[E06002]: use of unassigned variable
-   ┌─ tests/move_check/locals/use_after_move_simple.move:21:19
-   │
-20 │         let _s2 = s;
-   │                   -
-   │                   │
-   │                   The value of 's' was previously moved here.
-   │                   Suggestion: use 'copy s' to avoid the move.
-21 │         let _s3 = copy s;
-   │                   ^^^^^^ Invalid usage of previously moved variable 's'.
-
-error[E06002]: use of unassigned variable
    ┌─ tests/move_check/locals/use_after_move_simple.move:27:17
    │
 26 │         move x;
@@ -52,15 +30,4 @@ error[E06002]: use of unassigned variable
    │         Suggestion: use 'copy x' to avoid the move.
 27 │         let _ = &x;
    │                 ^^ Invalid usage of previously moved variable 'x'.
-
-error[E06002]: use of unassigned variable
-   ┌─ tests/move_check/locals/use_after_move_simple.move:31:19
-   │
-30 │         let _s2 = s;
-   │                   -
-   │                   │
-   │                   The value of 's' was previously moved here.
-   │                   Suggestion: use 'copy s' to avoid the move.
-31 │         let _s3 = &s;
-   │                   ^^ Invalid usage of previously moved variable 's'.
 

--- a/language/move-compiler/tests/move_check/translated_ir_tests/move/borrow_tests/copy_loc_borrowed_field_invalid.exp
+++ b/language/move-compiler/tests/move_check/translated_ir_tests/move/borrow_tests/copy_loc_borrowed_field_invalid.exp
@@ -4,5 +4,5 @@ error[E07002]: mutable ownership violated
 6 │         let r1 = &mut x.f;
   │                  -------- It is still being mutably borrowed by this reference
 7 │         copy x;
-  │         ^^^^^^ Invalid copy of local 'x'
+  │         ^^^^^^ Invalid copy of variable 'x'
 

--- a/language/move-compiler/tests/move_check/translated_ir_tests/move/borrow_tests/copy_loc_borrowed_indirect_invalid.exp
+++ b/language/move-compiler/tests/move_check/translated_ir_tests/move/borrow_tests/copy_loc_borrowed_indirect_invalid.exp
@@ -4,5 +4,5 @@ error[E07002]: mutable ownership violated
 5 │         let r1 = foo(&mut x, &mut y);
   │                  ------------------- It is still being mutably borrowed by this reference
 6 │         copy x;
-  │         ^^^^^^ Invalid copy of local 'x'
+  │         ^^^^^^ Invalid copy of variable 'x'
 

--- a/language/move-compiler/tests/move_check/translated_ir_tests/move/borrow_tests/copy_loc_borrowed_invalid.exp
+++ b/language/move-compiler/tests/move_check/translated_ir_tests/move/borrow_tests/copy_loc_borrowed_invalid.exp
@@ -4,5 +4,5 @@ error[E07002]: mutable ownership violated
 4 │         let r1 = &mut x;
   │                  ------ It is still being mutably borrowed by this reference
 5 │         copy x;
-  │         ^^^^^^ Invalid copy of local 'x'
+  │         ^^^^^^ Invalid copy of variable 'x'
 

--- a/language/move-compiler/tests/move_check/translated_ir_tests/move/borrow_tests/mutate_with_borrowed_loc_invalid.exp
+++ b/language/move-compiler/tests/move_check/translated_ir_tests/move/borrow_tests/mutate_with_borrowed_loc_invalid.exp
@@ -4,5 +4,5 @@ error[E07003]: invalid operation, could create dangling a reference
 4 │         let y = &x;
   │                 -- It is still being borrowed by this reference
 5 │         x = 0;
-  │         ^ Invalid assignment of local 'x'
+  │         ^ Invalid assignment of variable 'x'
 

--- a/language/move-compiler/tests/move_check/translated_ir_tests/move/borrow_tests/mutate_with_borrowed_loc_struct_invalid.exp
+++ b/language/move-compiler/tests/move_check/translated_ir_tests/move/borrow_tests/mutate_with_borrowed_loc_struct_invalid.exp
@@ -18,7 +18,7 @@ error[E07003]: invalid operation, could create dangling a reference
 6 │         let y = &x;
   │                 -- It is still being borrowed by this reference
 7 │         x = X { b: true };
-  │         ^ Invalid assignment of local 'x'
+  │         ^ Invalid assignment of variable 'x'
 
 error[E07003]: invalid operation, could create dangling a reference
    ┌─ tests/move_check/translated_ir_tests/move/borrow_tests/mutate_with_borrowed_loc_struct_invalid.move:16:9
@@ -26,5 +26,5 @@ error[E07003]: invalid operation, could create dangling a reference
 15 │         let z = &y.z;
    │                 ---- It is still being borrowed by this reference
 16 │         s = S { z: 7 };
-   │         ^ Invalid assignment of local 's'
+   │         ^ Invalid assignment of variable 's'
 

--- a/language/move-compiler/tests/move_check/translated_ir_tests/move/signer/read_ref_transitive.exp
+++ b/language/move-compiler/tests/move_check/translated_ir_tests/move/signer/read_ref_transitive.exp
@@ -9,11 +9,11 @@ error[E05001]: ability constraint not satisfied
 5 │         *&x
   │         ^^^ Invalid dereference. Dereference requires the 'copy' ability
 
-error[E05002]: type not implicitly copyable
+error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/translated_ir_tests/move/signer/read_ref_transitive.move:15:9
    │
 14 │         let x = S<signer> { s };
-   │                   ------ The type 'signer' is not implicitly copyable. Implicit copies are limited to simple primitive values
+   │                   ------ The type 'signer' does not have the ability 'copy'
 15 │         x.s
-   │         ^^^ Invalid implicit copy of field 's'. Try adding '*&' to the front of the field access
+   │         ^^^ Invalid implicit copy of field 's' without the 'copy' ability
 

--- a/language/move-compiler/tests/move_check/typing/conditional_drop_invalid.exp
+++ b/language/move-compiler/tests/move_check/typing/conditional_drop_invalid.exp
@@ -38,17 +38,6 @@ error[E05001]: ability constraint not satisfied
    │         Cannot ignore values without the 'drop' ability. The value must be used
    │         The type '0x42::M::Box<0x42::M::Box<T>>' does not have the ability 'drop'
 
-error[E06002]: use of unassigned variable
-   ┌─ tests/move_check/typing/conditional_drop_invalid.move:13:35
-   │
-12 │         Box<T> { f: t };
-   │                     -
-   │                     │
-   │                     The value of 't' was previously moved here.
-   │                     Suggestion: use 'copy t' to avoid the move.
-13 │         Box<Box<T>> { f: Box { f: t } };
-   │                                   ^ Invalid usage of previously moved variable 't'.
-
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/conditional_drop_invalid.move:14:9
    │
@@ -119,18 +108,6 @@ error[E05001]: ability constraint not satisfied
    │         '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
    │         The type '0x42::M::Box<T>' does not have the ability 'drop'
 
-error[E06002]: use of unassigned variable
-   ┌─ tests/move_check/typing/conditional_drop_invalid.move:19:21
-   │
-13 │         Box<Box<T>> { f: Box { f: t } };
-   │                                   -
-   │                                   │
-   │                                   The value of 't' was previously moved here.
-   │                                   Suggestion: use 'copy t' to avoid the move.
-   ·
-19 │         Box<T> { f: t } == Box<T> { f: t };
-   │                     ^ Invalid usage of previously moved variable 't'.
-
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/conditional_drop_invalid.move:19:28
    │
@@ -140,15 +117,6 @@ error[E05001]: ability constraint not satisfied
    │                            │   The type '0x42::M::Box<T>' can have the ability 'drop' but the type argument 'T' does not have the required ability 'drop'
    │                            '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
    │                            The type '0x42::M::Box<T>' does not have the ability 'drop'
-
-error[E06002]: use of unassigned variable
-   ┌─ tests/move_check/typing/conditional_drop_invalid.move:19:40
-   │
-19 │         Box<T> { f: t } == Box<T> { f: t };
-   │                     -                  ^ Invalid usage of previously moved variable 't'.
-   │                     │                   
-   │                     The value of 't' was previously moved here.
-   │                     Suggestion: use 'copy t' to avoid the move.
 
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/conditional_drop_invalid.move:20:9
@@ -160,17 +128,6 @@ error[E05001]: ability constraint not satisfied
    │         '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
    │         The type '0x42::M::Box<0x42::M::Box<T>>' does not have the ability 'drop'
 
-error[E06002]: use of unassigned variable
-   ┌─ tests/move_check/typing/conditional_drop_invalid.move:20:35
-   │
-19 │         Box<T> { f: t } == Box<T> { f: t };
-   │                                        -
-   │                                        │
-   │                                        The value of 't' was previously moved here.
-   │                                        Suggestion: use 'copy t' to avoid the move.
-20 │         Box<Box<T>> { f: Box { f: t } } == Box<Box<T>> { f: Box { f: t} };
-   │                                   ^ Invalid usage of previously moved variable 't'.
-
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/conditional_drop_invalid.move:20:44
    │
@@ -180,15 +137,6 @@ error[E05001]: ability constraint not satisfied
    │                                            │   The type '0x42::M::Box<0x42::M::Box<T>>' can have the ability 'drop' but the type argument '0x42::M::Box<T>' does not have the required ability 'drop'
    │                                            '==' requires the 'drop' ability as the value is consumed. Try borrowing the values with '&' first.'
    │                                            The type '0x42::M::Box<0x42::M::Box<T>>' does not have the ability 'drop'
-
-error[E06002]: use of unassigned variable
-   ┌─ tests/move_check/typing/conditional_drop_invalid.move:20:70
-   │
-20 │         Box<Box<T>> { f: Box { f: t } } == Box<Box<T>> { f: Box { f: t} };
-   │                                   -                                  ^ Invalid usage of previously moved variable 't'.
-   │                                   │                                   
-   │                                   The value of 't' was previously moved here.
-   │                                   Suggestion: use 'copy t' to avoid the move.
 
 error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/conditional_drop_invalid.move:21:9

--- a/language/move-compiler/tests/move_check/typing/implicit_deref_borrow_field_not_copyable.exp
+++ b/language/move-compiler/tests/move_check/typing/implicit_deref_borrow_field_not_copyable.exp
@@ -1,36 +1,24 @@
-error[E05002]: type not implicitly copyable
-  ┌─ tests/move_check/typing/implicit_deref_borrow_field_not_copyable.move:7:10
-  │
-4 │     struct B has drop { s: S, r: R }
-  │                            - The type '0x8675309::M::S' is not implicitly copyable. Implicit copies are limited to simple primitive values
-  ·
-7 │         (b.s: S);
-  │          ^^^ Invalid implicit copy of field 's'. Try adding '*&' to the front of the field access
-
-error[E05002]: type not implicitly copyable
+error[E05001]: ability constraint not satisfied
   ┌─ tests/move_check/typing/implicit_deref_borrow_field_not_copyable.move:8:15
   │
+2 │     struct R has drop {}
+  │            - To satisfy the constraint, the 'copy' ability would need to be added here
+3 │     struct S has copy, drop {}
 4 │     struct B has drop { s: S, r: R }
-  │                                  - The type '0x8675309::M::R' is not implicitly copyable. Implicit copies are limited to simple primitive values
+  │                                  - The type '0x8675309::M::R' does not have the ability 'copy'
   ·
 8 │         R{} = b.r;
-  │               ^^^ Invalid implicit copy of field 'r'. Try adding '*&' to the front of the field access
+  │               ^^^ Invalid implicit copy of field 'r' without the 'copy' ability
 
-error[E05002]: type not implicitly copyable
-   ┌─ tests/move_check/typing/implicit_deref_borrow_field_not_copyable.move:10:10
-   │
- 4 │     struct B has drop { s: S, r: R }
-   │                            - The type '0x8675309::M::S' is not implicitly copyable. Implicit copies are limited to simple primitive values
-   ·
-10 │         (bref.s: S);
-   │          ^^^^^^ Invalid implicit copy of field 's'. Try adding '*&' to the front of the field access
-
-error[E05002]: type not implicitly copyable
+error[E05001]: ability constraint not satisfied
    ┌─ tests/move_check/typing/implicit_deref_borrow_field_not_copyable.move:11:15
    │
+ 2 │     struct R has drop {}
+   │            - To satisfy the constraint, the 'copy' ability would need to be added here
+ 3 │     struct S has copy, drop {}
  4 │     struct B has drop { s: S, r: R }
-   │                                  - The type '0x8675309::M::R' is not implicitly copyable. Implicit copies are limited to simple primitive values
+   │                                  - The type '0x8675309::M::R' does not have the ability 'copy'
    ·
 11 │         R{} = bref.r;
-   │               ^^^^^^ Invalid implicit copy of field 'r'. Try adding '*&' to the front of the field access
+   │               ^^^^^^ Invalid implicit copy of field 'r' without the 'copy' ability
 

--- a/language/move-compiler/tests/move_check/typing/mutate_non_ref.exp
+++ b/language/move-compiler/tests/move_check/typing/mutate_non_ref.exp
@@ -56,15 +56,6 @@ error[E04007]: incompatible types
    │          Invalid mutation. Expected a mutable reference
    │          Expected: '&mut _'
 
-error[E05002]: type not implicitly copyable
-   ┌─ tests/move_check/typing/mutate_non_ref.move:17:10
-   │
- 3 │     struct X has copy, drop { s: S }
-   │                                  - The type '0x8675309::M::S' is not implicitly copyable. Implicit copies are limited to simple primitive values
-   ·
-17 │         *x.s = S { f: 0 };
-   │          ^^^ Invalid implicit copy of field 's'. Try adding '*&' to the front of the field access
-
 error[E04007]: incompatible types
    ┌─ tests/move_check/typing/mutate_non_ref.move:18:10
    │
@@ -88,15 +79,6 @@ error[E04007]: incompatible types
    │          │
    │          Invalid mutation. Expected a mutable reference
    │          Expected: '&mut _'
-
-error[E05002]: type not implicitly copyable
-   ┌─ tests/move_check/typing/mutate_non_ref.move:21:10
-   │
- 3 │     struct X has copy, drop { s: S }
-   │                                  - The type '0x8675309::M::S' is not implicitly copyable. Implicit copies are limited to simple primitive values
-   ·
-21 │         *x_ref.s = S{ f: 0 };
-   │          ^^^^^^^ Invalid implicit copy of field 's'. Try adding '*&' to the front of the field access
 
 error[E04007]: incompatible types
    ┌─ tests/move_check/typing/mutate_non_ref.move:22:10

--- a/language/move-model/src/lib.rs
+++ b/language/move-model/src/lib.rs
@@ -332,7 +332,7 @@ fn add_move_lang_diagnostics(env: &mut GlobalEnv, diags: Diagnostics) {
         let loc = env.to_loc(&loc);
         Label::new(style, loc.file_id(), loc.span()).with_message(msg)
     };
-    for (severity, msg, primary_label, secondary_labels) in diags.into_codespan_format() {
+    for (severity, msg, primary_label, secondary_labels, notes) in diags.into_codespan_format() {
         let diag = Diagnostic::new(severity)
             .with_labels(vec![mk_label(true, primary_label)])
             .with_message(msg)
@@ -341,7 +341,8 @@ fn add_move_lang_diagnostics(env: &mut GlobalEnv, diags: Diagnostics) {
                     .into_iter()
                     .map(|e| mk_label(false, e))
                     .collect(),
-            );
+            )
+            .with_notes(notes);
         env.add_diag(diag);
     }
 }

--- a/language/move-prover/bytecode/tests/borrow/basic_test.exp
+++ b/language/move-prover/bytecode/tests/borrow/basic_test.exp
@@ -33,7 +33,7 @@ fun TestBorrow::test1(): TestBorrow::R {
 fun TestBorrow::test2($t0|x_ref: &mut u64, $t1|v: u64) {
      var $t2: u64
      var $t3: &mut u64
-  0: $t2 := copy($t1)
+  0: $t2 := move($t1)
   1: $t3 := move($t0)
   2: write_ref($t3, $t2)
   3: return ()
@@ -51,7 +51,7 @@ public fun TestBorrow::test3($t0|r_ref: &mut TestBorrow::R, $t1|v: u64) {
   1: $t4 := borrow_field<TestBorrow::R>.x($t3)
   2: $t2 := $t4
   3: $t5 := move($t2)
-  4: $t6 := copy($t1)
+  4: $t6 := move($t1)
   5: TestBorrow::test2($t5, $t6)
   6: return ()
 }
@@ -142,7 +142,7 @@ fun TestBorrow::test7($t0|b: bool) {
   5: $t2 := $t7
   6: $t8 := borrow_local($t1)
   7: $t3 := $t8
-  8: $t9 := copy($t0)
+  8: $t9 := move($t0)
   9: if ($t9) goto 10 else goto 16
  10: label L0
  11: $t10 := move($t3)
@@ -221,13 +221,13 @@ fun TestBorrow::test8($t0|b: bool, $t1|n: u64, $t2|r_ref: &mut TestBorrow::R) {
  29: $t5 := $t21
  30: goto 31
  31: label L6
- 32: $t22 := copy($t1)
+ 32: $t22 := move($t1)
  33: $t23 := 1
  34: $t24 := -($t22, $t23)
  35: $t1 := $t24
  36: goto 9
  37: label L2
- 38: $t25 := copy($t0)
+ 38: $t25 := move($t0)
  39: if ($t25) goto 40 else goto 47
  40: label L8
  41: $t26 := move($t5)

--- a/language/move-prover/bytecode/tests/borrow/hyper_edge.exp
+++ b/language/move-prover/bytecode/tests/borrow/hyper_edge.exp
@@ -85,7 +85,7 @@ public fun Collection::borrow_mut<#0>($t0|c: &mut Collection::Collection<#0>, $t
      var $t5: &mut #0
   0: $t2 := move($t0)
   1: $t3 := borrow_field<Collection::Collection<#0>>.items($t2)
-  2: $t4 := copy($t1)
+  2: $t4 := move($t1)
   3: $t5 := Vector::borrow_mut<#0>($t3, $t4)
   4: return $t5
 }
@@ -117,7 +117,7 @@ public fun Test::foo<#0>($t0|i: u64) {
   0: $t3 := Collection::make_collection<Test::Token<#0>>()
   1: $t1 := $t3
   2: $t4 := borrow_local($t1)
-  3: $t5 := copy($t0)
+  3: $t5 := move($t0)
   4: $t6 := Collection::borrow_mut<Test::Token<#0>>($t4, $t5)
   5: $t2 := $t6
   6: $t7 := 0

--- a/language/move-prover/bytecode/tests/borrow_strong/basic_test.exp
+++ b/language/move-prover/bytecode/tests/borrow_strong/basic_test.exp
@@ -65,7 +65,7 @@ fun TestBorrow::test10($t0|b: bool): TestBorrow::R {
  11: label L0
  12: $t11 := move($t2)
  13: destroy($t11)
- 14: $t12 := copy($t0)
+ 14: $t12 := move($t0)
  15: $t13 := move($t3)
  16: $t14 := TestBorrow::test9($t12, $t13)
  17: $t2 := $t14
@@ -87,7 +87,7 @@ fun TestBorrow::test10($t0|b: bool): TestBorrow::R {
 fun TestBorrow::test2($t0|x_ref: &mut u64, $t1|v: u64) {
      var $t2: u64
      var $t3: &mut u64
-  0: $t2 := copy($t1)
+  0: $t2 := move($t1)
   1: $t3 := move($t0)
   2: write_ref($t3, $t2)
   3: return ()
@@ -105,7 +105,7 @@ public fun TestBorrow::test3($t0|r_ref: &mut TestBorrow::R, $t1|v: u64) {
   1: $t4 := borrow_field<TestBorrow::R>.x($t3)
   2: $t2 := $t4
   3: $t5 := move($t2)
-  4: $t6 := copy($t1)
+  4: $t6 := move($t1)
   5: TestBorrow::test2($t5, $t6)
   6: return ()
 }
@@ -204,7 +204,7 @@ fun TestBorrow::test7($t0|b: bool) {
   7: $t2 := $t9
   8: $t10 := borrow_local($t1)
   9: $t3 := $t10
- 10: $t11 := copy($t0)
+ 10: $t11 := move($t0)
  11: if ($t11) goto 12 else goto 18
  12: label L0
  13: $t12 := move($t3)
@@ -287,13 +287,13 @@ fun TestBorrow::test8($t0|b: bool, $t1|n: u64, $t2|r_ref: &mut TestBorrow::R) {
  31: $t5 := $t23
  32: goto 33
  33: label L6
- 34: $t24 := copy($t1)
+ 34: $t24 := move($t1)
  35: $t25 := 1
  36: $t26 := -($t24, $t25)
  37: $t1 := $t26
  38: goto 11
  39: label L2
- 40: $t27 := copy($t0)
+ 40: $t27 := move($t0)
  41: if ($t27) goto 42 else goto 49
  42: label L8
  43: $t28 := move($t5)
@@ -330,7 +330,7 @@ fun TestBorrow::test9($t0|b: bool, $t1|r_ref: &mut TestBorrow::R): &mut u64 {
   0: $t3 := copy($t1)
   1: $t4 := borrow_field<TestBorrow::R>.x($t3)
   2: $t2 := $t4
-  3: $t5 := copy($t0)
+  3: $t5 := move($t0)
   4: if ($t5) goto 5 else goto 12
   5: label L0
   6: $t6 := move($t2)

--- a/language/move-prover/bytecode/tests/borrow_strong/mut_ref.exp
+++ b/language/move-prover/bytecode/tests/borrow_strong/mut_ref.exp
@@ -96,7 +96,7 @@ fun TestMutRef::call_return_ref_different_path($t0|b: bool): TestMutRef::N {
   2: $t5 := pack TestMutRef::T($t4)
   3: $t6 := pack TestMutRef::N($t3, $t5)
   4: $t2 := $t6
-  5: $t7 := copy($t0)
+  5: $t7 := move($t0)
   6: $t8 := borrow_local($t2)
   7: $t9 := TestMutRef::return_ref_different_path($t7, $t8)
   8: $t1 := $t9
@@ -143,7 +143,7 @@ fun TestMutRef::call_return_ref_different_path_vec($t0|b: bool): TestMutRef::V {
  11: $t12 := move($t3)
  12: $t13 := pack TestMutRef::V($t11, $t12)
  13: $t4 := $t13
- 14: $t14 := copy($t0)
+ 14: $t14 := move($t0)
  15: $t15 := borrow_local($t4)
  16: $t16 := TestMutRef::return_ref_different_path_vec($t14, $t15)
  17: $t2 := $t16
@@ -204,7 +204,7 @@ fun TestMutRef::call_return_ref_different_path_vec2($t0|b: bool): TestMutRef::V 
  19: $t18 := move($t3)
  20: $t19 := pack TestMutRef::V($t17, $t18)
  21: $t4 := $t19
- 22: $t20 := copy($t0)
+ 22: $t20 := move($t0)
  23: $t21 := borrow_local($t4)
  24: $t22 := TestMutRef::return_ref_different_path_vec2($t20, $t21)
  25: $t2 := $t22
@@ -265,7 +265,7 @@ fun TestMutRef::call_return_ref_different_path_vec2_incorrect($t0|b: bool): Test
  19: $t18 := move($t3)
  20: $t19 := pack TestMutRef::V($t17, $t18)
  21: $t4 := $t19
- 22: $t20 := copy($t0)
+ 22: $t20 := move($t0)
  23: $t21 := borrow_local($t4)
  24: $t22 := TestMutRef::return_ref_different_path_vec2($t20, $t21)
  25: $t2 := $t22
@@ -300,7 +300,7 @@ fun TestMutRef::call_return_ref_different_root($t0|b: bool): (TestMutRef::T, Tes
   3: $t6 := 10
   4: $t7 := pack TestMutRef::R($t6)
   5: $t3 := $t7
-  6: $t8 := copy($t0)
+  6: $t8 := move($t0)
   7: $t9 := borrow_local($t2)
   8: $t10 := borrow_local($t3)
   9: $t11 := TestMutRef::return_ref_different_root($t8, $t9, $t10)
@@ -324,7 +324,7 @@ fun TestMutRef::return_ref_different_path($t0|b: bool, $t1|x: &mut TestMutRef::N
      var $t7: &mut TestMutRef::T
      var $t8: &mut u64
      var $t9: &mut u64
-  0: $t3 := copy($t0)
+  0: $t3 := move($t0)
   1: if ($t3) goto 2 else goto 7
   2: label L0
   3: $t4 := move($t1)
@@ -356,7 +356,7 @@ fun TestMutRef::return_ref_different_path_vec($t0|b: bool, $t1|x: &mut TestMutRe
      var $t10: u64
      var $t11: &mut u64
      var $t12: &mut u64
-  0: $t3 := copy($t0)
+  0: $t3 := move($t0)
   1: if ($t3) goto 2 else goto 9
   2: label L0
   3: $t4 := move($t1)
@@ -392,7 +392,7 @@ fun TestMutRef::return_ref_different_path_vec2($t0|b: bool, $t1|x: &mut TestMutR
      var $t11: &mut TestMutRef::T
      var $t12: &mut u64
      var $t13: &mut u64
-  0: $t3 := copy($t0)
+  0: $t3 := move($t0)
   1: if ($t3) goto 2 else goto 9
   2: label L0
   3: $t4 := move($t1)
@@ -426,7 +426,7 @@ fun TestMutRef::return_ref_different_root($t0|b: bool, $t1|x: &mut TestMutRef::T
      var $t9: &mut TestMutRef::R
      var $t10: &mut u64
      var $t11: &mut u64
-  0: $t4 := copy($t0)
+  0: $t4 := move($t0)
   1: if ($t4) goto 2 else goto 9
   2: label L0
   3: $t5 := move($t2)

--- a/language/move-prover/bytecode/tests/escape_analysis/global_spec_relevance.exp
+++ b/language/move-prover/bytecode/tests/escape_analysis/global_spec_relevance.exp
@@ -5,8 +5,8 @@ public fun GlobalSpecRelevance::create($t0|i: u64, $t1|j: u64): GlobalSpecReleva
      var $t2: u64
      var $t3: u64
      var $t4: GlobalSpecRelevance::Nonzero
-  0: $t2 := copy($t0)
-  1: $t3 := copy($t1)
+  0: $t2 := move($t0)
+  1: $t3 := move($t1)
   2: $t4 := pack GlobalSpecRelevance::Nonzero($t2, $t3)
   3: return $t4
 }
@@ -68,8 +68,8 @@ public fun GlobalSpecRelevance::create($t0|i: u64, $t1|j: u64): GlobalSpecReleva
      var $t2: u64
      var $t3: u64
      var $t4: GlobalSpecRelevance::Nonzero
-  0: $t2 := copy($t0)
-  1: $t3 := copy($t1)
+  0: $t2 := move($t0)
+  1: $t3 := move($t1)
   2: $t4 := pack GlobalSpecRelevance::Nonzero($t2, $t3)
   3: return $t4
 }

--- a/language/move-prover/bytecode/tests/escape_analysis/return_internal_refs.exp
+++ b/language/move-prover/bytecode/tests/escape_analysis/return_internal_refs.exp
@@ -20,7 +20,7 @@ fun LeakInternalRefs::leak_in_branch($t0|b: bool, $t1|x: &mut u64, $t2|s: &mut L
      var $t8: &mut LeakInternalRefs::S
      var $t9: &mut u64
      var $t10: &mut u64
-  0: $t4 := copy($t0)
+  0: $t4 := move($t0)
   1: if ($t4) goto 2 else goto 8
   2: label L0
   3: $t5 := move($t2)
@@ -79,7 +79,7 @@ fun LeakInternalRefs::leak_in_loop($t0|x: &mut u64, $t1|s: &mut LeakInternalRefs
  17: $t12 := borrow_field<LeakInternalRefs::S>.f($t11)
  18: return $t12
  19: label L5
- 20: $t13 := copy($t2)
+ 20: $t13 := move($t2)
  21: $t14 := 1
  22: $t15 := +($t13, $t14)
  23: $t2 := $t15
@@ -150,7 +150,7 @@ fun LeakInternalRefs::leak_in_branch($t0|b: bool, $t1|x: &mut u64, $t2|s: &mut L
      var $t8: &mut LeakInternalRefs::S
      var $t9: &mut u64
      var $t10: &mut u64
-  0: $t4 := copy($t0)
+  0: $t4 := move($t0)
   1: if ($t4) goto 2 else goto 8
   2: label L0
   3: $t5 := move($t2)
@@ -209,7 +209,7 @@ fun LeakInternalRefs::leak_in_loop($t0|x: &mut u64, $t1|s: &mut LeakInternalRefs
  17: $t12 := borrow_field<LeakInternalRefs::S>.f($t11)
  18: return $t12
  19: label L5
- 20: $t13 := copy($t2)
+ 20: $t13 := move($t2)
  21: $t14 := 1
  22: $t15 := +($t13, $t14)
  23: $t2 := $t15

--- a/language/move-prover/bytecode/tests/escape_analysis/struct_spec_relevance.exp
+++ b/language/move-prover/bytecode/tests/escape_analysis/struct_spec_relevance.exp
@@ -17,8 +17,8 @@ public fun StructSpecRelevance::create($t0|i: u64, $t1|j: u64): StructSpecReleva
   5: $t5 := 0
   6: abort($t5)
   7: label L0
-  8: $t6 := copy($t0)
-  9: $t7 := copy($t1)
+  8: $t6 := move($t0)
+  9: $t7 := move($t1)
  10: $t8 := pack StructSpecRelevance::Nonzero($t6, $t7)
  11: return $t8
 }
@@ -62,8 +62,8 @@ public fun StructSpecRelevance::create($t0|i: u64, $t1|j: u64): StructSpecReleva
   5: $t5 := 0
   6: abort($t5)
   7: label L0
-  8: $t6 := copy($t0)
-  9: $t7 := copy($t1)
+  8: $t6 := move($t0)
+  9: $t7 := move($t1)
  10: $t8 := pack StructSpecRelevance::Nonzero($t6, $t7)
  11: return $t8
 }

--- a/language/move-prover/bytecode/tests/from_move/regression_generic_and_native_type.exp
+++ b/language/move-prover/bytecode/tests/from_move/regression_generic_and_native_type.exp
@@ -138,7 +138,7 @@ public fun Diem::preburn<#0>($t0|preburn_ref: &mut Diem::Preburn<#0>, $t1|coin: 
  10: $t11 := copy($t3)
  11: $t12 := borrow_field<Diem::Info<#0>>.preburn_value($t11)
  12: $t13 := read_ref($t12)
- 13: $t14 := copy($t2)
+ 13: $t14 := move($t2)
  14: $t15 := +($t13, $t14)
  15: $t16 := move($t3)
  16: $t17 := borrow_field<Diem::Info<#0>>.preburn_value($t16)

--- a/language/move-prover/bytecode/tests/from_move/smoke_test.exp
+++ b/language/move-prover/bytecode/tests/from_move/smoke_test.exp
@@ -36,8 +36,8 @@ fun SmokeTest::arithmetic_ops($t0|a: u64): (u64, u64) {
   7: $t6 := 42
   8: abort($t6)
   9: label L2
- 10: $t7 := copy($t1)
- 11: $t8 := copy($t0)
+ 10: $t7 := move($t1)
+ 11: $t8 := move($t0)
  12: return ($t7, $t8)
 }
 
@@ -97,8 +97,8 @@ fun SmokeTest::bool_ops($t0|a: u64, $t1|b: u64): (bool, bool) {
  23: $t3 := $t17
  24: goto 31
  25: label L6
- 26: $t18 := copy($t0)
- 27: $t19 := copy($t1)
+ 26: $t18 := move($t0)
+ 27: $t19 := move($t1)
  28: $t20 := <=($t18, $t19)
  29: $t3 := $t20
  30: goto 31
@@ -114,8 +114,8 @@ fun SmokeTest::bool_ops($t0|a: u64, $t1|b: u64): (bool, bool) {
  40: $t26 := 42
  41: abort($t26)
  42: label L10
- 43: $t27 := copy($t4)
- 44: $t28 := copy($t5)
+ 43: $t27 := move($t4)
+ 44: $t28 := move($t5)
  45: return ($t27, $t28)
 }
 
@@ -135,7 +135,7 @@ fun SmokeTest::borrow_global_mut_test($t0|a: address) {
   2: $t1 := $t4
   3: $t5 := move($t1)
   4: destroy($t5)
-  5: $t6 := copy($t0)
+  5: $t6 := move($t0)
   6: $t7 := borrow_global<SmokeTest::R>($t6)
   7: $t2 := $t7
   8: $t8 := move($t2)
@@ -201,7 +201,7 @@ fun SmokeTest::move_from_addr($t0|a: address) {
      var $t3: SmokeTest::R
      var $t4: SmokeTest::R
      var $t5: u64
-  0: $t2 := copy($t0)
+  0: $t2 := move($t0)
   1: $t3 := move_from<SmokeTest::R>($t2)
   2: $t1 := $t3
   3: $t4 := move($t1)
@@ -222,14 +222,14 @@ fun SmokeTest::move_from_addr_to_sender($t0|sender: &signer, $t1|a: address) {
      var $t8: &signer
      var $t9: u64
      var $t10: SmokeTest::R
-  0: $t4 := copy($t1)
+  0: $t4 := move($t1)
   1: $t5 := move_from<SmokeTest::R>($t4)
   2: $t2 := $t5
   3: $t6 := move($t2)
   4: $t7 := unpack SmokeTest::R($t6)
   5: $t3 := $t7
   6: $t8 := move($t0)
-  7: $t9 := copy($t3)
+  7: $t9 := move($t3)
   8: $t10 := pack SmokeTest::R($t9)
   9: move_to<SmokeTest::R>($t10, $t8)
  10: return ()
@@ -241,8 +241,8 @@ fun SmokeTest::pack_A($t0|a: address, $t1|va: u64): SmokeTest::A {
      var $t2: address
      var $t3: u64
      var $t4: SmokeTest::A
-  0: $t2 := copy($t0)
-  1: $t3 := copy($t1)
+  0: $t2 := move($t0)
+  1: $t3 := move($t1)
   2: $t4 := pack SmokeTest::A($t2, $t3)
   3: return $t4
 }
@@ -259,11 +259,11 @@ fun SmokeTest::pack_B($t0|a: address, $t1|va: u64, $t2|vb: u64): SmokeTest::B {
      var $t9: SmokeTest::A
      var $t10: SmokeTest::B
      var $t11: SmokeTest::B
-  0: $t5 := copy($t0)
-  1: $t6 := copy($t1)
+  0: $t5 := move($t0)
+  1: $t6 := move($t1)
   2: $t7 := pack SmokeTest::A($t5, $t6)
   3: $t3 := $t7
-  4: $t8 := copy($t2)
+  4: $t8 := move($t2)
   5: $t9 := move($t3)
   6: $t10 := pack SmokeTest::B($t8, $t9)
   7: $t4 := $t10
@@ -287,15 +287,15 @@ fun SmokeTest::pack_C($t0|a: address, $t1|va: u64, $t2|vb: u64, $t3|vc: u64): Sm
      var $t14: SmokeTest::B
      var $t15: SmokeTest::C
      var $t16: SmokeTest::C
-  0: $t7 := copy($t0)
-  1: $t8 := copy($t1)
+  0: $t7 := move($t0)
+  1: $t8 := move($t1)
   2: $t9 := pack SmokeTest::A($t7, $t8)
   3: $t4 := $t9
-  4: $t10 := copy($t2)
+  4: $t10 := move($t2)
   5: $t11 := move($t4)
   6: $t12 := pack SmokeTest::B($t10, $t11)
   7: $t5 := $t12
-  8: $t13 := copy($t3)
+  8: $t13 := move($t3)
   9: $t14 := move($t5)
  10: $t15 := pack SmokeTest::C($t13, $t14)
  11: $t6 := $t15
@@ -329,16 +329,16 @@ fun SmokeTest::ref_A($t0|a: address, $t1|b: bool): SmokeTest::A {
      var $t22: bool
      var $t23: u64
      var $t24: SmokeTest::A
-  0: $t7 := copy($t1)
+  0: $t7 := move($t1)
   1: if ($t7) goto 2 else goto 8
   2: label L0
-  3: $t8 := copy($t0)
+  3: $t8 := move($t0)
   4: $t9 := 1
   5: $t10 := pack SmokeTest::A($t8, $t9)
   6: $t2 := $t10
   7: goto 14
   8: label L2
-  9: $t11 := copy($t0)
+  9: $t11 := move($t0)
  10: $t12 := 42
  11: $t13 := pack SmokeTest::A($t11, $t12)
  12: $t2 := $t13
@@ -354,7 +354,7 @@ fun SmokeTest::ref_A($t0|a: address, $t1|b: bool): SmokeTest::A {
  22: $t18 := move($t3)
  23: $t19 := read_ref($t18)
  24: $t4 := $t19
- 25: $t20 := copy($t4)
+ 25: $t20 := move($t4)
  26: $t21 := 42
  27: $t22 := !=($t20, $t21)
  28: if ($t22) goto 29 else goto 32
@@ -380,16 +380,16 @@ fun SmokeTest::unpack_A($t0|a: address, $t1|va: u64): (address, u64) {
      var $t10: u64
      var $t11: address
      var $t12: u64
-  0: $t5 := copy($t0)
-  1: $t6 := copy($t1)
+  0: $t5 := move($t0)
+  1: $t6 := move($t1)
   2: $t7 := pack SmokeTest::A($t5, $t6)
   3: $t4 := $t7
   4: $t8 := move($t4)
   5: ($t9, $t10) := unpack SmokeTest::A($t8)
   6: $t3 := $t10
   7: $t2 := $t9
-  8: $t11 := copy($t2)
-  9: $t12 := copy($t3)
+  8: $t11 := move($t2)
+  9: $t12 := move($t3)
  10: return ($t11, $t12)
 }
 
@@ -415,11 +415,11 @@ fun SmokeTest::unpack_B($t0|a: address, $t1|va: u64, $t2|vb: u64): (address, u64
      var $t19: address
      var $t20: u64
      var $t21: u64
-  0: $t8 := copy($t0)
-  1: $t9 := copy($t1)
+  0: $t8 := move($t0)
+  1: $t9 := move($t1)
   2: $t10 := pack SmokeTest::A($t8, $t9)
   3: $t6 := $t10
-  4: $t11 := copy($t2)
+  4: $t11 := move($t2)
   5: $t12 := move($t6)
   6: $t13 := pack SmokeTest::B($t11, $t12)
   7: $t7 := $t13
@@ -429,9 +429,9 @@ fun SmokeTest::unpack_B($t0|a: address, $t1|va: u64, $t2|vb: u64): (address, u64
  11: $t4 := $t18
  12: $t3 := $t17
  13: $t5 := $t15
- 14: $t19 := copy($t3)
- 15: $t20 := copy($t4)
- 16: $t21 := copy($t5)
+ 14: $t19 := move($t3)
+ 15: $t20 := move($t4)
+ 16: $t21 := move($t5)
  17: return ($t19, $t20, $t21)
 }
 
@@ -465,15 +465,15 @@ fun SmokeTest::unpack_C($t0|a: address, $t1|va: u64, $t2|vb: u64, $t3|vc: u64): 
      var $t28: u64
      var $t29: u64
      var $t30: u64
-  0: $t11 := copy($t0)
-  1: $t12 := copy($t1)
+  0: $t11 := move($t0)
+  1: $t12 := move($t1)
   2: $t13 := pack SmokeTest::A($t11, $t12)
   3: $t8 := $t13
-  4: $t14 := copy($t2)
+  4: $t14 := move($t2)
   5: $t15 := move($t8)
   6: $t16 := pack SmokeTest::B($t14, $t15)
   7: $t9 := $t16
-  8: $t17 := copy($t3)
+  8: $t17 := move($t3)
   9: $t18 := move($t9)
  10: $t19 := pack SmokeTest::C($t17, $t18)
  11: $t10 := $t19
@@ -485,9 +485,9 @@ fun SmokeTest::unpack_C($t0|a: address, $t1|va: u64, $t2|vb: u64, $t3|vc: u64): 
  17: $t4 := $t25
  18: $t6 := $t23
  19: $t7 := $t21
- 20: $t27 := copy($t4)
- 21: $t28 := copy($t5)
- 22: $t29 := copy($t6)
- 23: $t30 := copy($t7)
+ 20: $t27 := move($t4)
+ 21: $t28 := move($t5)
+ 22: $t29 := move($t6)
+ 23: $t30 := move($t7)
  24: return ($t27, $t28, $t29, $t30)
 }

--- a/language/move-prover/bytecode/tests/from_move/specs-in-fun.exp
+++ b/language/move-prover/bytecode/tests/from_move/specs-in-fun.exp
@@ -18,14 +18,14 @@ fun TestSpecBlock::looping($t0|x: u64): u64 {
   6: if ($t3) goto 7 else goto 14
   7: label L0
   8: assume Lt($t0, 10)
-  9: $t4 := copy($t0)
+  9: $t4 := move($t0)
  10: $t5 := 1
  11: $t6 := +($t4, $t5)
  12: $t0 := $t6
  13: goto 2
  14: label L2
  15: assert Eq<u64>($t0, 10)
- 16: $t7 := copy($t0)
+ 16: $t7 := move($t0)
  17: return $t7
 }
 

--- a/language/move-prover/bytecode/tests/global_invariant_analysis/mutual_inst.exp
+++ b/language/move-prover/bytecode/tests/global_invariant_analysis/mutual_inst.exp
@@ -8,8 +8,8 @@ public fun S::publish_u64_bool($t0|account: signer, $t1|x: u64, $t2|y: bool) {
      var $t6: u8
      var $t7: S::Storage<u64, bool>
   0: $t3 := borrow_local($t0)
-  1: $t4 := copy($t1)
-  2: $t5 := copy($t2)
+  1: $t4 := move($t1)
+  2: $t5 := move($t2)
   3: $t6 := 0
   4: $t7 := pack S::Storage<u64, bool>($t4, $t5, $t6)
   5: move_to<S::Storage<u64, bool>>($t7, $t3)
@@ -25,7 +25,7 @@ public fun S::publish_u64_y<#0>($t0|account: signer, $t1|x: u64, $t2|y: #0) {
      var $t6: u8
      var $t7: S::Storage<u64, #0>
   0: $t3 := borrow_local($t0)
-  1: $t4 := copy($t1)
+  1: $t4 := move($t1)
   2: $t5 := move($t2)
   3: $t6 := 1
   4: $t7 := pack S::Storage<u64, #0>($t4, $t5, $t6)
@@ -43,7 +43,7 @@ public fun S::publish_x_bool<#0>($t0|account: signer, $t1|x: #0, $t2|y: bool) {
      var $t7: S::Storage<#0, bool>
   0: $t3 := borrow_local($t0)
   1: $t4 := move($t1)
-  2: $t5 := copy($t2)
+  2: $t5 := move($t2)
   3: $t6 := 2
   4: $t7 := pack S::Storage<#0, bool>($t4, $t5, $t6)
   5: move_to<S::Storage<#0, bool>>($t7, $t3)

--- a/language/move-prover/bytecode/tests/global_invariant_analysis/uninst_type_param_in_inv.exp
+++ b/language/move-prover/bytecode/tests/global_invariant_analysis/uninst_type_param_in_inv.exp
@@ -30,7 +30,7 @@ fun Demo::f1($t0|addr: address) {
  13: if ($t8) goto 14 else goto 21
  14: label L3
  15: $t9 := 0
- 16: $t10 := copy($t0)
+ 16: $t10 := move($t0)
  17: $t11 := borrow_global<Demo::S1<u64>>($t10)
  18: $t12 := borrow_field<Demo::S1<u64>>.v($t11)
  19: write_ref($t12, $t9)

--- a/language/move-prover/bytecode/tests/global_invariant_instrumentation/borrow.exp
+++ b/language/move-prover/bytecode/tests/global_invariant_instrumentation/borrow.exp
@@ -12,7 +12,7 @@ public fun Test::borrow($t0|a: address) {
      var $t8: u64
      var $t9: &mut Test::R
      var $t10: &mut u64
-  0: $t2 := copy($t0)
+  0: $t2 := move($t0)
   1: $t3 := borrow_global<Test::R>($t2)
   2: $t1 := $t3
   3: $t4 := copy($t1)

--- a/language/move-prover/bytecode/tests/global_invariant_instrumentation/move.exp
+++ b/language/move-prover/bytecode/tests/global_invariant_instrumentation/move.exp
@@ -17,7 +17,7 @@ public fun Test::publish($t0|s: &signer) {
 public fun Test::remove($t0|a: address): Test::R {
      var $t1: address
      var $t2: Test::R
-  0: $t1 := copy($t0)
+  0: $t1 := move($t0)
   1: $t2 := move_from<Test::R>($t1)
   2: return $t2
 }

--- a/language/move-prover/bytecode/tests/global_invariant_instrumentation/update.exp
+++ b/language/move-prover/bytecode/tests/global_invariant_instrumentation/update.exp
@@ -12,7 +12,7 @@ public fun Test::incr($t0|a: address) {
      var $t8: u64
      var $t9: &mut Test::R
      var $t10: &mut u64
-  0: $t2 := copy($t0)
+  0: $t2 := move($t0)
   1: $t3 := borrow_global<Test::R>($t2)
   2: $t1 := $t3
   3: $t4 := copy($t1)

--- a/language/move-prover/bytecode/tests/livevar/basic_test.exp
+++ b/language/move-prover/bytecode/tests/livevar/basic_test.exp
@@ -39,7 +39,7 @@ fun TestLiveVars::test2($t0|b: bool): u64 {
   5: $t2 := $t7
   6: $t8 := borrow_local($t1)
   7: $t3 := $t8
-  8: $t9 := copy($t0)
+  8: $t9 := move($t0)
   9: if ($t9) goto 10 else goto 16
  10: label L0
  11: $t10 := move($t3)
@@ -108,7 +108,7 @@ fun TestLiveVars::test3($t0|n: u64, $t1|r_ref: &TestLiveVars::R): u64 {
  27: $t1 := $t18
  28: goto 29
  29: label L6
- 30: $t19 := copy($t0)
+ 30: $t19 := move($t0)
  31: $t20 := 1
  32: $t21 := -($t19, $t20)
  33: $t0 := $t21

--- a/language/move-prover/bytecode/tests/memory_instr/basic_test.exp
+++ b/language/move-prover/bytecode/tests/memory_instr/basic_test.exp
@@ -33,7 +33,7 @@ fun TestPackref::test1(): TestPackref::R {
 fun TestPackref::test2($t0|x_ref: &mut u64, $t1|v: u64) {
      var $t2: u64
      var $t3: &mut u64
-  0: $t2 := copy($t1)
+  0: $t2 := move($t1)
   1: $t3 := move($t0)
   2: write_ref($t3, $t2)
   3: return ()
@@ -51,7 +51,7 @@ public fun TestPackref::test3($t0|r_ref: &mut TestPackref::R, $t1|v: u64) {
   1: $t4 := borrow_field<TestPackref::R>.x($t3)
   2: $t2 := $t4
   3: $t5 := move($t2)
-  4: $t6 := copy($t1)
+  4: $t6 := move($t1)
   5: TestPackref::test2($t5, $t6)
   6: return ()
 }
@@ -142,7 +142,7 @@ fun TestPackref::test7($t0|b: bool) {
   5: $t2 := $t7
   6: $t8 := borrow_local($t1)
   7: $t3 := $t8
-  8: $t9 := copy($t0)
+  8: $t9 := move($t0)
   9: if ($t9) goto 10 else goto 16
  10: label L0
  11: $t10 := move($t3)
@@ -221,13 +221,13 @@ fun TestPackref::test8($t0|b: bool, $t1|n: u64, $t2|r_ref: &mut TestPackref::R) 
  29: $t5 := $t21
  30: goto 31
  31: label L6
- 32: $t22 := copy($t1)
+ 32: $t22 := move($t1)
  33: $t23 := 1
  34: $t24 := -($t22, $t23)
  35: $t1 := $t24
  36: goto 9
  37: label L2
- 38: $t25 := copy($t0)
+ 38: $t25 := move($t0)
  39: if ($t25) goto 40 else goto 47
  40: label L8
  41: $t26 := move($t5)

--- a/language/move-prover/bytecode/tests/memory_instr/mut_ref.exp
+++ b/language/move-prover/bytecode/tests/memory_instr/mut_ref.exp
@@ -72,7 +72,7 @@ public fun TestMutRefs::delete($t0|x: TestMutRefs::T) {
   6: $t7 := copy($t1)
   7: $t8 := borrow_field<TestMutRefs::TSum>.sum($t7)
   8: $t9 := read_ref($t8)
-  9: $t10 := copy($t2)
+  9: $t10 := move($t2)
  10: $t11 := -($t9, $t10)
  11: $t12 := move($t1)
  12: $t13 := borrow_field<TestMutRefs::TSum>.sum($t12)
@@ -169,7 +169,7 @@ public fun TestMutRefs::new($t0|x: u64): TestMutRefs::T {
   8: $t9 := move($t1)
   9: $t10 := borrow_field<TestMutRefs::TSum>.sum($t9)
  10: write_ref($t10, $t8)
- 11: $t11 := copy($t0)
+ 11: $t11 := move($t0)
  12: $t12 := pack TestMutRefs::T($t11)
  13: return $t12
 }

--- a/language/move-prover/bytecode/tests/mono_analysis/test.exp
+++ b/language/move-prover/bytecode/tests/mono_analysis/test.exp
@@ -17,7 +17,7 @@ public fun Test::f2($t0|x: u8): Test::B<u8> {
      var $t1: u8
      var $t2: Test::A<u8, u64>
      var $t3: Test::B<u8>
-  0: $t1 := copy($t0)
+  0: $t1 := move($t0)
   1: $t2 := Test::f1<u8>($t1)
   2: $t3 := pack Test::B<u8>($t2)
   3: return $t3

--- a/language/move-prover/bytecode/tests/mut_ref_instrumentation/basic_test.exp
+++ b/language/move-prover/bytecode/tests/mut_ref_instrumentation/basic_test.exp
@@ -33,7 +33,7 @@ fun TestEliminateMutRefs::test1(): TestEliminateMutRefs::R {
 fun TestEliminateMutRefs::test2($t0|x_ref: &mut u64, $t1|v: u64) {
      var $t2: u64
      var $t3: &mut u64
-  0: $t2 := copy($t1)
+  0: $t2 := move($t1)
   1: $t3 := move($t0)
   2: write_ref($t3, $t2)
   3: return ()
@@ -51,7 +51,7 @@ public fun TestEliminateMutRefs::test3($t0|r_ref: &mut TestEliminateMutRefs::R, 
   1: $t4 := borrow_field<TestEliminateMutRefs::R>.x($t3)
   2: $t2 := $t4
   3: $t5 := move($t2)
-  4: $t6 := copy($t1)
+  4: $t6 := move($t1)
   5: TestEliminateMutRefs::test2($t5, $t6)
   6: return ()
 }
@@ -142,7 +142,7 @@ fun TestEliminateMutRefs::test7($t0|b: bool) {
   5: $t2 := $t7
   6: $t8 := borrow_local($t1)
   7: $t3 := $t8
-  8: $t9 := copy($t0)
+  8: $t9 := move($t0)
   9: if ($t9) goto 10 else goto 16
  10: label L0
  11: $t10 := move($t3)
@@ -221,13 +221,13 @@ fun TestEliminateMutRefs::test8($t0|b: bool, $t1|n: u64, $t2|r_ref: &mut TestEli
  29: $t5 := $t21
  30: goto 31
  31: label L6
- 32: $t22 := copy($t1)
+ 32: $t22 := move($t1)
  33: $t23 := 1
  34: $t24 := -($t22, $t23)
  35: $t1 := $t24
  36: goto 9
  37: label L2
- 38: $t25 := copy($t0)
+ 38: $t25 := move($t0)
  39: if ($t25) goto 40 else goto 47
  40: label L8
  41: $t26 := move($t5)
@@ -282,7 +282,7 @@ fun TestEliminateMutRefs::test1(): TestEliminateMutRefs::R {
 fun TestEliminateMutRefs::test2($t0|x_ref: &mut u64, $t1|v: u64) {
      var $t2: u64
      var $t3: &mut u64
-  0: $t2 := copy($t1)
+  0: $t2 := move($t1)
   1: $t3 := copy($t0)
   2: write_ref($t3, $t2)
   3: trace_local[x_ref]($t0)
@@ -301,7 +301,7 @@ public fun TestEliminateMutRefs::test3($t0|r_ref: &mut TestEliminateMutRefs::R, 
   1: $t4 := borrow_field<TestEliminateMutRefs::R>.x($t3)
   2: $t2 := $t4
   3: $t5 := move($t2)
-  4: $t6 := copy($t1)
+  4: $t6 := move($t1)
   5: TestEliminateMutRefs::test2($t5, $t6)
   6: trace_local[r_ref]($t0)
   7: return ()
@@ -394,7 +394,7 @@ fun TestEliminateMutRefs::test7($t0|b: bool) {
   5: $t2 := $t7
   6: $t8 := borrow_local($t1)
   7: $t3 := $t8
-  8: $t9 := copy($t0)
+  8: $t9 := move($t0)
   9: if ($t9) goto 10 else goto 15
  10: label L0
  11: $t10 := move($t3)
@@ -470,13 +470,13 @@ fun TestEliminateMutRefs::test8($t0|b: bool, $t1|n: u64, $t2|r_ref: &mut TestEli
  27: $t21 := borrow_local($t4)
  28: $t5 := $t21
  29: label L6
- 30: $t22 := copy($t1)
+ 30: $t22 := move($t1)
  31: $t23 := 1
  32: $t24 := -($t22, $t23)
  33: $t1 := $t24
  34: goto 8
  35: label L2
- 36: $t25 := copy($t0)
+ 36: $t25 := move($t0)
  37: if ($t25) goto 38 else goto 45
  38: label L8
  39: $t26 := move($t5)

--- a/language/move-prover/bytecode/tests/reaching_def/basic_test.exp
+++ b/language/move-prover/bytecode/tests/reaching_def/basic_test.exp
@@ -12,12 +12,12 @@ fun ReachingDefTest::basic($t0|a: u64, $t1|b: u64): u64 {
      var $t9: u64
      var $t10: u64
   0: $t3 := copy($t0)
-  1: $t4 := copy($t1)
+  1: $t4 := move($t1)
   2: $t5 := +($t3, $t4)
-  3: $t6 := copy($t0)
+  3: $t6 := move($t0)
   4: $t7 := /($t5, $t6)
   5: $t2 := $t7
-  6: $t8 := copy($t2)
+  6: $t8 := move($t2)
   7: $t9 := 1
   8: $t10 := +($t8, $t9)
   9: return $t10
@@ -53,12 +53,12 @@ fun ReachingDefTest::basic($t0|a: u64, $t1|b: u64): u64 {
      var $t9: u64
      var $t10: u64
   0: $t3 := copy($t0)
-  1: $t4 := copy($t1)
+  1: $t4 := move($t1)
   2: $t5 := +($t0, $t1)
-  3: $t6 := copy($t0)
+  3: $t6 := move($t0)
   4: $t7 := /($t5, $t0)
   5: $t2 := $t7
-  6: $t8 := copy($t7)
+  6: $t8 := move($t7)
   7: $t9 := 1
   8: $t10 := +($t7, $t9)
   9: return $t10

--- a/language/move-prover/bytecode/tests/reaching_def/test_branching.exp
+++ b/language/move-prover/bytecode/tests/reaching_def/test_branching.exp
@@ -9,7 +9,7 @@ fun TestBranching::branching($t0|cond: bool): u64 {
      var $t5: u64
      var $t6: u64
      var $t7: u64
-  0: $t3 := copy($t0)
+  0: $t3 := move($t0)
   1: if ($t3) goto 2 else goto 6
   2: label L0
   3: $t4 := 3
@@ -22,7 +22,7 @@ fun TestBranching::branching($t0|cond: bool): u64 {
  10: label L3
  11: $t6 := move($t1)
  12: $t2 := $t6
- 13: $t7 := copy($t2)
+ 13: $t7 := move($t2)
  14: return $t7
 }
 
@@ -37,7 +37,7 @@ fun TestBranching::branching($t0|cond: bool): u64 {
      var $t5: u64
      var $t6: u64
      var $t7: u64
-  0: $t3 := copy($t0)
+  0: $t3 := move($t0)
   1: if ($t0) goto 2 else goto 6
   2: label L0
   3: $t4 := 3
@@ -49,6 +49,6 @@ fun TestBranching::branching($t0|cond: bool): u64 {
   9: label L3
  10: $t6 := move($t1)
  11: $t2 := $t1
- 12: $t7 := copy($t1)
+ 12: $t7 := move($t1)
  13: return $t1
 }

--- a/language/move-prover/bytecode/tests/read_write_set/bool_footprint.exp
+++ b/language/move-prover/bytecode/tests/read_write_set/bool_footprint.exp
@@ -5,7 +5,7 @@ public fun BoolFootprint::call_get($t0|a: address) {
      var $t1: address
      var $t2: bool
      var $t3: u64
-  0: $t1 := copy($t0)
+  0: $t1 := move($t0)
   1: $t2 := BoolFootprint::global_get($t1)
   2: if ($t2) goto 6 else goto 3
   3: label L1
@@ -31,7 +31,7 @@ public fun BoolFootprint::global_get($t0|a: address): bool {
   1: $t3 := exists<BoolFootprint::B>($t2)
   2: if ($t3) goto 3 else goto 10
   3: label L0
-  4: $t4 := copy($t0)
+  4: $t4 := move($t0)
   5: $t5 := borrow_global<BoolFootprint::B>($t4)
   6: $t6 := borrow_field<BoolFootprint::B>.b($t5)
   7: $t7 := read_ref($t6)
@@ -60,7 +60,7 @@ public fun BoolFootprint::call_get($t0|a: address) {
      #
      # Locals:
      #
-  0: $t1 := copy($t0)
+  0: $t1 := move($t0)
   1: $t2 := BoolFootprint::global_get($t1)
   2: if ($t2) goto 6 else goto 3
   3: label L1
@@ -94,7 +94,7 @@ public fun BoolFootprint::global_get($t0|a: address): bool {
   1: $t3 := exists<BoolFootprint::B>($t2)
   2: if ($t3) goto 3 else goto 10
   3: label L0
-  4: $t4 := copy($t0)
+  4: $t4 := move($t0)
   5: $t5 := borrow_global<BoolFootprint::B>($t4)
   6: $t6 := borrow_field<BoolFootprint::B>.b($t5)
   7: $t7 := read_ref($t6)

--- a/language/move-prover/bytecode/tests/read_write_set/borrow.exp
+++ b/language/move-prover/bytecode/tests/read_write_set/borrow.exp
@@ -81,7 +81,7 @@ public intrinsic fun Vector::swap_remove<#0>($t0|v: &mut vector<#0>, $t1|i: u64)
 fun Borrow::borrow_s($t0|a: address) {
      var $t1: address
      var $t2: &Borrow::S
-  0: $t1 := copy($t0)
+  0: $t1 := move($t0)
   1: $t2 := borrow_global<Borrow::S>($t1)
   2: destroy($t2)
   3: return ()
@@ -92,7 +92,7 @@ fun Borrow::borrow_s($t0|a: address) {
 fun Borrow::borrow_s_mut($t0|a: address) {
      var $t1: address
      var $t2: &mut Borrow::S
-  0: $t1 := copy($t0)
+  0: $t1 := move($t0)
   1: $t2 := borrow_global<Borrow::S>($t1)
   2: destroy($t2)
   3: return ()
@@ -217,7 +217,7 @@ fun Borrow::borrow_s($t0|a: address) {
      #
      # Locals:
      #
-  0: $t1 := copy($t0)
+  0: $t1 := move($t0)
   1: $t2 := borrow_global<Borrow::S>($t1)
   2: destroy($t2)
   3: return ()
@@ -233,7 +233,7 @@ fun Borrow::borrow_s_mut($t0|a: address) {
      #
      # Locals:
      #
-  0: $t1 := copy($t0)
+  0: $t1 := move($t0)
   1: $t2 := borrow_global<Borrow::S>($t1)
   2: destroy($t2)
   3: return ()

--- a/language/move-prover/bytecode/tests/read_write_set/copy_struct.exp
+++ b/language/move-prover/bytecode/tests/read_write_set/copy_struct.exp
@@ -48,7 +48,7 @@ public fun CopyStruct::g() {
 public fun CopyStruct::ret_struct($t0|a: address): CopyStruct::S {
      var $t1: address
      var $t2: CopyStruct::S
-  0: $t1 := copy($t0)
+  0: $t1 := move($t0)
   1: $t2 := pack CopyStruct::S($t1)
   2: return $t2
 }
@@ -61,7 +61,7 @@ public fun CopyStruct::ret_struct_copy($t0|a: address): CopyStruct::S {
      var $t3: CopyStruct::S
      var $t4: &CopyStruct::S
      var $t5: CopyStruct::S
-  0: $t2 := copy($t0)
+  0: $t2 := move($t0)
   1: $t3 := pack CopyStruct::S($t2)
   2: $t1 := $t3
   3: $t4 := borrow_local($t1)
@@ -130,7 +130,7 @@ public fun CopyStruct::ret_struct($t0|a: address): CopyStruct::S {
      # Locals:
      # Ret(0)/a: Formal(0)
      #
-  0: $t1 := copy($t0)
+  0: $t1 := move($t0)
   1: $t2 := pack CopyStruct::S($t1)
   2: return $t2
 }
@@ -149,7 +149,7 @@ public fun CopyStruct::ret_struct_copy($t0|a: address): CopyStruct::S {
      # Locals:
      # Ret(0)/a: Formal(0)
      #
-  0: $t2 := copy($t0)
+  0: $t2 := move($t0)
   1: $t3 := pack CopyStruct::S($t2)
   2: $t1 := $t3
   3: $t4 := borrow_local($t1)

--- a/language/move-prover/bytecode/tests/read_write_set/counter.exp
+++ b/language/move-prover/bytecode/tests/read_write_set/counter.exp
@@ -15,7 +15,7 @@ fun Counter::call_increment1($t0|s: &mut Counter::S) {
 fun Counter::call_increment2($t0|a: address) {
      var $t1: address
      var $t2: &mut Counter::S
-  0: $t1 := copy($t0)
+  0: $t1 := move($t0)
   1: $t2 := borrow_global<Counter::S>($t1)
   2: Counter::increment2($t2)
   3: return ()
@@ -89,7 +89,7 @@ fun Counter::call_increment2($t0|a: address) {
      #
      # Locals:
      #
-  0: $t1 := copy($t0)
+  0: $t1 := move($t0)
   1: $t2 := borrow_global<Counter::S>($t1)
   2: Counter::increment2($t2)
   3: return ()

--- a/language/move-prover/bytecode/tests/read_write_set/exists.exp
+++ b/language/move-prover/bytecode/tests/read_write_set/exists.exp
@@ -4,7 +4,7 @@
 public fun Exists::call_with_type_param1($t0|a: address): bool {
      var $t1: address
      var $t2: bool
-  0: $t1 := copy($t0)
+  0: $t1 := move($t0)
   1: $t2 := Exists::exists_generic<Exists::T>($t1)
   2: return $t2
 }
@@ -14,7 +14,7 @@ public fun Exists::call_with_type_param1($t0|a: address): bool {
 public fun Exists::call_with_type_param2<#0, #1>($t0|a: address): bool {
      var $t1: address
      var $t2: bool
-  0: $t1 := copy($t0)
+  0: $t1 := move($t0)
   1: $t2 := Exists::exists_generic<#1>($t1)
   2: return $t2
 }
@@ -48,7 +48,7 @@ public fun Exists::exists_field($t0|s: &Exists::S): bool {
 public fun Exists::exists_formal($t0|a: address): bool {
      var $t1: address
      var $t2: bool
-  0: $t1 := copy($t0)
+  0: $t1 := move($t0)
   1: $t2 := exists<Exists::T>($t1)
   2: return $t2
 }
@@ -58,7 +58,7 @@ public fun Exists::exists_formal($t0|a: address): bool {
 public fun Exists::exists_generic<#0>($t0|a: address): bool {
      var $t1: address
      var $t2: bool
-  0: $t1 := copy($t0)
+  0: $t1 := move($t0)
   1: $t2 := exists<Exists::V<#0>>($t1)
   2: return $t2
 }
@@ -68,7 +68,7 @@ public fun Exists::exists_generic<#0>($t0|a: address): bool {
 public fun Exists::exists_generic_instantiated($t0|a: address): bool {
      var $t1: address
      var $t2: bool
-  0: $t1 := copy($t0)
+  0: $t1 := move($t0)
   1: $t2 := exists<Exists::V<Exists::T>>($t1)
   2: return $t2
 }
@@ -85,7 +85,7 @@ public fun Exists::call_with_type_param1($t0|a: address): bool {
      #
      # Locals:
      #
-  0: $t1 := copy($t0)
+  0: $t1 := move($t0)
   1: $t2 := Exists::exists_generic<Exists::T>($t1)
   2: return $t2
 }
@@ -101,7 +101,7 @@ public fun Exists::call_with_type_param2<#0, #1>($t0|a: address): bool {
      #
      # Locals:
      #
-  0: $t1 := copy($t0)
+  0: $t1 := move($t0)
   1: $t2 := Exists::exists_generic<#1>($t1)
   2: return $t2
 }
@@ -153,7 +153,7 @@ public fun Exists::exists_formal($t0|a: address): bool {
      #
      # Locals:
      #
-  0: $t1 := copy($t0)
+  0: $t1 := move($t0)
   1: $t2 := exists<Exists::T>($t1)
   2: return $t2
 }
@@ -169,7 +169,7 @@ public fun Exists::exists_generic<#0>($t0|a: address): bool {
      #
      # Locals:
      #
-  0: $t1 := copy($t0)
+  0: $t1 := move($t0)
   1: $t2 := exists<Exists::V<#0>>($t1)
   2: return $t2
 }
@@ -185,7 +185,7 @@ public fun Exists::exists_generic_instantiated($t0|a: address): bool {
      #
      # Locals:
      #
-  0: $t1 := copy($t0)
+  0: $t1 := move($t0)
   1: $t2 := exists<Exists::V<Exists::T>>($t1)
   2: return $t2
 }

--- a/language/move-prover/bytecode/tests/read_write_set/footprint.exp
+++ b/language/move-prover/bytecode/tests/read_write_set/footprint.exp
@@ -6,7 +6,7 @@ public fun Footprint::reassign_cond($t0|a: address, $t1|b: bool): address {
      var $t3: address
      var $t4: u64
      var $t5: address
-  0: $t2 := copy($t1)
+  0: $t2 := move($t1)
   1: if ($t2) goto 2 else goto 6
   2: label L0
   3: $t3 := 0x2
@@ -15,7 +15,7 @@ public fun Footprint::reassign_cond($t0|a: address, $t1|b: bool): address {
   6: label L2
   7: $t4 := 4
   8: destroy($t4)
-  9: $t5 := copy($t0)
+  9: $t5 := move($t0)
  10: return $t5
 }
 
@@ -26,7 +26,7 @@ public fun Footprint::reassign_constant($t0|a: address): address {
      var $t2: address
   0: $t1 := 0x2
   1: $t0 := $t1
-  2: $t2 := copy($t0)
+  2: $t2 := move($t0)
   3: return $t2
 }
 
@@ -51,7 +51,7 @@ public fun Footprint::reassign_field_cond($t0|s: &mut Footprint::S, $t1|b: bool)
      var $t4: &mut Footprint::S
      var $t5: &mut address
      var $t6: &mut Footprint::S
-  0: $t2 := copy($t1)
+  0: $t2 := move($t1)
   1: if ($t2) goto 2 else goto 8
   2: label L0
   3: $t3 := 0x2
@@ -72,9 +72,9 @@ public fun Footprint::reassign_field_cond($t0|s: &mut Footprint::S, $t1|b: bool)
 public fun Footprint::reassign_other_param($t0|a1: address, $t1|a2: address): address {
      var $t2: address
      var $t3: address
-  0: $t2 := copy($t1)
+  0: $t2 := move($t1)
   1: $t0 := $t2
-  2: $t3 := copy($t0)
+  2: $t3 := move($t0)
   3: return $t3
 }
 
@@ -93,7 +93,7 @@ public fun Footprint::reassign_cond($t0|a: address, $t1|b: bool): address {
      # Locals:
      # Ret(0): {0x2, Formal(0), }
      #
-  0: $t2 := copy($t1)
+  0: $t2 := move($t1)
   1: if ($t2) goto 2 else goto 6
   2: label L0
   3: $t3 := 0x2
@@ -102,7 +102,7 @@ public fun Footprint::reassign_cond($t0|a: address, $t1|b: bool): address {
   6: label L2
   7: $t4 := 4
   8: destroy($t4)
-  9: $t5 := copy($t0)
+  9: $t5 := move($t0)
  10: return $t5
 }
 
@@ -118,7 +118,7 @@ public fun Footprint::reassign_constant($t0|a: address): address {
      #
   0: $t1 := 0x2
   1: $t0 := $t1
-  2: $t2 := copy($t0)
+  2: $t2 := move($t0)
   3: return $t2
 }
 
@@ -158,7 +158,7 @@ public fun Footprint::reassign_field_cond($t0|s: &mut Footprint::S, $t1|b: bool)
      # Locals:
      # Formal(0)/f: {0x2, Formal(0)/f, }
      #
-  0: $t2 := copy($t1)
+  0: $t2 := move($t1)
   1: if ($t2) goto 2 else goto 8
   2: label L0
   3: $t3 := 0x2
@@ -185,8 +185,8 @@ public fun Footprint::reassign_other_param($t0|a1: address, $t1|a2: address): ad
      # Locals:
      # Ret(0): Formal(1)
      #
-  0: $t2 := copy($t1)
+  0: $t2 := move($t1)
   1: $t0 := $t2
-  2: $t3 := copy($t0)
+  2: $t3 := move($t0)
   3: return $t3
 }

--- a/language/move-prover/bytecode/tests/read_write_set/functions.exp
+++ b/language/move-prover/bytecode/tests/read_write_set/functions.exp
@@ -5,7 +5,7 @@ public fun Funtions::call_write_vec($t0|a: address, $t1|v: vector<u8>) {
      var $t2: address
      var $t3: &mut Funtions::R
      var $t4: vector<u8>
-  0: $t2 := copy($t0)
+  0: $t2 := move($t0)
   1: $t3 := borrow_global<Funtions::R>($t2)
   2: $t4 := move($t1)
   3: Funtions::write_vec($t3, $t4)
@@ -20,7 +20,7 @@ public fun Funtions::choice($t0|a: vector<address>, $t1|b: vector<address>, $t2|
      var $t5: vector<address>
      var $t6: vector<address>
      var $t7: vector<address>
-  0: $t4 := copy($t2)
+  0: $t4 := move($t2)
   1: if ($t4) goto 2 else goto 6
   2: label L0
   3: $t5 := move($t0)
@@ -39,7 +39,7 @@ public fun Funtions::choice($t0|a: vector<address>, $t1|b: vector<address>, $t2|
 [variant baseline]
 public fun Funtions::id($t0|a: address): address {
      var $t1: address
-  0: $t1 := copy($t0)
+  0: $t1 := move($t0)
   1: return $t1
 }
 
@@ -95,7 +95,7 @@ public fun Funtions::call_write_vec($t0|a: address, $t1|v: vector<u8>) {
      #
      # Locals:
      #
-  0: $t2 := copy($t0)
+  0: $t2 := move($t0)
   1: $t3 := borrow_global<Funtions::R>($t2)
   2: $t4 := move($t1)
   3: Funtions::write_vec($t3, $t4)
@@ -118,7 +118,7 @@ public fun Funtions::choice($t0|a: vector<address>, $t1|b: vector<address>, $t2|
      # Locals:
      # Ret(0): {Formal(0), Formal(1), }
      #
-  0: $t4 := copy($t2)
+  0: $t4 := move($t2)
   1: if ($t4) goto 2 else goto 6
   2: label L0
   3: $t5 := move($t0)
@@ -143,7 +143,7 @@ public fun Funtions::id($t0|a: address): address {
      # Locals:
      # Ret(0): Formal(0)
      #
-  0: $t1 := copy($t0)
+  0: $t1 := move($t0)
   1: return $t1
 }
 

--- a/language/move-prover/bytecode/tests/read_write_set/multi_deps.exp
+++ b/language/move-prover/bytecode/tests/read_write_set/multi_deps.exp
@@ -14,7 +14,7 @@ fun MultiDeps::add_to($t0|s: &mut MultiDeps::S, $t1|t: &MultiDeps::T, $t2|v: boo
      var $t12: u64
      var $t13: &mut MultiDeps::S
      var $t14: &mut u64
-  0: $t4 := copy($t2)
+  0: $t4 := move($t2)
   1: if ($t4) goto 2 else goto 10
   2: label L0
   3: $t5 := move($t1)
@@ -64,7 +64,7 @@ fun MultiDeps::add_to($t0|s: &mut MultiDeps::S, $t1|t: &MultiDeps::T, $t2|v: boo
      # Locals:
      # Formal(0)/f: {Formal(0)/f, Formal(1)/f, }
      #
-  0: $t4 := copy($t2)
+  0: $t4 := move($t2)
   1: if ($t4) goto 2 else goto 10
   2: label L0
   3: $t5 := move($t1)

--- a/language/move-prover/bytecode/tests/read_write_set/nested_fields.exp
+++ b/language/move-prover/bytecode/tests/read_write_set/nested_fields.exp
@@ -56,7 +56,7 @@ fun NestedFields::nested_fields_interproc($t0|a1: &NestedFields::A, $t1|a2: &Nes
      var $t12: &NestedFields::B
      var $t13: address
      var $t14: address
-  0: $t4 := copy($t2)
+  0: $t4 := move($t2)
   1: if ($t4) goto 2 else goto 11
   2: label L0
   3: $t5 := move($t1)
@@ -171,7 +171,7 @@ fun NestedFields::nested_fields_interproc($t0|a1: &NestedFields::A, $t1|a2: &Nes
      # Locals:
      # Ret(0): {Formal(0)/b/c/f, Formal(1)/b/c/f, }
      #
-  0: $t4 := copy($t2)
+  0: $t4 := move($t2)
   1: if ($t4) goto 2 else goto 11
   2: label L0
   3: $t5 := move($t1)

--- a/language/move-prover/bytecode/tests/read_write_set/pack_unpack.exp
+++ b/language/move-prover/bytecode/tests/read_write_set/pack_unpack.exp
@@ -9,7 +9,7 @@ fun PackUnpack::pack_then_read($t0|a2: address): address {
      var $t5: &PackUnpack::T
      var $t6: &address
      var $t7: address
-  0: $t2 := copy($t0)
+  0: $t2 := move($t0)
   1: $t3 := false
   2: $t4 := pack PackUnpack::T($t2, $t3)
   3: $t1 := $t4
@@ -32,7 +32,7 @@ fun PackUnpack::read_packed_borrow_glob($t0|a2: address): bool {
      var $t8: &PackUnpack::Glob
      var $t9: &bool
      var $t10: bool
-  0: $t2 := copy($t0)
+  0: $t2 := move($t0)
   1: $t3 := false
   2: $t4 := pack PackUnpack::T($t2, $t3)
   3: $t1 := $t4
@@ -69,14 +69,14 @@ fun PackUnpack::read_unpacked_addr($t0|s: PackUnpack::S): address {
   4: $t4 := $t10
   5: $t3 := $t9
   6: $t2 := $t6
-  7: $t11 := copy($t4)
+  7: $t11 := move($t4)
   8: if ($t11) goto 9 else goto 13
   9: label L0
- 10: $t12 := copy($t2)
+ 10: $t12 := move($t2)
  11: $t1 := $t12
  12: goto 17
  13: label L2
- 14: $t13 := copy($t3)
+ 14: $t13 := move($t3)
  15: $t1 := $t13
  16: goto 17
  17: label L3
@@ -101,7 +101,7 @@ fun PackUnpack::read_unpacked_borrow_glob($t0|s: PackUnpack::S): bool {
   2: destroy($t5)
   3: destroy($t4)
   4: $t1 := $t3
-  5: $t6 := copy($t1)
+  5: $t6 := move($t1)
   6: $t7 := borrow_global<PackUnpack::Glob>($t6)
   7: $t8 := borrow_field<PackUnpack::Glob>.b($t7)
   8: $t9 := read_ref($t8)
@@ -128,7 +128,7 @@ fun PackUnpack::reassign_packed_addr($t0|a2: address): address {
   3: $t1 := $t4
   4: $t5 := move($t1)
   5: destroy($t5)
-  6: $t6 := copy($t0)
+  6: $t6 := move($t0)
   7: $t7 := false
   8: $t8 := pack PackUnpack::T($t6, $t7)
   9: $t1 := $t8
@@ -153,10 +153,10 @@ fun PackUnpack::use_results($t0|_: u64, $t1|a: address): address {
      var $t11: PackUnpack::S
      var $t12: PackUnpack::S
      var $t13: address
-  0: $t4 := copy($t1)
+  0: $t4 := move($t1)
   1: $t5 := PackUnpack::pack_then_read($t4)
   2: $t2 := $t5
-  3: $t6 := copy($t2)
+  3: $t6 := move($t2)
   4: $t7 := 0x7
   5: $t8 := true
   6: $t9 := pack PackUnpack::T($t7, $t8)
@@ -185,7 +185,7 @@ fun PackUnpack::pack_then_read($t0|a2: address): address {
      # Locals:
      # Ret(0): Formal(0)
      #
-  0: $t2 := copy($t0)
+  0: $t2 := move($t0)
   1: $t3 := false
   2: $t4 := pack PackUnpack::T($t2, $t3)
   3: $t1 := $t4
@@ -215,7 +215,7 @@ fun PackUnpack::read_packed_borrow_glob($t0|a2: address): bool {
      # Locals:
      # Ret(0): Formal(0)/0x1::PackUnpack::Glob/b
      #
-  0: $t2 := copy($t0)
+  0: $t2 := move($t0)
   1: $t3 := false
   2: $t4 := pack PackUnpack::T($t2, $t3)
   3: $t1 := $t4
@@ -260,14 +260,14 @@ fun PackUnpack::read_unpacked_addr($t0|s: PackUnpack::S): address {
   4: $t4 := $t10
   5: $t3 := $t9
   6: $t2 := $t6
-  7: $t11 := copy($t4)
+  7: $t11 := move($t4)
   8: if ($t11) goto 9 else goto 13
   9: label L0
- 10: $t12 := copy($t2)
+ 10: $t12 := move($t2)
  11: $t1 := $t12
  12: goto 17
  13: label L2
- 14: $t13 := copy($t3)
+ 14: $t13 := move($t3)
  15: $t1 := $t13
  16: goto 17
  17: label L3
@@ -300,7 +300,7 @@ fun PackUnpack::read_unpacked_borrow_glob($t0|s: PackUnpack::S): bool {
   2: destroy($t5)
   3: destroy($t4)
   4: $t1 := $t3
-  5: $t6 := copy($t1)
+  5: $t6 := move($t1)
   6: $t7 := borrow_global<PackUnpack::Glob>($t6)
   7: $t8 := borrow_field<PackUnpack::Glob>.b($t7)
   8: $t9 := read_ref($t8)
@@ -333,7 +333,7 @@ fun PackUnpack::reassign_packed_addr($t0|a2: address): address {
   3: $t1 := $t4
   4: $t5 := move($t1)
   5: destroy($t5)
-  6: $t6 := copy($t0)
+  6: $t6 := move($t0)
   7: $t7 := false
   8: $t8 := pack PackUnpack::T($t6, $t7)
   9: $t1 := $t8
@@ -364,10 +364,10 @@ fun PackUnpack::use_results($t0|_: u64, $t1|a: address): address {
      # Locals:
      # Ret(0): {0x7, Formal(1), }
      #
-  0: $t4 := copy($t1)
+  0: $t4 := move($t1)
   1: $t5 := PackUnpack::pack_then_read($t4)
   2: $t2 := $t5
-  3: $t6 := copy($t2)
+  3: $t6 := move($t2)
   4: $t7 := 0x7
   5: $t8 := true
   6: $t9 := pack PackUnpack::T($t7, $t8)

--- a/language/move-prover/bytecode/tests/read_write_set/read_vector.exp
+++ b/language/move-prover/bytecode/tests/read_write_set/read_vector.exp
@@ -109,7 +109,7 @@ fun ReadVector::read_addr_from_vec($t0|s: ReadVector::S): bool {
   0: $t2 := move($t0)
   1: $t3 := ReadVector::extract_addr_from_vec($t2)
   2: $t1 := $t3
-  3: $t4 := copy($t1)
+  3: $t4 := move($t1)
   4: $t5 := borrow_global<ReadVector::Glob>($t4)
   5: $t6 := borrow_field<ReadVector::Glob>.b($t5)
   6: $t7 := read_ref($t6)
@@ -249,7 +249,7 @@ fun ReadVector::read_addr_from_vec($t0|s: ReadVector::S): bool {
   0: $t2 := move($t0)
   1: $t3 := ReadVector::extract_addr_from_vec($t2)
   2: $t1 := $t3
-  3: $t4 := copy($t1)
+  3: $t4 := move($t1)
   4: $t5 := borrow_global<ReadVector::Glob>($t4)
   5: $t6 := borrow_field<ReadVector::Glob>.b($t5)
   6: $t7 := read_ref($t6)

--- a/language/move-prover/bytecode/tests/read_write_set/secondary_index.exp
+++ b/language/move-prover/bytecode/tests/read_write_set/secondary_index.exp
@@ -37,7 +37,7 @@ fun SecondaryIndex::read_secondary_index_from_formal_interproc($t0|a_addr: addre
      var $t3: SecondaryIndex::A
      var $t4: &SecondaryIndex::A
      var $t5: address
-  0: $t2 := copy($t0)
+  0: $t2 := move($t0)
   1: $t3 := pack SecondaryIndex::A($t2)
   2: $t1 := $t3
   3: $t4 := borrow_local($t1)
@@ -57,12 +57,12 @@ fun SecondaryIndex::read_secondary_index_from_global($t0|a: address): address {
      var $t7: &SecondaryIndex::B
      var $t8: &address
      var $t9: address
-  0: $t2 := copy($t0)
+  0: $t2 := move($t0)
   1: $t3 := borrow_global<SecondaryIndex::A>($t2)
   2: $t4 := borrow_field<SecondaryIndex::A>.a_addr($t3)
   3: $t5 := read_ref($t4)
   4: $t1 := $t5
-  5: $t6 := copy($t1)
+  5: $t6 := move($t1)
   6: $t7 := borrow_global<SecondaryIndex::B>($t6)
   7: $t8 := borrow_field<SecondaryIndex::B>.b_addr($t7)
   8: $t9 := read_ref($t8)
@@ -75,7 +75,7 @@ fun SecondaryIndex::read_secondary_index_from_global_interproc($t0|a: address): 
      var $t1: address
      var $t2: &SecondaryIndex::A
      var $t3: address
-  0: $t1 := copy($t0)
+  0: $t1 := move($t0)
   1: $t2 := borrow_global<SecondaryIndex::A>($t1)
   2: $t3 := SecondaryIndex::read_secondary_index_from_formal($t2)
   3: return $t3
@@ -99,7 +99,7 @@ fun SecondaryIndex::two_secondary_indexes($t0|s: &SecondaryIndex::S, $t1|b: bool
      var $t14: &address
      var $t15: address
      var $t16: address
-  0: $t3 := copy($t1)
+  0: $t3 := move($t1)
   1: if ($t3) goto 2 else goto 11
   2: label L0
   3: $t4 := move($t0)
@@ -146,10 +146,10 @@ fun SecondaryIndex::write_both_fields($t0|c: &mut SecondaryIndex::C, $t1|b: Seco
   6: write_ref($t7, $t5)
   7: goto 8
   8: label L2
-  9: $t8 := copy($t3)
+  9: $t8 := move($t3)
  10: if ($t8) goto 11 else goto 18
  11: label L3
- 12: $t9 := copy($t2)
+ 12: $t9 := move($t2)
  13: $t10 := move($t0)
  14: $t11 := borrow_field<SecondaryIndex::C>.b($t10)
  15: $t12 := borrow_field<SecondaryIndex::B>.b_addr($t11)
@@ -227,7 +227,7 @@ fun SecondaryIndex::read_secondary_index_from_formal_interproc($t0|a_addr: addre
      # Locals:
      # Ret(0): Formal(0)/0x1::SecondaryIndex::B/b_addr
      #
-  0: $t2 := copy($t0)
+  0: $t2 := move($t0)
   1: $t3 := pack SecondaryIndex::A($t2)
   2: $t1 := $t3
   3: $t4 := borrow_local($t1)
@@ -255,12 +255,12 @@ fun SecondaryIndex::read_secondary_index_from_global($t0|a: address): address {
      # Locals:
      # Ret(0): Formal(0)/0x1::SecondaryIndex::A/a_addr/0x1::SecondaryIndex::B/b_addr
      #
-  0: $t2 := copy($t0)
+  0: $t2 := move($t0)
   1: $t3 := borrow_global<SecondaryIndex::A>($t2)
   2: $t4 := borrow_field<SecondaryIndex::A>.a_addr($t3)
   3: $t5 := read_ref($t4)
   4: $t1 := $t5
-  5: $t6 := copy($t1)
+  5: $t6 := move($t1)
   6: $t7 := borrow_global<SecondaryIndex::B>($t6)
   7: $t8 := borrow_field<SecondaryIndex::B>.b_addr($t7)
   8: $t9 := read_ref($t8)
@@ -282,7 +282,7 @@ fun SecondaryIndex::read_secondary_index_from_global_interproc($t0|a: address): 
      # Locals:
      # Ret(0): Formal(0)/0x1::SecondaryIndex::A/a_addr/0x1::SecondaryIndex::B/b_addr
      #
-  0: $t1 := copy($t0)
+  0: $t1 := move($t0)
   1: $t2 := borrow_global<SecondaryIndex::A>($t1)
   2: $t3 := SecondaryIndex::read_secondary_index_from_formal($t2)
   3: return $t3
@@ -317,7 +317,7 @@ fun SecondaryIndex::two_secondary_indexes($t0|s: &SecondaryIndex::S, $t1|b: bool
      # Locals:
      # Ret(0): {Formal(0)/f/0x1::SecondaryIndex::A/a_addr, Formal(0)/g/0x1::SecondaryIndex::A/a_addr, }
      #
-  0: $t3 := copy($t1)
+  0: $t3 := move($t1)
   1: if ($t3) goto 2 else goto 11
   2: label L0
   3: $t4 := move($t0)
@@ -376,10 +376,10 @@ fun SecondaryIndex::write_both_fields($t0|c: &mut SecondaryIndex::C, $t1|b: Seco
   6: write_ref($t7, $t5)
   7: goto 8
   8: label L2
-  9: $t8 := copy($t3)
+  9: $t8 := move($t3)
  10: if ($t8) goto 11 else goto 18
  11: label L3
- 12: $t9 := copy($t2)
+ 12: $t9 := move($t2)
  13: $t10 := move($t0)
  14: $t11 := borrow_field<SecondaryIndex::C>.b($t10)
  15: $t12 := borrow_field<SecondaryIndex::B>.b_addr($t11)

--- a/language/move-prover/bytecode/tests/read_write_set/simple_pack_unpack.exp
+++ b/language/move-prover/bytecode/tests/read_write_set/simple_pack_unpack.exp
@@ -7,7 +7,7 @@ fun SimplePackUnpack::pack_unpack($t0|a: address): address {
      var $t3: SimplePackUnpack::S
      var $t4: SimplePackUnpack::S
      var $t5: address
-  0: $t2 := copy($t0)
+  0: $t2 := move($t0)
   1: $t3 := pack SimplePackUnpack::S($t2)
   2: $t1 := $t3
   3: $t4 := move($t1)
@@ -42,7 +42,7 @@ fun SimplePackUnpack::pack_unpack($t0|a: address): address {
      # Locals:
      # Ret(0): Formal(0)
      #
-  0: $t2 := copy($t0)
+  0: $t2 := move($t0)
   1: $t3 := pack SimplePackUnpack::S($t2)
   2: $t1 := $t3
   3: $t4 := move($t1)

--- a/language/move-prover/bytecode/tests/read_write_set/summary.exp
+++ b/language/move-prover/bytecode/tests/read_write_set/summary.exp
@@ -26,7 +26,7 @@ public fun Summary::write_callee($t0|s2: &mut Summary::S2) {
 public fun Summary::write_caller1($t0|a: address) {
      var $t1: address
      var $t2: &mut Summary::S2
-  0: $t1 := copy($t0)
+  0: $t1 := move($t0)
   1: $t2 := borrow_global<Summary::S2>($t1)
   2: Summary::write_callee($t2)
   3: return ()
@@ -38,7 +38,7 @@ public fun Summary::write_caller2($t0|a: address) {
      var $t1: address
      var $t2: &mut Summary::S1
      var $t3: &mut Summary::S2
-  0: $t1 := copy($t0)
+  0: $t1 := move($t0)
   1: $t2 := borrow_global<Summary::S1>($t1)
   2: $t3 := borrow_field<Summary::S1>.s2($t2)
   3: Summary::write_callee($t3)
@@ -92,7 +92,7 @@ public fun Summary::write_caller1($t0|a: address) {
      #
      # Locals:
      #
-  0: $t1 := copy($t0)
+  0: $t1 := move($t0)
   1: $t2 := borrow_global<Summary::S2>($t1)
   2: Summary::write_callee($t2)
   3: return ()
@@ -111,7 +111,7 @@ public fun Summary::write_caller2($t0|a: address) {
      #
      # Locals:
      #
-  0: $t1 := copy($t0)
+  0: $t1 := move($t0)
   1: $t2 := borrow_global<Summary::S1>($t1)
   2: $t3 := borrow_field<Summary::S1>.s2($t2)
   3: Summary::write_callee($t3)

--- a/language/move-prover/bytecode/tests/read_write_set/update_return.exp
+++ b/language/move-prover/bytecode/tests/read_write_set/update_return.exp
@@ -8,7 +8,7 @@ public fun UpdateReturn::abort_or_write($t0|s: &mut UpdateReturn::S, $t1|b: bool
      var $t6: &mut UpdateReturn::S
      var $t7: u64
      var $t8: u64
-  0: $t3 := copy($t1)
+  0: $t3 := move($t1)
   1: if ($t3) goto 2 else goto 7
   2: label L0
   3: $t4 := move($t0)
@@ -17,7 +17,7 @@ public fun UpdateReturn::abort_or_write($t0|s: &mut UpdateReturn::S, $t1|b: bool
   6: abort($t5)
   7: label L2
   8: $t6 := move($t0)
-  9: $t7 := copy($t2)
+  9: $t7 := move($t2)
  10: $t8 := UpdateReturn::write_f($t6, $t7)
  11: return $t8
 }
@@ -33,7 +33,7 @@ public fun UpdateReturn::write_f($t0|s: &mut UpdateReturn::S, $t1|x: u64): u64 {
   1: $t3 := move($t0)
   2: $t4 := borrow_field<UpdateReturn::S>.f($t3)
   3: write_ref($t4, $t2)
-  4: $t5 := copy($t1)
+  4: $t5 := move($t1)
   5: return $t5
 }
 
@@ -56,7 +56,7 @@ public fun UpdateReturn::abort_or_write($t0|s: &mut UpdateReturn::S, $t1|b: bool
      # Locals:
      # Ret(0): Formal(2)
      #
-  0: $t3 := copy($t1)
+  0: $t3 := move($t1)
   1: if ($t3) goto 2 else goto 7
   2: label L0
   3: $t4 := move($t0)
@@ -65,7 +65,7 @@ public fun UpdateReturn::abort_or_write($t0|s: &mut UpdateReturn::S, $t1|b: bool
   6: abort($t5)
   7: label L2
   8: $t6 := move($t0)
-  9: $t7 := copy($t2)
+  9: $t7 := move($t2)
  10: $t8 := UpdateReturn::write_f($t6, $t7)
  11: return $t8
 }
@@ -89,6 +89,6 @@ public fun UpdateReturn::write_f($t0|s: &mut UpdateReturn::S, $t1|x: u64): u64 {
   1: $t3 := move($t0)
   2: $t4 := borrow_field<UpdateReturn::S>.f($t3)
   3: write_ref($t4, $t2)
-  4: $t5 := copy($t1)
+  4: $t5 := move($t1)
   5: return $t5
 }

--- a/language/move-prover/bytecode/tests/spec_instrumentation/fun_spec.exp
+++ b/language/move-prover/bytecode/tests/spec_instrumentation/fun_spec.exp
@@ -11,17 +11,17 @@ fun Test::branching_result($t0|is_div: bool, $t1|a: u64, $t2|b: u64): u64 {
      var $t9: u64
      var $t10: u64
      var $t11: u64
-  0: $t4 := copy($t0)
+  0: $t4 := move($t0)
   1: if ($t4) goto 2 else goto 8
   2: label L0
-  3: $t5 := copy($t1)
-  4: $t6 := copy($t2)
+  3: $t5 := move($t1)
+  4: $t6 := move($t2)
   5: $t7 := /($t5, $t6)
   6: $t3 := $t7
   7: goto 14
   8: label L2
-  9: $t8 := copy($t1)
- 10: $t9 := copy($t2)
+  9: $t8 := move($t1)
+ 10: $t9 := move($t2)
  11: $t10 := *($t8, $t9)
  12: $t3 := $t10
  13: goto 14
@@ -48,8 +48,8 @@ fun Test::implicit_and_explicit_abort($t0|a: u64, $t1|b: u64): u64 {
   5: $t5 := 22
   6: abort($t5)
   7: label L2
-  8: $t6 := copy($t0)
-  9: $t7 := copy($t1)
+  8: $t6 := move($t0)
+  9: $t7 := move($t1)
  10: $t8 := /($t6, $t7)
  11: return $t8
 }
@@ -66,8 +66,8 @@ fun Test::multiple_results($t0|a: u64, $t1|b: u64): (u64, u64) {
   0: $t2 := copy($t0)
   1: $t3 := copy($t1)
   2: $t4 := /($t2, $t3)
-  3: $t5 := copy($t0)
-  4: $t6 := copy($t1)
+  3: $t5 := move($t0)
+  4: $t6 := move($t1)
   5: $t7 := %($t5, $t6)
   6: return ($t4, $t7)
 }
@@ -99,7 +99,7 @@ fun Test::mut_ref_param($t0|r: &mut Test::R): u64 {
   9: $t10 := move($t0)
  10: $t11 := borrow_field<Test::R>.v($t10)
  11: write_ref($t11, $t9)
- 12: $t12 := copy($t1)
+ 12: $t12 := move($t1)
  13: return $t12
 }
 
@@ -156,7 +156,7 @@ fun Test::resource_with_old($t0|val: u64) {
  11: $t8 := copy($t1)
  12: $t9 := borrow_field<Test::R>.v($t8)
  13: $t10 := read_ref($t9)
- 14: $t11 := copy($t0)
+ 14: $t11 := move($t0)
  15: $t12 := +($t10, $t11)
  16: $t13 := move($t1)
  17: $t14 := borrow_field<Test::R>.v($t13)

--- a/language/move-prover/bytecode/tests/spec_instrumentation/generics.exp
+++ b/language/move-prover/bytecode/tests/spec_instrumentation/generics.exp
@@ -4,7 +4,7 @@
 fun Generics::remove<#0>($t0|a: address): Generics::R<#0> {
      var $t1: address
      var $t2: Generics::R<#0>
-  0: $t1 := copy($t0)
+  0: $t1 := move($t0)
   1: $t2 := move_from<Generics::R<#0>>($t1)
   2: return $t2
 }
@@ -14,7 +14,7 @@ fun Generics::remove<#0>($t0|a: address): Generics::R<#0> {
 fun Generics::remove_u64($t0|a: address): Generics::R<u64> {
      var $t1: address
      var $t2: Generics::R<u64>
-  0: $t1 := copy($t0)
+  0: $t1 := move($t0)
   1: $t2 := Generics::remove<u64>($t1)
   2: return $t2
 }

--- a/language/move-prover/bytecode/tests/spec_instrumentation/modifies.exp
+++ b/language/move-prover/bytecode/tests/spec_instrumentation/modifies.exp
@@ -8,7 +8,7 @@ public fun A::mutate_at($t0|addr: address) {
      var $t4: u64
      var $t5: &mut A::S
      var $t6: &mut u64
-  0: $t2 := copy($t0)
+  0: $t2 := move($t0)
   1: $t3 := borrow_global<A::S>($t2)
   2: $t1 := $t3
   3: $t4 := 2
@@ -27,7 +27,7 @@ public fun A::read_at($t0|addr: address): u64 {
      var $t4: &A::S
      var $t5: &u64
      var $t6: u64
-  0: $t2 := copy($t0)
+  0: $t2 := move($t0)
   1: $t3 := borrow_global<A::S>($t2)
   2: $t1 := $t3
   3: $t4 := move($t1)
@@ -52,10 +52,10 @@ public fun B::move_from_test_incorrect($t0|addr1: address, $t1|addr2: address): 
   0: $t5 := copy($t1)
   1: $t6 := A::read_at($t5)
   2: $t3 := $t6
-  3: $t7 := copy($t0)
+  3: $t7 := move($t0)
   4: $t8 := move_from<B::T>($t7)
   5: $t2 := $t8
-  6: $t9 := copy($t1)
+  6: $t9 := move($t1)
   7: $t10 := A::read_at($t9)
   8: $t4 := $t10
   9: assert Eq<u64>($t3, $t4)
@@ -82,7 +82,7 @@ public fun B::move_to_test_incorrect($t0|account: &signer, $t1|addr2: address) {
   4: $t7 := 2
   5: $t8 := pack B::T($t7)
   6: move_to<B::T>($t8, $t6)
-  7: $t9 := copy($t1)
+  7: $t9 := move($t1)
   8: $t10 := A::read_at($t9)
   9: $t3 := $t10
  10: assert Eq<u64>($t2, $t3)
@@ -102,9 +102,9 @@ public fun B::mutate_S_test1_incorrect($t0|addr1: address, $t1|addr2: address) {
   0: $t4 := copy($t1)
   1: $t5 := A::read_at($t4)
   2: $t2 := $t5
-  3: $t6 := copy($t0)
+  3: $t6 := move($t0)
   4: A::mutate_at($t6)
-  5: $t7 := copy($t1)
+  5: $t7 := move($t1)
   6: $t8 := A::read_at($t7)
   7: $t3 := $t8
   8: assert Eq<u64>($t2, $t3)
@@ -126,7 +126,7 @@ public fun B::mutate_S_test2_incorrect($t0|addr: address) {
   2: $t1 := $t4
   3: $t5 := copy($t0)
   4: A::mutate_at($t5)
-  5: $t6 := copy($t0)
+  5: $t6 := move($t0)
   6: $t7 := A::read_at($t6)
   7: $t2 := $t7
   8: assert Eq<u64>($t1, $t2)
@@ -151,14 +151,14 @@ public fun B::mutate_at_test_incorrect($t0|addr1: address, $t1|addr2: address) {
   0: $t5 := copy($t1)
   1: $t6 := A::read_at($t5)
   2: $t3 := $t6
-  3: $t7 := copy($t0)
+  3: $t7 := move($t0)
   4: $t8 := borrow_global<B::T>($t7)
   5: $t2 := $t8
   6: $t9 := 2
   7: $t10 := move($t2)
   8: $t11 := borrow_field<B::T>.x($t10)
   9: write_ref($t11, $t9)
- 10: $t12 := copy($t1)
+ 10: $t12 := move($t1)
  11: $t13 := A::read_at($t12)
  12: $t4 := $t13
  13: assert Eq<u64>($t3, $t4)

--- a/language/move-prover/bytecode/tests/spec_instrumentation/opaque_call.exp
+++ b/language/move-prover/bytecode/tests/spec_instrumentation/opaque_call.exp
@@ -29,7 +29,7 @@ fun Test::get_and_incr($t0|addr: address): u64 {
   5: $t6 := 33
   6: abort($t6)
   7: label L2
-  8: $t7 := copy($t0)
+  8: $t7 := move($t0)
   9: $t8 := borrow_global<Test::R>($t7)
  10: $t1 := $t8
  11: $t9 := copy($t1)
@@ -44,7 +44,7 @@ fun Test::get_and_incr($t0|addr: address): u64 {
  20: $t17 := move($t1)
  21: $t18 := borrow_field<Test::R>.v($t17)
  22: write_ref($t18, $t16)
- 23: $t19 := copy($t2)
+ 23: $t19 := move($t2)
  24: return $t19
 }
 

--- a/language/move-prover/bytecode/tests/verification_analysis/inv_relevance.exp
+++ b/language/move-prover/bytecode/tests/verification_analysis/inv_relevance.exp
@@ -29,7 +29,7 @@ public fun InvRelevance::outer_bool($t0|s: &signer, $t1|t: bool) {
      var $t2: &signer
      var $t3: bool
   0: $t2 := move($t0)
-  1: $t3 := copy($t1)
+  1: $t3 := move($t1)
   2: InvRelevance::inner<bool>($t2, $t3)
   3: return ()
 }
@@ -40,7 +40,7 @@ public fun InvRelevance::outer_u64($t0|s: &signer, $t1|t: u64) {
      var $t2: &signer
      var $t3: u64
   0: $t2 := move($t0)
-  1: $t3 := copy($t1)
+  1: $t3 := move($t1)
   2: InvRelevance::inner<u64>($t2, $t3)
   3: return ()
 }

--- a/language/move-prover/bytecode/tests/verification_analysis/inv_suspension.exp
+++ b/language/move-prover/bytecode/tests/verification_analysis/inv_suspension.exp
@@ -29,7 +29,7 @@ public fun InvRelevance::outer_bool($t0|s: &signer, $t1|t: bool) {
      var $t2: &signer
      var $t3: bool
   0: $t2 := move($t0)
-  1: $t3 := copy($t1)
+  1: $t3 := move($t1)
   2: InvRelevance::inner<bool>($t2, $t3)
   3: return ()
 }
@@ -40,7 +40,7 @@ public fun InvRelevance::outer_u64($t0|s: &signer, $t1|t: u64) {
      var $t2: &signer
      var $t3: u64
   0: $t2 := move($t0)
-  1: $t3 := copy($t1)
+  1: $t3 := move($t1)
   2: InvRelevance::inner<u64>($t2, $t3)
   3: return ()
 }

--- a/language/tools/move-cli/src/sandbox/utils/mod.rs
+++ b/language/tools/move-cli/src/sandbox/utils/mod.rs
@@ -427,6 +427,7 @@ pub(crate) fn explain_publish_error(
                             diagnostics::codes::Declarations::InvalidFunction,
                             (map.definition_location, err_string),
                             Vec::<(Loc, String)>::new(),
+                            Vec::<String>::new(),
                         );
                         diags.add(diag);
                     }

--- a/language/tools/move-cli/tests/testsuite/module_publish_view/args.exp
+++ b/language/tools/move-cli/tests/testsuite/module_publish_view/args.exp
@@ -11,7 +11,7 @@ struct S {
 
 public foo(): S {
 B0:
-	0: CopyLoc[0](Arg0: u64)
+	0: MoveLoc[0](Arg0: u64)
 	1: Pack[0](S)
 	2: Ret
 }

--- a/language/tools/move-cli/tests/testsuite/package_basics/args.exp
+++ b/language/tools/move-cli/tests/testsuite/package_basics/args.exp
@@ -65,7 +65,7 @@ B1:
 [2]	6: Abort
 B2:
 [4]	7: CopyLoc[0](x: u64)
-[4]	8: CopyLoc[0](x: u64)
+[4]	8: MoveLoc[0](x: u64)
 [4]	9: Mul
 [4]	10: Ret
 }
@@ -78,50 +78,50 @@ module 1.Errors {
 public already_published(): u64 {
 B0:
 	0: LdAddr[0](U8: [6])
-	1: CopyLoc[0](reason: u64)
+	1: MoveLoc[0](reason: u64)
 	2: Call[6](make(u8, u64): u64)
 	3: Ret
 }
 public custom(): u64 {
 B0:
 	0: LdAddr[1](U8: [255])
-	1: CopyLoc[0](reason: u64)
+	1: MoveLoc[0](reason: u64)
 	2: Call[6](make(u8, u64): u64)
 	3: Ret
 }
 public internal(): u64 {
 B0:
 	0: LdAddr[2](U8: [10])
-	1: CopyLoc[0](reason: u64)
+	1: MoveLoc[0](reason: u64)
 	2: Call[6](make(u8, u64): u64)
 	3: Ret
 }
 public invalid_argument(): u64 {
 B0:
 	0: LdAddr[3](U8: [7])
-	1: CopyLoc[0](reason: u64)
+	1: MoveLoc[0](reason: u64)
 	2: Call[6](make(u8, u64): u64)
 	3: Ret
 }
 public invalid_state(): u64 {
 B0:
 	0: LdAddr[4](U8: [1])
-	1: CopyLoc[0](reason: u64)
+	1: MoveLoc[0](reason: u64)
 	2: Call[6](make(u8, u64): u64)
 	3: Ret
 }
 public limit_exceeded(): u64 {
 B0:
 	0: LdAddr[5](U8: [8])
-	1: CopyLoc[0](reason: u64)
+	1: MoveLoc[0](reason: u64)
 	2: Call[6](make(u8, u64): u64)
 	3: Ret
 }
 make(): u64 {
 B0:
-	0: CopyLoc[0](category: u8)
+	0: MoveLoc[0](category: u8)
 	1: CastU64
-	2: CopyLoc[1](reason: u64)
+	2: MoveLoc[1](reason: u64)
 	3: LdU8(8)
 	4: Shl
 	5: Add
@@ -130,28 +130,28 @@ B0:
 public not_published(): u64 {
 B0:
 	0: LdAddr[6](U8: [5])
-	1: CopyLoc[0](reason: u64)
+	1: MoveLoc[0](reason: u64)
 	2: Call[6](make(u8, u64): u64)
 	3: Ret
 }
 public requires_address(): u64 {
 B0:
 	0: LdAddr[7](U8: [2])
-	1: CopyLoc[0](reason: u64)
+	1: MoveLoc[0](reason: u64)
 	2: Call[6](make(u8, u64): u64)
 	3: Ret
 }
 public requires_capability(): u64 {
 B0:
 	0: LdAddr[8](U8: [4])
-	1: CopyLoc[0](reason: u64)
+	1: MoveLoc[0](reason: u64)
 	2: Call[6](make(u8, u64): u64)
 	3: Ret
 }
 public requires_role(): u64 {
 B0:
 	0: LdAddr[9](U8: [3])
-	1: CopyLoc[0](reason: u64)
+	1: MoveLoc[0](reason: u64)
 	2: Call[6](make(u8, u64): u64)
 	3: Ret
 }

--- a/language/tools/move-cli/tests/testsuite/print_stack_trace/args.exp
+++ b/language/tools/move-cli/tests/testsuite/print_stack_trace/args.exp
@@ -40,7 +40,7 @@ Call Stack:
     [2] 00000000000000000000000000000002::M::sum
 
         Code:
-            [10] CopyLoc(0)
+            [10] MoveLoc(0)
             [11] LdU64(1)
             [12] Sub
           > [13] Call(0)
@@ -49,14 +49,14 @@ Call Stack:
             [16] MoveLoc(1)
 
         Locals:
-            [0] 4
+            [0] -
             [1] -
 
 
     [3] 00000000000000000000000000000002::M::sum
 
         Code:
-            [10] CopyLoc(0)
+            [10] MoveLoc(0)
             [11] LdU64(1)
             [12] Sub
           > [13] Call(0)
@@ -65,14 +65,14 @@ Call Stack:
             [16] MoveLoc(1)
 
         Locals:
-            [0] 3
+            [0] -
             [1] -
 
 
     [4] 00000000000000000000000000000002::M::sum
 
         Code:
-            [10] CopyLoc(0)
+            [10] MoveLoc(0)
             [11] LdU64(1)
             [12] Sub
           > [13] Call(0)
@@ -81,7 +81,7 @@ Call Stack:
             [16] MoveLoc(1)
 
         Locals:
-            [0] 2
+            [0] -
             [1] -
 
 
@@ -130,7 +130,7 @@ Call Stack:
     [2] 00000000000000000000000000000002::M::sum
 
         Code:
-            [10] CopyLoc(0)
+            [10] MoveLoc(0)
             [11] LdU64(1)
             [12] Sub
           > [13] Call(0)
@@ -139,14 +139,14 @@ Call Stack:
             [16] MoveLoc(1)
 
         Locals:
-            [0] 4
+            [0] -
             [1] -
 
 
     [3] 00000000000000000000000000000002::M::sum
 
         Code:
-            [10] CopyLoc(0)
+            [10] MoveLoc(0)
             [11] LdU64(1)
             [12] Sub
           > [13] Call(0)
@@ -155,14 +155,14 @@ Call Stack:
             [16] MoveLoc(1)
 
         Locals:
-            [0] 3
+            [0] -
             [1] -
 
 
     [4] 00000000000000000000000000000002::M::sum
 
         Code:
-            [10] CopyLoc(0)
+            [10] MoveLoc(0)
             [11] LdU64(1)
             [12] Sub
           > [13] Call(0)
@@ -171,7 +171,7 @@ Call Stack:
             [16] MoveLoc(1)
 
         Locals:
-            [0] 2
+            [0] -
             [1] -
 
 

--- a/language/tools/move-unit-test/src/test_reporter.rs
+++ b/language/tools/move-unit-test/src/test_reporter.rs
@@ -238,6 +238,7 @@ impl TestFailure {
                             diagnostics::codes::Tests::TestFailed,
                             (loc, base_message.clone()),
                             vec![(function_source_map.definition_location, msg)],
+                            std::iter::empty::<String>(),
                         ))
                     })
                     .collect();


### PR DESCRIPTION
- Allow implicit copy on any value whose type has the copy ability
- Switch last usage of every variable to a move
- Refuse/error to infer copy/move if the local is borrowed during its last usage

## Motivation

- It has been a source of confusion for a while
- The original motivation of only allowing primitives was to save gas. But it doesn't really help with that in a general setting. Sure, it helps in this one narrow case, but there are so many potential gas issues that I don't think accidental duplication is at the top of the list. Hopefully this new assumption isn't wrong

## Test Plan

- new test
