### PR TITLE
[move-compiler] Allow different address mappings per file

### DIFF
--- a/language/benchmarks/src/move_vm.rs
+++ b/language/benchmarks/src/move_vm.rs
@@ -35,11 +35,13 @@ pub fn bench<M: Measurement + 'static>(c: &mut Criterion<M>, fun: &str) {
 fn compile_modules() -> Vec<CompiledModule> {
     let mut src_files = move_stdlib::move_stdlib_files();
     src_files.push(MOVE_BENCH_SRC_PATH.to_str().unwrap().to_owned());
-    let (_files, compiled_units) = Compiler::new(&src_files, &[])
-        .set_flags(Flags::empty().set_sources_shadow_deps(false))
-        .set_named_address_values(move_stdlib::move_stdlib_named_addresses())
-        .build_and_report()
-        .expect("Error compiling...");
+    let (_files, compiled_units) = Compiler::new(
+        vec![(src_files, move_stdlib::move_stdlib_named_addresses())],
+        vec![],
+    )
+    .set_flags(Flags::empty().set_sources_shadow_deps(false))
+    .build_and_report()
+    .expect("Error compiling...");
     compiled_units
         .into_iter()
         .map(|unit| match unit {

--- a/language/move-compiler/src/bin/move-check.rs
+++ b/language/move-compiler/src/bin/move-check.rs
@@ -3,9 +3,10 @@
 
 #![forbid(unsafe_code)]
 
+use move_command_line_common::files::verify_and_create_named_address_mapping;
 use move_compiler::{
     command_line::{self as cli},
-    shared::{self, verify_and_create_named_address_mapping, Flags, NumericalAddress},
+    shared::{self, Flags, NumericalAddress},
 };
 use structopt::*;
 
@@ -57,11 +58,13 @@ pub fn main() -> anyhow::Result<()> {
         flags,
         named_addresses,
     } = Options::from_args();
-
-    let _files = move_compiler::Compiler::new(&source_files, &dependencies)
-        .set_interface_files_dir_opt(out_dir)
-        .set_named_address_values(verify_and_create_named_address_mapping(named_addresses)?)
-        .set_flags(flags)
-        .check_and_report()?;
+    let named_addr_map = verify_and_create_named_address_mapping(named_addresses)?;
+    let _files = move_compiler::Compiler::new(
+        vec![(source_files, named_addr_map.clone())],
+        vec![(dependencies, named_addr_map)],
+    )
+    .set_interface_files_dir_opt(out_dir)
+    .set_flags(flags)
+    .check_and_report()?;
     Ok(())
 }

--- a/language/move-compiler/src/compiled_unit.rs
+++ b/language/move-compiler/src/compiled_unit.rs
@@ -94,7 +94,7 @@ impl AnnotatedCompiledModule {
         use crate::expansion::ast::Address;
         let address = match self.address_name {
             None => Address::Anonymous(sp(self.loc, self.named_module.address)),
-            Some(n) => Address::Named(n),
+            Some(n) => Address::Named(n, Some(self.named_module.address)),
         };
         sp(
             self.loc,

--- a/language/move-compiler/src/expansion/unique_modules_after_mapping.rs
+++ b/language/move-compiler/src/expansion/unique_modules_after_mapping.rs
@@ -27,16 +27,13 @@ pub fn verify(
         let sp!(nloc, n_) = module.0;
         let addr_name = match &address {
             Address::Anonymous(_) => None,
-            Address::Named(n) => Some(*n),
+            Address::Named(n, _) => Some(*n),
         };
         let addr_bytes = match &address {
             Address::Anonymous(sp!(_, addr_bytes)) => *addr_bytes,
-            Address::Named(n) => match compilation_env.named_address_mapping().get(&n.value) {
-                // undeclared or no value bound, so can skip
-                None => continue,
-                // copy the assigned value
-                Some(addr_bytes) => *addr_bytes,
-            },
+            Address::Named(_, Some(addr_bytes)) => *addr_bytes,
+            // No mapping given, already an error
+            Address::Named(_, None) => continue,
         };
         let mident_ = (addr_bytes, n_);
         let compiled_mident = (loc, addr_name, addr_bytes, ModuleName(sp(nloc, n_)));

--- a/language/move-compiler/src/hlir/translate.rs
+++ b/language/move-compiler/src/hlir/translate.rs
@@ -1506,12 +1506,12 @@ fn builtin(
     }
 }
 
-fn value(context: &mut Context, sp!(loc, ev_): E::Value) -> H::Value {
+fn value(_context: &mut Context, sp!(loc, ev_): E::Value) -> H::Value {
     use E::Value_ as EV;
     use H::Value_ as HV;
     let v_ = match ev_ {
         EV::InferredNum(_) => panic!("ICE should have been expanded"),
-        EV::Address(a) => HV::Address(a.into_addr_bytes(context.env.named_address_mapping())),
+        EV::Address(a) => HV::Address(a.into_addr_bytes()),
         EV::U8(u) => HV::U8(u),
         EV::U64(u) => HV::U64(u),
         EV::U128(u) => HV::U128(u),

--- a/language/move-compiler/src/naming/ast.rs
+++ b/language/move-compiler/src/naming/ast.rs
@@ -183,6 +183,7 @@ pub type Type = Spanned<Type_>;
 //**************************************************************************************************
 
 #[derive(Debug, PartialEq, Clone)]
+#[allow(clippy::large_enum_variant)]
 pub enum LValue_ {
     Ignore,
     Var(Var),

--- a/language/move-compiler/src/to_bytecode/translate.rs
+++ b/language/move-compiler/src/to_bytecode/translate.rs
@@ -188,12 +188,12 @@ fn module(
     let friends = mdef
         .friends
         .into_iter()
-        .map(|(mident, _loc)| context.translate_module_ident(mident))
+        .map(|(mident, _loc)| Context::translate_module_ident(mident))
         .collect();
 
     let addr_name = match &ident.value.address {
         Address::Anonymous(_) => None,
-        Address::Named(n) => Some(*n),
+        Address::Named(n, _) => Some(*n),
     };
     let addr_bytes = context.resolve_address(ident.value.address);
     let (imports, explicit_dependency_declarations) = context.materialize(

--- a/language/move-compiler/src/unit_test/plan_builder.rs
+++ b/language/move-compiler/src/unit_test/plan_builder.rs
@@ -27,8 +27,8 @@ impl<'env> Context<'env> {
         }
     }
 
-    fn resolve_address(&mut self, addr: &Address) -> NumericalAddress {
-        (*addr).into_addr_bytes(self.env.named_address_mapping())
+    fn resolve_address(&self, addr: &Address) -> NumericalAddress {
+        (*addr).into_addr_bytes()
     }
 }
 

--- a/language/move-compiler/tests/move_check_testsuite.rs
+++ b/language/move-compiler/tests/move_check_testsuite.rs
@@ -64,11 +64,15 @@ fn move_check_testsuite(path: &Path) -> datatest_stable::Result<()> {
 fn run_test(path: &Path, exp_path: &Path, out_path: &Path, flags: Flags) -> anyhow::Result<()> {
     let targets: Vec<String> = vec![path.to_str().unwrap().to_owned()];
 
-    let (files, comments_and_compiler_res) =
-        Compiler::new(&targets, &move_stdlib::move_stdlib_files())
-            .set_flags(flags)
-            .set_named_address_values(default_testing_addresses())
-            .run::<PASS_PARSER>()?;
+    let (files, comments_and_compiler_res) = Compiler::new(
+        vec![(targets, default_testing_addresses())],
+        vec![(
+            move_stdlib::move_stdlib_files(),
+            default_testing_addresses(),
+        )],
+    )
+    .set_flags(flags)
+    .run::<PASS_PARSER>()?;
     let diags = move_check_for_errors(comments_and_compiler_res);
 
     let has_diags = !diags.is_empty();

--- a/language/move-vm/integration-tests/src/compiler.rs
+++ b/language/move-vm/integration-tests/src/compiler.rs
@@ -16,10 +16,15 @@ pub fn compile_units(s: &str) -> Result<Vec<AnnotatedCompiledUnit>> {
         writeln!(file, "{}", s)?;
     }
 
-    let (_, units) = MoveCompiler::new(&[file_path.to_str().unwrap().to_string()], &[])
-        .set_flags(Flags::empty().set_sources_shadow_deps(false))
-        .set_named_address_values(move_stdlib::move_stdlib_named_addresses())
-        .build_and_report()?;
+    let (_, units) = MoveCompiler::new(
+        vec![(
+            vec![file_path.to_str().unwrap().to_string()],
+            move_stdlib::move_stdlib_named_addresses(),
+        )],
+        vec![],
+    )
+    .set_flags(Flags::empty().set_sources_shadow_deps(false))
+    .build_and_report()?;
 
     dir.close()?;
 
@@ -36,9 +41,15 @@ fn expect_modules(
 }
 
 pub fn compile_modules_in_file(path: &Path) -> Result<Vec<CompiledModule>> {
-    let (_, units) = MoveCompiler::new(&[path.to_str().unwrap().to_string()], &[])
-        .set_flags(Flags::empty().set_sources_shadow_deps(false))
-        .build_and_report()?;
+    let (_, units) = MoveCompiler::new(
+        vec![(
+            vec![path.to_str().unwrap().to_string()],
+            std::collections::BTreeMap::new(),
+        )],
+        vec![],
+    )
+    .set_flags(Flags::empty().set_sources_shadow_deps(false))
+    .build_and_report()?;
 
     expect_modules(units).collect()
 }

--- a/language/testing-infra/test-generation/src/lib.rs
+++ b/language/testing-infra/test-generation/src/lib.rs
@@ -57,10 +57,15 @@ fn run_verifier(module: CompiledModule) -> Result<CompiledModule, String> {
 
 static STORAGE_WITH_MOVE_STDLIB: Lazy<InMemoryStorage> = Lazy::new(|| {
     let mut storage = InMemoryStorage::new();
-    let (_, compiled_units) = Compiler::new(&move_stdlib::move_stdlib_files(), &[])
-        .set_named_address_values(move_stdlib::move_stdlib_named_addresses())
-        .build_and_report()
-        .unwrap();
+    let (_, compiled_units) = Compiler::new(
+        vec![(
+            move_stdlib::move_stdlib_files(),
+            move_stdlib::move_stdlib_named_addresses(),
+        )],
+        vec![],
+    )
+    .build_and_report()
+    .unwrap();
     let compiled_modules = compiled_units.into_iter().map(|unit| match unit {
         AnnotatedCompiledUnit::Module(annot_module) => annot_module.named_module.module,
         AnnotatedCompiledUnit::Script(_) => panic!("Unexpected Script in stdlib"),

--- a/language/tools/move-cli/src/base/commands/check.rs
+++ b/language/tools/move-cli/src/base/commands/check.rs
@@ -12,18 +12,20 @@ use move_compiler::{
 
 /// Type-check the user modules in `files` and the dependencies in `interface_files`
 pub fn check(
-    interface_files: &[String],
+    interface_files: Vec<String>,
     sources_shadow_deps: bool,
-    files: &[String],
+    files: Vec<String>,
     named_addresses: BTreeMap<String, NumericalAddress>,
     verbose: bool,
 ) -> Result<()> {
     if verbose {
         println!("Checking Move files...");
     }
-    Compiler::new(files, interface_files)
-        .set_flags(Flags::empty().set_sources_shadow_deps(sources_shadow_deps))
-        .set_named_address_values(named_addresses)
-        .check_and_report()?;
+    Compiler::new(
+        vec![(files, named_addresses.clone())],
+        vec![(interface_files, named_addresses)],
+    )
+    .set_flags(Flags::empty().set_sources_shadow_deps(sources_shadow_deps))
+    .check_and_report()?;
     Ok(())
 }

--- a/language/tools/move-cli/src/base/commands/compile.rs
+++ b/language/tools/move-cli/src/base/commands/compile.rs
@@ -13,10 +13,10 @@ use move_compiler::{
 /// Compile the user modules in `sources` against the dependencies in `interface_files`, placing
 /// the resulting binaries in `output_dir`.
 pub fn compile(
-    interface_files: &[String],
+    interface_files: Vec<String>,
     output_dir: &str,
     sources_shadow_deps: bool,
-    sources: &[String],
+    sources: Vec<String>,
     named_address_mapping: BTreeMap<String, NumericalAddress>,
     emit_source_map: bool,
     verbose: bool,
@@ -24,9 +24,11 @@ pub fn compile(
     if verbose {
         println!("Compiling Move files...");
     }
-    let (files, compiled_units) = Compiler::new(sources, interface_files)
-        .set_flags(Flags::empty().set_sources_shadow_deps(sources_shadow_deps))
-        .set_named_address_values(named_address_mapping)
-        .build_and_report()?;
+    let (files, compiled_units) = Compiler::new(
+        vec![(sources, named_address_mapping.clone())],
+        vec![(interface_files, named_address_mapping)],
+    )
+    .set_flags(Flags::empty().set_sources_shadow_deps(sources_shadow_deps))
+    .build_and_report()?;
     move_compiler::output_compiled_units(emit_source_map, files, compiled_units, output_dir)
 }

--- a/language/tools/move-package/src/compilation/compiled_package.rs
+++ b/language/tools/move-package/src/compilation/compiled_package.rs
@@ -558,17 +558,19 @@ impl CompiledPackage {
             Flags::empty()
         };
 
-        let compiler = Compiler::new(&sources, &dep_paths)
-            .set_compiled_module_named_address_mapping(
-                module_resolution_metadata
-                    .clone()
-                    .into_iter()
-                    .map(|(x, ident)| (x, ident.to_string()))
-                    .collect::<BTreeMap<_, _>>(),
-            )
-            .set_named_address_values(in_scope_named_addrs.clone())
-            .set_interface_files_dir(tmp_interface_dir.path().to_string_lossy().to_string())
-            .set_flags(flags);
+        let compiler = Compiler::new(
+            vec![(sources.clone(), in_scope_named_addrs.clone())],
+            vec![(dep_paths, in_scope_named_addrs.clone())],
+        )
+        .set_compiled_module_named_address_mapping(
+            module_resolution_metadata
+                .clone()
+                .into_iter()
+                .map(|(x, ident)| (x, ident.to_string()))
+                .collect::<BTreeMap<_, _>>(),
+        )
+        .set_interface_files_dir(tmp_interface_dir.path().to_string_lossy().to_string())
+        .set_flags(flags);
         let (file_map, compiled_units) = compiler_driver(compiler, is_root_package)?;
 
         let (compiled_units, resolutions): (Vec<_>, Vec<_>) = compiled_units


### PR DESCRIPTION
- Updated source language compiler to allow multiple address mappings
- A different mapping can be specified per file
- Feature not yet utilized

## Motivation

- Will allow the package system to use source files 

## Test Plan

- ran em