### PR TITLE
[evm examples] Added Move modules for the ERC165, ERC721 contracts and their interfaces

### DIFF
--- a/language/evm/examples/sources/ERC165.move
+++ b/language/evm/examples/sources/ERC165.move
@@ -1,0 +1,14 @@
+#[contract]
+/// An implementation of the ERC-165.
+module Evm::ERC165 {
+    use Evm::IERC165;
+    use Std::Errors;
+    use Std::Vector;
+
+    // Query if a contract implements an interface.
+    // The length of `interfaceId` is required to be 4.
+    public fun supportInterface(interfaceId: vector<u8>): bool {
+        assert!(Vector::length(&interfaceId) == 4, Errors::invalid_argument(0));
+        (interfaceId == IERC165::selector_supportInterface())
+    }
+}

--- a/language/evm/examples/sources/ERC20.move
+++ b/language/evm/examples/sources/ERC20.move
@@ -1,5 +1,5 @@
 #[contract]
-/// Another implementation of ERC20 using Table.
+/// An implementation of the ERC-20 Token Standard.
 module Evm::ERC20_ALT {
     use Evm::Evm::{sender, self, sign, emit};
     use Evm::Table::{Self, Table};

--- a/language/evm/examples/sources/ERC721.move
+++ b/language/evm/examples/sources/ERC721.move
@@ -1,0 +1,212 @@
+#[contract]
+/// An implementation of the ERC-721 Non-Fungible Token Standard.
+module Evm::ERC721 {
+    use Evm::Evm::{sender, self, sign, emit, isContract};
+    use Evm::Result;
+    use Evm::IERC721Receiver;
+    use Evm::IERC721;
+    use Evm::IERC165;
+    use Evm::Table::{Self, Table};
+    use Std::Errors;
+
+    #[event]
+    struct Transfer {
+        from: address,
+        to: address,
+        tokenId: u128,
+    }
+
+    #[event]
+    struct Approval {
+        owner: address,
+        approved: address,
+        tokenId: u128,
+    }
+
+    #[event]
+    struct ApprovalForAll {
+        owner: address,
+        operator: address,
+        approved: bool,
+    }
+
+    #[storage]
+    /// Represents the state of this contract. This is located at `borrow_global<State>(self())`.
+    struct State has key {
+        owners: Table<u128, address>,
+        balances: Table<address, u128>,
+        tokenApprovals: Table<u128, address>,
+        operatorApprovals: Table<address, Table<address, bool>>,
+    }
+
+    #[create]
+    /// Constructor of this contract.
+    public fun create() {
+        // Initial state of contract
+        move_to<State>(
+            sign(self()),
+            State {
+                owners: Table::empty<u128, address>(),
+                balances: Table::empty<address, u128>(),
+                tokenApprovals: Table::empty<u128, address>(),
+                operatorApprovals: Table::empty<address, Table<address, bool>>(),
+            }
+        );
+    }
+
+    #[callable]
+    /// Count all NFTs assigned to an owner.
+    public fun balanceOf(owner: address): u128 acquires State {
+        let s = borrow_global_mut<State>(self());
+        *mut_balanceOf(s, owner)
+    }
+
+    #[callable]
+    /// Find the owner of an NFT.
+    public fun ownerOf(tokenId: u128): address acquires State {
+        let s = borrow_global_mut<State>(self());
+        *mut_ownerOf(s, tokenId)
+    }
+
+    #[callable(name=safeTransferFrom)] // Overloading `safeTransferFrom`
+    /// Transfers the ownership of an NFT from one address to another address.
+    public fun safeTransferFrom_with_data(from: address, to: address, tokenId: u128, data: vector<u8>) acquires State {
+        transferFrom(from, to, tokenId);
+        doSafeTransferAcceptanceCheck(from, to, tokenId, data);
+
+    }
+
+    #[callable]
+    /// Transfers the ownership of an NFT from one address to another address.
+    public fun safeTransferFrom(from: address, to: address, tokenId: u128) acquires State {
+        safeTransferFrom_with_data(from, to, tokenId, b"");
+    }
+
+    #[callable]
+    /// Transfer ownership of an NFT. THE CALLER IS RESPONSIBLE
+    ///  TO CONFIRM THAT `_to` IS CAPABLE OF RECEIVING NFTS OR ELSE
+    ///  THEY MAY BE PERMANENTLY LOST
+    public fun transferFrom(from: address, to: address, tokenId: u128) acquires State {
+        assert!(isApprovedOrOwner(sender(), tokenId), Errors::invalid_argument(0));
+        assert!(ownerOf(tokenId) == from, Errors::invalid_argument(0));
+        assert!(to != @0x0, Errors::invalid_argument(0));
+
+        // Clear approvals from the previous owner
+        approve(@0x0, tokenId);
+
+        let s = borrow_global_mut<State>(self());
+
+        let mut_balance_from = mut_balanceOf(s, from);
+        *mut_balance_from = *mut_balance_from - 1;
+
+        let mut_balance_to = mut_balanceOf(s, to);
+        *mut_balance_to = *mut_balance_to + 1;
+
+        let mut_owner_token = mut_ownerOf(s, tokenId);
+        *mut_owner_token = to;
+
+        emit(Transfer{from, to, tokenId});
+    }
+
+    #[callable]
+    /// Change or reaffirm the approved address for an NFT.
+    public fun approve(approved: address, tokenId: u128) acquires State {
+        let owner = ownerOf(tokenId);
+        assert!(owner != @0x0, Errors::invalid_argument(0));
+        assert!(approved != owner, Errors::invalid_argument(0));
+        assert!(sender() == owner || isApprovedForAll(owner, sender()), Errors::invalid_argument(0));
+
+        let s = borrow_global_mut<State>(self());
+        let mut_tokenApproval_tokenId = mut_tokenApproval(s, tokenId);
+        *mut_tokenApproval_tokenId = approved;
+        emit(Approval{ owner, approved, tokenId})
+    }
+
+    #[callable]
+    /// Enable or disable approval for a third party ("operator") to manage
+    ///  all of the sender's assets.
+    public fun setApprovalForAll(operator: address, approved: bool) acquires State {
+        let s = borrow_global_mut<State>(self());
+        *mut_operatorApproval(s, sender(), operator) = approved;
+    }
+
+    #[callable]
+    /// Get the approved address for a single NFT.
+    public fun getApproved(tokenId: u128): address acquires State {
+        let s = borrow_global_mut<State>(self());
+        assert!(tokenExists(s, tokenId), Errors::invalid_argument(0));
+        *mut_tokenApproval(s, tokenId)
+    }
+
+    #[callable]
+    /// Query if an address is an authorized operator for another address.
+    public fun isApprovedForAll(owner: address, operator: address): bool acquires State {
+        let s = borrow_global_mut<State>(self());
+        *mut_operatorApproval(s, owner, operator)
+    }
+
+    #[callable]
+    // Query if this contract implements a certain interface.
+    public fun supportsInterface(interfaceId: vector<u8>): bool {
+        copy interfaceId == IERC721::interfaceId() || interfaceId == IERC165::interfaceId()
+    }
+
+    /// Helper function to return true iff `spender` is the owner or an approved one for `tokenId`.
+    fun isApprovedOrOwner(spender: address, tokenId: u128): bool acquires State {
+        let s = borrow_global_mut<State>(self());
+        assert!(tokenExists(s, tokenId), Errors::invalid_argument(0));
+        let owner = ownerOf(tokenId);
+        return (spender == owner || getApproved(tokenId) == spender || isApprovedForAll(owner, spender))
+    }
+
+    /// Helper function to return a mut ref to the balance of a owner.
+    fun mut_balanceOf(s: &mut State, owner: address): &mut u128 {
+        Table::borrow_mut_with_default(&mut s.balances, owner, 0)
+    }
+
+    /// Helper function to return a mut ref to the balance of a owner.
+    fun mut_ownerOf(s: &mut State, tokenId: u128): &mut address {
+        Table::borrow_mut_with_default(&mut s.owners, tokenId, @0x0)
+    }
+
+    /// Helper function to return a mut ref to the balance of a owner.
+    fun mut_tokenApproval(s: &mut State, tokenId: u128): &mut address {
+        Table::borrow_mut_with_default(&mut s.tokenApprovals, tokenId, @0x0)
+    }
+
+    /// Helper function to return a mut ref to the operator approval.
+    fun mut_operatorApproval(s: &mut State, owner: address, operator: address): &mut bool {
+        if(!Table::contains(&s.operatorApprovals, &owner)) {
+            Table::insert(
+                &mut s.operatorApprovals,
+                owner,
+                Table::empty<address, bool>()
+            )
+        };
+        let approvals = Table::borrow_mut(&mut s.operatorApprovals, &owner);
+        Table::borrow_mut_with_default(approvals, operator, false)
+    }
+
+    /// Helper function to return true iff the token exists.
+    fun tokenExists(s: &mut State, tokenId: u128): bool {
+        let mut_ownerOf_tokenId = mut_ownerOf(s, tokenId);
+        *mut_ownerOf_tokenId != @0x0
+    }
+
+    /// Helper function for the acceptance check.
+    fun doSafeTransferAcceptanceCheck(from: address, to: address, tokenId: u128, data: vector<u8>) {
+        if (isContract(to)) {
+            // try IERC721Receiver(to).onERC721Received(_msgSender(), from, tokenId, _data) returns (bytes4 retval) {
+            let result = IERC721Receiver::call_onERC721Received(to, sender(), from, tokenId, data);
+            if (Result::is_ok(&result)) {
+                let retval = Result::unwrap(result);
+                let expected = IERC721Receiver::selector_onERC721Received();
+                assert!(retval == expected, Errors::custom(0));
+            }
+            else {
+                let _error = Result::unwrap_err(result);
+                abort(Errors::custom(1)) // TODO: abort with the `_error` value.
+            }
+        }
+    }
+}

--- a/language/evm/examples/sources/Evm.move
+++ b/language/evm/examples/sources/Evm.move
@@ -2,6 +2,8 @@
 ////
 /// This currently only represents a basic subset of what we may want to expose.
 module Evm::Evm {
+    use Std::Vector;
+    use Std::Errors;
 
     /// Returns the address of the executing contract.
     public native fun self(): address;
@@ -24,4 +26,38 @@ module Evm::Evm {
 
     /// Creates a signer for the contract's address space.
     public native fun sign(addr: address): &signer;
+
+    /// Returns the keccak256 hash for the input `data`.
+    /// The length of the resulting vector should be 32.
+    public native fun keccak256(data: vector<u8>): vector<u8>;
+
+    /// Returns the first four bytes of `data`.
+    /// This is the equivalent to the type casting operation `bytes4` in Solidity.
+    public fun bytes4(data: vector<u8>): vector<u8> {
+        assert!(Vector::length(&data) >= 4, Errors::invalid_argument(0));
+        let res = Vector::empty<u8>();
+        Vector::push_back(&mut res, *Vector::borrow(&data, 0));
+        Vector::push_back(&mut res, *Vector::borrow(&data, 1));
+        Vector::push_back(&mut res, *Vector::borrow(&data, 2));
+        Vector::push_back(&mut res, *Vector::borrow(&data, 3));
+        res
+    }
+
+    /// Returns the result of (`v1` xor `v2`).
+    // TODO: implment this in Move.
+    public native fun bytes_xor(v1: vector<u8>, v2: vector<u8>): vector<u8>;
+
+    /// Returns true iff `addr` is a contract address.
+    // This can be implemented in Solidity as follows:
+    // ```
+    // uint32 size;
+    // assembly {
+    //   size := extcodesize(_addr)
+    // }
+    // return (size > 0);
+    // ```
+    public native fun isContract(addr: address): bool;
+
+    /// Define the unit (null or void) type.
+    struct Unit {}
 }

--- a/language/evm/examples/sources/IERC1155.move
+++ b/language/evm/examples/sources/IERC1155.move
@@ -1,0 +1,13 @@
+#[interface]
+/// The interface for ERC-1155.
+/// This module defines the API for the interface of ERC-1155 and
+/// the utility functions such as selectors and `interfaceId`.
+module Evm::IERC1155 {
+
+    #[interface_id]
+    /// Return the interface identifier.
+    // TODO: complete this function.
+   public native fun interfaceId(): vector<u8>;
+
+    // TODO: complete this module.
+}

--- a/language/evm/examples/sources/IERC1155Receiver.move
+++ b/language/evm/examples/sources/IERC1155Receiver.move
@@ -1,0 +1,35 @@
+#[interface]
+/// The interface for ERC-721 Token Receiver.
+/// This module defines the API for the interface of ERC-721 Token Receiver and
+/// the utility functions such as selectors and `interfaceId`.
+module Evm::IERC1155Receiver {
+    use Evm::Evm::{keccak256, bytes4, bytes_xor};
+    use Evm::Result::{Result};
+
+    #[external]
+    public native fun call_onERC1155Received(contract: address, operator: address, from: address, id: u128, amount: u128, bytes: vector<u8>): Result<vector<u8>, vector<u8>>;
+
+    #[external]
+    public native fun call_onERC1155BatchReceived(contract: address, operator: address, from: address, ids: vector<u128>, amounts: vector<u128>, bytes: vector<u8>): Result<vector<u8>, vector<u8>>;
+
+    #[selector]
+    /// Return the selector of the function `onERC1155Received`
+    public fun selector_onERC1155Received(): vector<u8> {
+        bytes4(keccak256(b"onERC1155Received(address,address,uint256,uint256,bytes)"))
+    }
+
+    #[selector]
+    /// Return the selector of the function `onERC1155Received`
+    public fun selector_onERC1155BatchReceived(): vector<u8> {
+        bytes4(keccak256(b"onERC1155BatchReceived(address,address,uint256[],uint256[],bytes)"))
+    }
+
+    #[interface_id]
+    /// Return the interface identifier of this interface.
+    public fun interfaceId(): vector<u8> {
+        bytes_xor(
+            selector_onERC1155Received(),
+            selector_onERC1155BatchReceived()
+        )
+    }
+}

--- a/language/evm/examples/sources/IERC165.move
+++ b/language/evm/examples/sources/IERC165.move
@@ -1,0 +1,28 @@
+#[interface]
+/// The interface for the ERC-165.
+/// This module defines the API for the interface of ERC-165 and
+/// the utility functions such as selectors and `interfaceId`.
+module Evm::IERC165 {
+    use Evm::Evm::{keccak256, bytes4};
+    use Evm::Result::{Result};
+
+    #[external]
+    public native fun call_supportInterface(contract: address, interfaceId: vector<u8>): Result<bool, vector<u8>>;
+
+    #[selector]
+    public fun selector_supportInterface(): vector<u8> {
+        bytes4(keccak256(b"supportInterface(bytes4)"))
+    }
+
+    #[interface_id]
+    /// Return the interface identifier. This function corresponds to
+    /// `type(I).interfaceId` in Solidity where `I` is an interface.
+    // The following is a excerpt from the Solidity documentation:
+    //   A bytes4 value containing the EIP-165 interface identifier of
+    //   the given interface I. This identifier is defined as the XOR
+    //   of all function selectors defined within the interface itself
+    //   - excluding all inherited functions.
+    public fun interfaceId(): vector<u8> {
+        selector_supportInterface()
+    }
+}

--- a/language/evm/examples/sources/IERC721.move
+++ b/language/evm/examples/sources/IERC721.move
@@ -1,0 +1,21 @@
+#[interface]
+/// The interface for ERC-721.
+/// This module defines the API for the interface of ERC-721 and
+/// the utility functions such as selectors and `interfaceId`.
+module Evm::IERC721 {
+    use Evm::Evm::{Unit};
+    use Evm::Result::{Result};
+
+    #[interface]
+    public native fun safeTransferFrom(contract: address, from: address, to: address, tokenId: u128): Result<Unit, vector<u8>>;
+
+    #[interface(name=safeTransferFrom)]
+    public native fun safeTransferFrom_with_data(contract: address, from: address, to: address, tokenId: u128, data: vector<u8>): Result<Unit, vector<u8>>;
+
+    #[interface_id]
+    /// Return the interface identifier.
+    // TODO: complete this function.
+   public native fun interfaceId(): vector<u8>;
+
+    // TODO: complete this module.
+}

--- a/language/evm/examples/sources/IERC721Receiver.move
+++ b/language/evm/examples/sources/IERC721Receiver.move
@@ -1,0 +1,23 @@
+#[interface]
+/// The interface for ERC-721 Token Receiver.
+/// This module defines the API for the interface of ERC-721 Token Receiver and
+/// the utility functions such as selectors and `interfaceId`.
+module Evm::IERC721Receiver {
+    use Evm::Evm::{keccak256, bytes4};
+    use Evm::Result::{Result};
+
+    #[interface]
+    public native fun call_onERC721Received(contract: address, operator: address, from: address, tokenId: u128, bytes: vector<u8>): Result<vector<u8>, vector<u8>>;
+
+    #[selector]
+    /// Return the selector of the function `onERC721Received`
+    public fun selector_onERC721Received(): vector<u8> {
+        bytes4(keccak256(b"onERC721Received(address,address,uint256,bytes)"))
+    }
+
+    #[interface_id]
+    /// Return the interface identifier for this interface.
+    public fun interfaceId(): vector<u8> {
+        selector_onERC721Received()
+    }
+}

--- a/language/evm/examples/sources/Result.move
+++ b/language/evm/examples/sources/Result.move
@@ -1,0 +1,49 @@
+/// This module defines the Result type and its methods.
+module Evm::Result {
+    use Std::Option::{Self, Option};
+
+    /// This struct will contain either a value of type T or an error value of type E.
+    struct Result<T, E> has copy, drop, store {
+        value: Option<T>,
+        error: Option<E>
+    }
+    spec Result {
+        /// `Result` cannot contain both a value and an error value.
+        invariant Option::is_some(value) ==> Option::is_none(error);
+        invariant Option::is_some(error) ==> Option::is_none(value);
+    }
+
+    /// Return a Result containing `value`.
+    public fun ok<T, E>(value: T): Result<T, E> {
+        Result<T, E>{value: Option::some(value), error: Option::none<E>()}
+    }
+
+    /// Return a Result containing 'error'.
+    public fun err<T, E>(error: E): Result<T, E> {
+        Result<T, E>{value: Option::none<T>(), error: Option::some(error)}
+    }
+
+    /// Return true if `result` holds a value.
+    public fun is_ok<T, E>(result: &Result<T, E>): bool {
+        Option::is_some(&result.value)
+    }
+
+    /// Return true if `result` holds an error value.
+    public fun is_err<T, E>(result: &Result<T, E>): bool {
+        Option::is_some(&result.error)
+    }
+
+    /// Destroy `result` and extract `value`.
+    public fun unwrap<T, E>(result: Result<T, E>): T {
+        let Result {value, error} = result;
+        Option::destroy_none(error);
+        Option::destroy_some(value)
+    }
+
+    /// Destroy `result` and extract `error`.
+    public fun unwrap_err<T, E>(result: Result<T, E>): E {
+        let Result {value, error} = result;
+        Option::destroy_none(value);
+        Option::destroy_some(error)
+    }
+}

--- a/language/evm/stdlib/sources/U256.move
+++ b/language/evm/stdlib/sources/U256.move
@@ -1,7 +1,7 @@
 #[evm_arith]
 module 0x1::U256 {
     native struct U256 has copy, drop, store;
-    native public fun u256_from_words(lo: u128, hi: u128): U256;
+    native public fun u256_from_words(hi: u128, lo: u128): U256;
     native public fun add(x: U256, y: U256): U256;
     native public fun sub(x: U256, y: U256): U256;
     native public fun mul(x: U256, y: U256): U256;


### PR DESCRIPTION
This PR:

- adds the Move modules for ERC165 and ERC721.
  - One thing to note is that the function `ERC721::safeTransferFrom` is
    overloaded. So, it's indicated as follows: 
    #[callable(name=safeTransferFrom)] 
    public fun safeTransferFrom_with_data (...

- adds the function `supportInterface` and proper transfer acceptance
  checks for ERC1155.

- adds the "interface" modules such as IERC165, IERC721,
  IERC721Receiver, IERC1155, IERC1155Receiver. The interface modules contain:
    - APIs for cross-contract call
      (e.g., `call_onERC1155Received`)
    - the selectors of the functions (e.g., the first 4 bytes of keccack256("onERC1155...")), and 
    - the interface identifier of the interface.

- adds the `Result` module as a library. A cross-contract call can fail in several ways. So, `Result<T, E>` is used to wrap the return types of the functions in the interface modules. `T` is the original return type of the function (for the successful case) while 'E' is the type of error values (for the case where the function fails)

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

To write ERC165 and ERC721 in Move

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

cargo test