### PR TITLE
[evm] initial implementation of evm execution utils

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,6 +75,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
+
+[[package]]
 name = "async-trait"
 version = "0.1.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -105,6 +111,18 @@ dependencies = [
  "hermit-abi",
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "auto_impl"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7862e21c893d65a1650125d157eaeec691439379a1cee17ee49031b79236ada4"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2 1.0.28",
+ "quote 1.0.9",
+ "syn 1.0.74",
 ]
 
 [[package]]
@@ -166,13 +184,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitvec"
+version = "0.20.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7774144344a4faa177370406a7ff5f1da24303817368584c6206c8303eb07848"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "blake2b_simd"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afa748e348ad3be8263be728124b24a24f268266f6f5d58af9d75f6a40b5c587"
 dependencies = [
  "arrayref",
- "arrayvec",
+ "arrayvec 0.5.2",
  "constant_time_eq",
 ]
 
@@ -232,6 +262,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63396b8a4b9de3f4fdfb320ab6080762242f66a8ef174c49d8e19b674db4cdbe"
 
 [[package]]
+name = "byte-slice-cast"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c751592b77c499e7bce34d99d67c2c11bdc0574e9a488ddade14150a4698"
+
+[[package]]
 name = "byte-tools"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -245,7 +281,7 @@ dependencies = [
  "curve25519-dalek-fiat",
  "ed25519-dalek-fiat",
  "sha2",
- "sha3",
+ "sha3 0.9.1",
  "workspace-hack",
 ]
 
@@ -694,6 +730,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "223089cd5a4e4491f0a0dddd9933f9575123160cf96ca2bb56a690046ecf1745"
 
 [[package]]
+name = "derive_more"
+version = "0.99.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
+dependencies = [
+ "proc-macro2 1.0.28",
+ "quote 1.0.9",
+ "syn 1.0.74",
+]
+
+[[package]]
 name = "determinator"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -788,6 +835,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
 name = "dirs-sys"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -873,6 +929,133 @@ dependencies = [
 ]
 
 [[package]]
+name = "environmental"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68b91989ae21441195d7d9b9993a2f9295c7e1a8c96255d8b729accddc124797"
+
+[[package]]
+name = "ethbloom"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfb684ac8fa8f6c5759f788862bb22ec6fe3cb392f6bfd08e3c64b603661e3f8"
+dependencies = [
+ "crunchy",
+ "fixed-hash",
+ "impl-codec",
+ "impl-rlp",
+ "scale-info",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "ethereum"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34c90e0a755da706ce0970ec0fa8cc48aabcc8e8efa1245336acf718dab06ffe"
+dependencies = [
+ "bytes",
+ "ethereum-types",
+ "hash-db",
+ "hash256-std-hasher",
+ "parity-scale-codec",
+ "rlp",
+ "rlp-derive",
+ "scale-info",
+ "serde 1.0.130",
+ "sha3 0.9.1",
+ "triehash",
+]
+
+[[package]]
+name = "ethereum-types"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05136f7057fe789f06e6d41d07b34e6f70d8c86e5693b60f97aaa6553553bdaf"
+dependencies = [
+ "ethbloom",
+ "fixed-hash",
+ "impl-codec",
+ "impl-rlp",
+ "primitive-types",
+ "scale-info",
+ "uint",
+]
+
+[[package]]
+name = "evm"
+version = "0.33.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "408ffdd509e16de15ea9b51f5333748f6086601f29d445d2ba53dd7e95565574"
+dependencies = [
+ "auto_impl",
+ "environmental",
+ "ethereum",
+ "evm-core",
+ "evm-gasometer",
+ "evm-runtime",
+ "log",
+ "parity-scale-codec",
+ "primitive-types",
+ "rlp",
+ "scale-info",
+ "serde 1.0.130",
+ "sha3 0.8.2",
+]
+
+[[package]]
+name = "evm-core"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dfe4f2a56c4c05a8107b8596380e2332fc2019ffcf56b8f2d01971393a30c4d"
+dependencies = [
+ "funty",
+ "parity-scale-codec",
+ "primitive-types",
+ "scale-info",
+ "serde 1.0.130",
+]
+
+[[package]]
+name = "evm-exec-utils"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "dirs 4.0.0",
+ "evm",
+ "hex",
+ "move-command-line-common",
+ "primitive-types",
+ "sha3 0.9.1",
+ "tempfile",
+ "workspace-hack",
+]
+
+[[package]]
+name = "evm-gasometer"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c446679607eacac4e8c8738e20c97ea9b3c86eddd8b43666744b05f416037bd9"
+dependencies = [
+ "environmental",
+ "evm-core",
+ "evm-runtime",
+ "primitive-types",
+]
+
+[[package]]
+name = "evm-runtime"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e8434ac6e850a8a4bc09a19406264582d1940913b2920be2af948f4ffc49b"
+dependencies = [
+ "environmental",
+ "evm-core",
+ "primitive-types",
+ "sha3 0.8.2",
+]
+
+[[package]]
 name = "fail"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -900,6 +1083,18 @@ name = "file_diff"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31a7a908b8f32538a2143e59a6e4e2508988832d5d4d6f7c156b3cbc762643a5"
