### PR TITLE
[evm][exec-utils] fix bug & better way to get addresses of created contracts

### DIFF
--- a/language/evm/exec-utils/contracts/stateful.sol
+++ b/language/evm/exec-utils/contracts/stateful.sol
@@ -1,0 +1,16 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+pragma solidity ^0.8.10;
+
+contract TwoFunctions {
+    uint counter = 0x0;
+
+    function inc() public {
+        counter = counter + 1;
+    }
+
+    function get() public view returns(uint) {
+        return counter;
+    }
+}


### PR DESCRIPTION
This makes some minor improvements to evm-test-utils:
  - This fixes the bug that changes to the storage made by a call are
    not applied to the backend.
  - This gets rid of the hack to obtain addresses of created accounts
    and replace it with a proper call to StackExecutor::create_address.