+
+[[package]]
+name = "fixed-hash"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcf0ed7fe52a17a03854ec54a9f76d6d84508d1c0e66bc1793301c73fc8493c"
+dependencies = [
+ "byteorder",
+ "rand 0.8.4",
+ "rustc-hex",
+ "static_assertions",
+]
 
 [[package]]
 name = "fixedbitset"
@@ -934,6 +1129,12 @@ name = "fst"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d79238883cf0307100b90aba4a755d8051a3182305dfe7f649a1e9dc0517006f"
+
+[[package]]
+name = "funty"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
 
 [[package]]
 name = "futures"
@@ -1183,6 +1384,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62aca2aba2d62b4a7f5b33f3712cb1b0692779a56fb510499d5c0aa594daeaf3"
 
 [[package]]
+name = "hash-db"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d23bd4e7b5eda0d0f3a307e8b381fdc8ba9000f26fbe912250c0a4cc3956364a"
+
+[[package]]
+name = "hash256-std-hasher"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92c171d55b98633f4ed3860808f004099b36c1cc29c42cfc53aa8591b21efcf2"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1284,6 +1500,35 @@ dependencies = [
  "sized-chunks",
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "impl-codec"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "161ebdfec3c8e3b52bf61c4f3550a1eea4f9579d10dc1b936f3171ebdcd6c443"
+dependencies = [
+ "parity-scale-codec",
+]
+
+[[package]]
+name = "impl-rlp"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28220f89297a075ddc7245cd538076ee98b01f2a9c23a53a4f1105d5a322808"
+dependencies = [
+ "rlp",
+]
+
+[[package]]
+name = "impl-trait-for-tuples"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d7a9f6330b71fea57921c9b61c47ee6e84f72d394754eff6163ae67e7395eb"
+dependencies = [
+ "proc-macro2 1.0.28",
+ "quote 1.0.9",
+ "syn 1.0.74",
 ]
 
 [[package]]
@@ -1469,7 +1714,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
 dependencies = [
- "arrayvec",
+ "arrayvec 0.5.2",
  "bitflags",
  "cfg-if 1.0.0",
  "ryu",
@@ -2270,7 +2515,7 @@ dependencies = [
  "move-vm-runtime",
  "move-vm-types",
  "sha2",
- "sha3",
+ "sha3 0.9.1",
  "smallvec",
  "tempfile",
  "walkdir",
@@ -2422,7 +2667,7 @@ dependencies = [
  "once_cell",
  "parking_lot 0.11.1",
  "proptest",
- "sha3",
+ "sha3 0.9.1",
  "tracing",
  "workspace-hack",
 ]
@@ -2798,6 +3043,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20448fd678ec04e6ea15bbe0476874af65e98a01515d667aa49f1434dc44ebf4"
 
 [[package]]
+name = "parity-scale-codec"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "373b1a4c1338d9cd3d1fa53b3a11bdab5ab6bd80a20f7f7becd76953ae2be909"
+dependencies = [
+ "arrayvec 0.7.2",
+ "bitvec",
+ "byte-slice-cast",
+ "impl-trait-for-tuples",
+ "parity-scale-codec-derive",
+ "serde 1.0.130",
+]
+
+[[package]]
+name = "parity-scale-codec-derive"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1557010476e0595c9b568d16dcfb81b93cdeb157612726f5170d31aa707bed27"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2 1.0.28",
+ "quote 1.0.9",
+ "syn 1.0.74",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3011,7 +3282,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad9940b913ee56ddd94aec2d3cd179dd47068236f42a1a6415ccf9d880ce2a61"
 dependencies = [
- "arrayvec",
+ "arrayvec 0.5.2",
  "typed-arena",
 ]
 
@@ -3038,6 +3309,29 @@ dependencies = [
  "lazy_static 1.4.0",
  "term",
  "unicode-width",
+]
+
+[[package]]
+name = "primitive-types"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05e4722c697a58a99d5d06a08c30821d7c082a4632198de1eaa5a6c22ef42373"
+dependencies = [
+ "fixed-hash",
+ "impl-codec",
+ "impl-rlp",
+ "scale-info",
+ "uint",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebace6889caf889b4d3f76becee12e90353f2b8c7d875534a71e5742f8f6f83"
+dependencies = [
+ "thiserror",
+ "toml",
 ]
 
 [[package]]
@@ -3240,6 +3534,12 @@ checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
  "proc-macro2 1.0.28",
 ]
+
+[[package]]
+name = "radium"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
 
 [[package]]
 name = "rand"
@@ -3496,6 +3796,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "rlp"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "999508abb0ae792aabed2460c45b89106d97fe4adac593bdaef433c2605847b5"
+dependencies = [
+ "bytes",
+ "rustc-hex",
+]
+
+[[package]]
+name = "rlp-derive"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e33d7b2abe0c340d8797fe2907d3f20d3b5ea5908683618bfe80df7f621f672a"
+dependencies = [
+ "proc-macro2 1.0.28",
+ "quote 1.0.9",
+ "syn 1.0.74",
+]
+
+[[package]]
 name = "rust-argon2"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3512,6 +3833,12 @@ name = "rust-ini"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e52c148ef37f8c375d49d5a73aa70713125b7f19095948a923f80afdeb22ec2"
+
+[[package]]
+name = "rustc-hex"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 
 [[package]]
 name = "rustc_version"
@@ -3547,6 +3874,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "scale-info"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c55b744399c25532d63a0d2789b109df8d46fc93752d46b0782991a931a782f"
+dependencies = [
+ "bitvec",
+ "cfg-if 1.0.0",
+ "derive_more",
+ "parity-scale-codec",
+ "scale-info-derive",
+]
+
+[[package]]
+name = "scale-info-derive"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baeb2780690380592f86205aa4ee49815feb2acad8c2f59e6dd207148c3f1fcd"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2 1.0.28",
+ "quote 1.0.9",
+ "syn 1.0.74",
 ]
 
 [[package]]
@@ -3724,6 +4076,19 @@ dependencies = [
  "cpuid-bool",
  "digest 0.9.0",
  "opaque-debug 0.3.0",
+]
+
+[[package]]
+name = "sha3"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd26bc0e7a2e3a7c959bc494caf58b72ee0c71d67704e9520f736ca7e4853ecf"
+dependencies = [
+ "block-buffer 0.7.3",
+ "byte-tools",
+ "digest 0.8.1",
+ "keccak",
+ "opaque-debug 0.2.3",
 ]
 
 [[package]]
@@ -3971,6 +4336,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4030,7 +4401,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd106a334b7657c10b7c540a0106114feadeb4dc314513e97df481d5d966f42"
 dependencies = [
  "byteorder",
- "dirs",
+ "dirs 1.0.5",
  "winapi",
 ]
 
@@ -4289,6 +4660,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "triehash"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1631b201eb031b563d2e85ca18ec8092508e262a3196ce9bd10a67ec87b9f5c"
+dependencies = [
+ "hash-db",
+ "rlp",
+]
+
+[[package]]
 name = "tui"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4328,6 +4709,18 @@ name = "ucd-trie"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
+
+[[package]]
+name = "uint"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f03af7ccf01dd611cc450a0d10dbc9b745770d096473e2faf0ca6e2d66d1e0"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "hex",
+ "static_assertions",
+]
 
 [[package]]
 name = "unic-char-property"
@@ -4474,7 +4867,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6cbce692ab4ca2f1f3047fcf732430249c0e971bfdd2b234cf2c47ad93af5983"
 dependencies = [
- "arrayvec",
+ "arrayvec 0.5.2",
  "utf8parse",
  "vte_generate_state_changes",
 ]
@@ -4626,12 +5019,14 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 name = "workspace-hack"
 version = "0.1.0"
 dependencies = [
- "arrayvec",
+ "arrayvec 0.5.2",
  "block-buffer 0.9.0",
  "bstr",
  "byteorder",
+ "bytes",
  "codespan-reporting",
  "crossbeam-utils",
+ "crunchy",
  "getrandom 0.2.2",
  "libc",
  "log",
@@ -4639,9 +5034,7 @@ dependencies = [
  "num-traits 0.2.14",
  "plotters",
  "proc-macro2 0.4.30",
- "proc-macro2 1.0.28",
  "quote 0.6.13",
- "quote 1.0.9",
  "rand_core 0.5.1",
  "regex",
  "regex-automata",
@@ -4649,8 +5042,15 @@ dependencies = [
  "serde 1.0.130",
  "syn 0.15.44",
  "syn 1.0.74",
+ "tiny-keccak",
  "tracing-core",
 ]
+
+[[package]]
+name = "wyz"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
 
 [[package]]
 name = "x"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "devtools/x-core",
     "devtools/x-lint",
     "language/benchmarks",
+    "language/evm/exec-utils",
     "language/evm/move-to-yul",
     "language/move-analyzer",
     "language/move-binary-format",

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -15,8 +15,10 @@ arrayvec = { version = "0.5.2", features = ["array-sizes-33-128", "std"] }
 block-buffer = { version = "0.9.0", default-features = false, features = ["block-padding"] }
 bstr = { version = "0.2.15", features = ["lazy_static", "regex-automata", "serde", "serde1", "serde1-nostd", "std", "unicode"] }
 byteorder = { version = "1.4.3", features = ["std"] }
+bytes = { version = "1.0.1", features = ["std"] }
 codespan-reporting = { version = "0.11.1", default-features = false, features = ["serde", "serialization"] }
 crossbeam-utils = { version = "0.8.3", features = ["lazy_static", "std"] }
+crunchy = { version = "0.2.2", features = ["limit_128", "limit_256", "std"] }
 getrandom = { version = "0.2.2", default-features = false, features = ["std"] }
 log = { version = "0.4.14", default-features = false, features = ["serde", "std"] }
 memchr = { version = "2.4.0", features = ["std", "use_std"] }
@@ -27,19 +29,21 @@ regex = { version = "1.4.3", features = ["aho-corasick", "memchr", "perf", "perf
 regex-automata = { version = "0.1.9", features = ["regex-syntax", "std"] }
 regex-syntax = { version = "0.6.23", features = ["unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
 serde = { version = "1.0.130", features = ["derive", "rc", "serde_derive", "std"] }
+tiny-keccak = { version = "2.0.2", features = ["keccak", "sha3"] }
 tracing-core = { version = "0.1.21", features = ["lazy_static", "std"] }
 
 [build-dependencies]
+crunchy = { version = "0.2.2", features = ["limit_128", "limit_256", "std"] }
 getrandom = { version = "0.2.2", default-features = false, features = ["std"] }
 memchr = { version = "2.4.0", features = ["std", "use_std"] }
-proc-macro2-9fbad63c4bcf4a8f = { package = "proc-macro2", version = "0.4.30", features = ["proc-macro"] }
-proc-macro2-dff4ba8e3ae991db = { package = "proc-macro2", version = "1.0.28", features = ["proc-macro"] }
-quote-3b31131e45eafb45 = { package = "quote", version = "0.6.13", features = ["proc-macro"] }
-quote-dff4ba8e3ae991db = { package = "quote", version = "1.0.9", features = ["proc-macro"] }
+proc-macro2 = { version = "0.4.30", features = ["proc-macro"] }
+quote = { version = "0.6.13", features = ["proc-macro"] }
 regex = { version = "1.4.3", features = ["aho-corasick", "memchr", "perf", "perf-cache", "perf-dfa", "perf-inline", "perf-literal", "std", "thread_local", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
 regex-syntax = { version = "0.6.23", features = ["unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
+serde = { version = "1.0.130", features = ["derive", "rc", "serde_derive", "std"] }
 syn-3575ec1268b04181 = { package = "syn", version = "0.15.44", features = ["clone-impls", "derive", "extra-traits", "full", "parsing", "printing", "proc-macro", "quote", "visit"] }
-syn-dff4ba8e3ae991db = { package = "syn", version = "1.0.74", features = ["clone-impls", "derive", "extra-traits", "full", "parsing", "printing", "proc-macro", "quote", "visit", "visit-mut"] }
+syn-dff4ba8e3ae991db = { package = "syn", version = "1.0.74", features = ["clone-impls", "derive", "extra-traits", "fold", "full", "parsing", "printing", "proc-macro", "quote", "visit", "visit-mut"] }
+tiny-keccak = { version = "2.0.2", features = ["keccak", "sha3"] }
 
 [target.x86_64-unknown-linux-gnu.dependencies]
 libc = { version = "0.2.112", features = ["std"] }

--- a/language/evm/exec-utils/Cargo.toml
+++ b/language/evm/exec-utils/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "evm-exec-utils"
+version = "0.1.0"
+authors = ["Diem Association <opensource@diem.com>"]
+edition = "2021"
+license = "Apache-2.0"
+publish = false
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+# external dependencies
+sha3 = "0.9.1"
+evm = "0.33.1"
+primitive-types = "0.10.1"
+hex = "0.4.3"
+tempfile = "3.2.0"
+dirs = "4.0.0"
+anyhow = "1.0.52"
+
+# move dependencies
+workspace-hack = { version = "0.1", path = "../../../crates/workspace-hack" }
+move-command-line-common = { path = "../../move-command-line-common" }

--- a/language/evm/exec-utils/contracts/a_plus_b.sol
+++ b/language/evm/exec-utils/contracts/a_plus_b.sol
@@ -1,0 +1,10 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+pragma solidity ^0.8.10;
+
+contract APlusB {
+    function plus(uint a, uint b) public pure returns(uint) {
+        return a + b;
+    }
+}

--- a/language/evm/exec-utils/contracts/hello_world.sol
+++ b/language/evm/exec-utils/contracts/hello_world.sol
@@ -1,0 +1,8 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+pragma solidity ^0.8.10;
+
+contract HelloWorld {
+    string public greet = "Hello World!";
+}

--- a/language/evm/exec-utils/contracts/two_functions.sol
+++ b/language/evm/exec-utils/contracts/two_functions.sol
@@ -1,0 +1,12 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+pragma solidity ^0.8.10;
+
+contract TwoFunctions {
+    function panic() pure public {
+        assert(false);
+    }
+
+    function do_nothing() public {}
+}

--- a/language/evm/exec-utils/src/compile.rs
+++ b/language/evm/exec-utils/src/compile.rs
@@ -1,0 +1,72 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{bail, format_err, Result};
+use std::{
+    collections::BTreeMap,
+    ffi::OsStr,
+    fs::{self},
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+fn solc_path() -> Result<PathBuf> {
+    let solc_exe = move_command_line_common::env::read_env_var("SOLC_EXE");
+
+    if solc_exe.is_empty() {
+        bail!("failed to find path to solc -- is the environment variable SOLC_EXE set?")
+    }
+
+    Ok(PathBuf::from(&solc_exe))
+}
+
+fn solc_impl(
+    source_paths: impl IntoIterator<Item = impl AsRef<OsStr>>,
+    output_dir: &Path,
+) -> Result<BTreeMap<String, Vec<u8>>> {
+    Command::new(&solc_path()?)
+        .args(source_paths)
+        .arg("--bin")
+        .arg("-o")
+        .arg(output_dir)
+        .output()
+        .map_err(|err| format_err!("failed to call solc: {:?}", err))?;
+
+    let mut compiled_contracts = BTreeMap::new();
+
+    for entry in fs::read_dir(output_dir)? {
+        let entry = entry?;
+
+        if entry.file_type()?.is_file() {
+            let path = entry.path();
+            if let Some(ext) = path.extension() {
+                if ext == "bin" {
+                    let data = fs::read(&path)?;
+                    let data = hex::decode(&data)?;
+
+                    compiled_contracts.insert(
+                        path.file_stem()
+                            .ok_or_else(|| format_err!("failed to extract file name"))?
+                            .to_string_lossy()
+                            .to_string(),
+                        data,
+                    );
+                }
+            }
+        }
+    }
+
+    Ok(compiled_contracts)
+}
+
+/// Compile the solodity sources using solc.
+/// Return a mapping with keys being contract names and values being compiled bytecode.
+///
+/// `~/bin/solc` must exist in order for this to work.
+pub fn solc(
+    source_paths: impl IntoIterator<Item = impl AsRef<OsStr>>,
+) -> Result<BTreeMap<String, Vec<u8>>> {
+    let temp = tempfile::tempdir()?;
+
+    solc_impl(source_paths, temp.path())
+}

--- a/language/evm/exec-utils/src/exec.rs
+++ b/language/evm/exec-utils/src/exec.rs
@@ -1,0 +1,157 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use evm::{
+    backend::{Apply, ApplyBackend, MemoryBackend, MemoryVicinity},
+    executor::stack::{MemoryStackState, StackExecutor, StackSubstateMetadata},
+    Config, ExitReason,
+};
+use primitive_types::{H160, H256, U256};
+use sha3::{Digest, Keccak256};
+use std::collections::BTreeMap;
+
+/// Stateful EVM executor backed by an in-memory storage.
+pub struct Executor<'v> {
+    storage_backend: MemoryBackend<'v>,
+}
+
+fn map_apply<F, T, U>(apply: Apply<T>, mut f: F) -> Apply<U>
+where
+    F: FnMut(T) -> U,
+{
+    match apply {
+        Apply::Modify {
+            address,
+            basic,
+            code,
+            storage,
+            reset_storage,
+        } => Apply::Modify {
+            address,
+            basic,
+            code,
+            storage: f(storage),
+            reset_storage,
+        },
+        Apply::Delete { address } => Apply::Delete { address },
+    }
+}
+
+// Try to find the address at which the contract has been deployed to.
+//
+// TODO: right now this feels more like a hack.
+// We should study it more and determine if it's acceptable and see if we need to use CREATE2 instead.
+fn find_contract_address<'a, I, T>(caller_address: H160, applies: I) -> H160
+where
+    I: IntoIterator<Item = &'a Apply<T>>,
+    T: 'a,
+{
+    for apply in applies {
+        if let Apply::Modify {
+            address,
+            code: Some(_),
+            ..
+        } = apply
+        {
+            if *address != caller_address {
+                return *address;
+            }
+        }
+    }
+
+    panic!("failed to find contract address -- something is wrong")
+}
+
+/// Return the 4-byte method selector derived from the signature, which is encoded as a string (e.g. `"foo(uint256,uint256)"`).
+//
+// TODO: Rust type to represent the signature.
+pub fn derive_method_selector(sig: &str) -> [u8; 4] {
+    let mut keccak = Keccak256::new();
+    keccak.update(sig.as_bytes());
+    let digest = keccak.finalize();
+    [digest[0], digest[1], digest[2], digest[3]]
+}
+
+impl<'v> Executor<'v> {
+    /// Create a new `Executor` with an empty in-memory storage backend.
+    //
+    // TODO: review the lifetime of vicinity.
+    pub fn new(vicinity: &'v MemoryVicinity) -> Self {
+        Self {
+            storage_backend: MemoryBackend::new(vicinity, BTreeMap::new()),
+        }
+    }
+
+    /// Return a reference to the in-memory storage backend.
+    pub fn storage(&self) -> &MemoryBackend<'v> {
+        &self.storage_backend
+    }
+
+    /// Create a contract and return the contract address if successful.
+    pub fn create_contract(
+        &mut self,
+        caller_address: H160,
+        contract_code: Vec<u8>,
+    ) -> Result<H160, ExitReason> {
+        let config = Config::london();
+        let metadata = StackSubstateMetadata::new(u64::MAX, &config);
+        let state = MemoryStackState::new(metadata, &self.storage_backend);
+        let mut exec = StackExecutor::new_with_precompiles(state, &config, &());
+
+        let exit_reason =
+            exec.transact_create(caller_address, 0.into(), contract_code, u64::MAX, vec![]);
+        let state = exec.into_state();
+
+        let (changes, logs) = state.deconstruct();
+
+        match &exit_reason {
+            ExitReason::Succeed(_) => {
+                let changes: Vec<Apply<Vec<(H256, H256)>>> = changes
+                    .into_iter()
+                    .map(|app| map_apply(app, |entries| entries.into_iter().collect()))
+                    .collect();
+
+                let contract_addr = find_contract_address(caller_address, &changes);
+
+                self.storage_backend.apply(changes, logs, false);
+                Ok(contract_addr)
+            }
+            _ => {
+                self.storage_backend.apply(changes, logs, false);
+                Err(exit_reason)
+            }
+        }
+    }
+
+    /// Call a contract method with the given signature.
+    pub fn call_function(
+        &mut self,
+        caller_address: H160,
+        contract_address: H160,
+        method_sig: &str,
+        method_args: &[u8],
+    ) -> (ExitReason, Vec<u8>) {
+        let config = Config::london();
+        let metadata = StackSubstateMetadata::new(u64::MAX, &config);
+        let state = MemoryStackState::new(metadata, &self.storage_backend);
+        let mut exec = StackExecutor::new_with_precompiles(state, &config, &());
+
+        let mut data = vec![];
+        data.extend(derive_method_selector(method_sig));
+        data.extend(method_args);
+
+        exec.transact_call(
+            caller_address,
+            contract_address,
+            U256::zero(),
+            data,
+            u64::MAX,
+            vec![],
+        )
+    }
+
+    // TODO: implement this.
+    // pub fn run_custom_code(&mut self, _code: Vec<u8>, _data: Vec<u8>) {
+    //     unimplemented!()
+    // }
+}

--- a/language/evm/exec-utils/src/lib.rs
+++ b/language/evm/exec-utils/src/lib.rs
@@ -1,0 +1,7 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod compile;
+pub mod exec;
+#[cfg(test)]
+pub mod tests;

--- a/language/evm/exec-utils/src/tests.rs
+++ b/language/evm/exec-utils/src/tests.rs
@@ -1,0 +1,102 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{compile::solc, exec::Executor};
+use anyhow::Result;
+use evm::{backend::MemoryVicinity, ExitReason};
+use primitive_types::{H160, U256};
+use std::path::{Path, PathBuf};
+
+fn contract_path(file_name: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("contracts")
+        .join(file_name)
+}
+
+fn test_vincinity() -> MemoryVicinity {
+    MemoryVicinity {
+        gas_price: 0.into(),
+        origin: H160::zero(),
+        chain_id: 0.into(),
+        block_hashes: vec![],
+        block_number: 0.into(),
+        block_coinbase: H160::zero(),
+        block_timestamp: 0.into(),
+        block_difficulty: 0.into(),
+        block_gas_limit: U256::MAX,
+        block_base_fee_per_gas: 0.into(),
+    }
+}
+
+#[test]
+fn test_hello_world() -> Result<()> {
+    let (_contract_name, contract_code) = solc([contract_path("hello_world.sol")])?
+        .into_iter()
+        .next()
+        .unwrap();
+
+    let vicinity = test_vincinity();
+    let mut exec = Executor::new(&vicinity);
+
+    assert!(exec.create_contract(H160::zero(), contract_code).is_ok());
+
+    Ok(())
+}
+
+#[test]
+fn test_two_functions() -> Result<()> {
+    let (_contract_name, contract_code) = solc([contract_path("two_functions.sol")])?
+        .into_iter()
+        .next()
+        .unwrap();
+
+    let vicinity = test_vincinity();
+    let mut exec = Executor::new(&vicinity);
+
+    let contract_address = exec
+        .create_contract(H160::zero(), contract_code)
+        .expect("failed to create contract");
+
+    let (exit_reason, _buffer) =
+        exec.call_function(H160::zero(), contract_address, "do_nothing()", &[]);
+    assert!(matches!(exit_reason, ExitReason::Succeed(_)));
+
+    let (exit_reason, _buffer) = exec.call_function(H160::zero(), contract_address, "panic()", &[]);
+    assert!(matches!(exit_reason, ExitReason::Revert(_)));
+
+    Ok(())
+}
+
+#[test]
+fn test_a_plus_b() -> Result<()> {
+    let (_contract_name, contract_code) = solc([contract_path("a_plus_b.sol")])?
+        .into_iter()
+        .next()
+        .unwrap();
+
+    let vicinity = test_vincinity();
+    let mut exec = Executor::new(&vicinity);
+
+    let contract_address = exec
+        .create_contract(H160::zero(), contract_code)
+        .expect("failed to create contract");
+
+    let mut args = vec![0u8; 64];
+    args[0] = 1;
+    args[32] = 2;
+
+    let (exit_reason, buffer) = exec.call_function(
+        H160::zero(),
+        contract_address,
+        "plus(uint256,uint256)",
+        &args,
+    );
+    assert!(matches!(exit_reason, ExitReason::Succeed(_)));
+
+    assert!(buffer.len() >= 32);
+    let mut expected = [0u8; 32];
+    expected[0] = 0x3;
+    assert_eq!(&buffer[..32], &expected);
+
+    Ok(())
+}

--- a/x.toml
+++ b/x.toml
@@ -152,6 +152,7 @@ members = [
     "bytecode-interpreter-testsuite",
     "bytecode-verifier-tests",
     "bytecode-verifier-transactional-tests",
+    "evm-exec-utils",
     "invalid-mutations",
     "language-benchmarks",
     "mirai-dataflow-analysis",


### PR DESCRIPTION
This introduces a crate `evm-exec-utils`, which contains some wrappers around compiling solidity code (for testing) and executing EVM bytecode using [SputnikVM](https://github.com/rust-blockchain/evm). 

Right now, this has limited functionalities and some of the parameters might not having been properly set up. We'll explore and fix them over time.