### PR TITLE
[evm][exec-utils] implement mint, transfer_eth, execute_custom_code

### DIFF
--- a/language/evm/exec-utils/src/exec.rs
+++ b/language/evm/exec-utils/src/exec.rs
@@ -2,13 +2,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use evm::{
-    backend::{ApplyBackend, MemoryBackend, MemoryVicinity},
+    backend::{Apply, ApplyBackend, Basic, MemoryAccount, MemoryBackend, MemoryVicinity},
     executor::stack::{MemoryStackState, StackExecutor, StackSubstateMetadata},
-    Config, CreateScheme, ExitReason,
+    Config, Context, CreateScheme, ExitReason, Runtime,
 };
 use primitive_types::{H160, U256};
 use sha3::{Digest, Keccak256};
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, error::Error, fmt, rc::Rc};
+
+// TODO: implement these features:
+//   - Proper handling of gas
 
 /// Stateful EVM executor backed by an in-memory storage.
 pub struct Executor<'v> {
@@ -25,7 +28,68 @@ pub fn derive_method_selector(sig: &str) -> [u8; 4] {
     [digest[0], digest[1], digest[2], digest[3]]
 }
 
+#[derive(Debug)]
+pub enum MintError {
+    BalanceOverflow,
+}
+
+impl fmt::Display for MintError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+impl Error for MintError {}
+
 impl<'v> Executor<'v> {
+    /// Return a reference to the in-memory storage backend.
+    pub fn storage(&self) -> &MemoryBackend<'v> {
+        &self.storage_backend
+    }
+
+    /// Return a reference to the in-memory representation of the account at the specified adress if one exists.
+    fn account_info(&self, address: H160) -> Option<&MemoryAccount> {
+        self.storage_backend.state().get(&address)
+    }
+
+    /// Return the balance of the account at the specified address if one exists.
+    pub fn account_balance(&self, address: H160) -> Option<U256> {
+        self.account_info(address).map(|account| account.balance)
+    }
+
+    /// Add balance to the specified account.
+    /// Intended to used for testing.
+    ///
+    /// Note: this will create a new account at the given address if one does not exist.
+    pub fn mint(&mut self, address: H160, eth_amount: U256) -> Result<(), MintError> {
+        let (balance, nonce) = match self.account_info(address) {
+            Some(account) => {
+                let balance = account
+                    .balance
+                    .checked_add(eth_amount)
+                    .ok_or(MintError::BalanceOverflow)?;
+                let nonce = account.nonce; // REVIEW: should the nonce be incremented?
+
+                (balance, nonce)
+            }
+            None => (eth_amount, U256::from(0)),
+        };
+
+        self.storage_backend.apply(
+            [Apply::Modify {
+                address,
+                basic: Basic { balance, nonce },
+                code: None,
+                storage: [],
+                reset_storage: false,
+            }],
+            [],
+            false,
+        );
+
+        Ok(())
+    }
+
     /// Create a new `Executor` with an empty in-memory storage backend.
     //
     // TODO: review the lifetime of vicinity.
@@ -35,9 +99,25 @@ impl<'v> Executor<'v> {
         }
     }
 
-    /// Return a reference to the in-memory storage backend.
-    pub fn storage(&self) -> &MemoryBackend<'v> {
-        &self.storage_backend
+    // Perform a transaction and commit the changes to the storage backend.
+    fn transact<F, R>(&mut self, op: F) -> R
+    where
+        F: for<'c> FnOnce(
+            &mut StackExecutor<'c, 'static, MemoryStackState<'c, 'c, MemoryBackend<'v>>, ()>,
+        ) -> R,
+    {
+        let config = Config::london();
+        let metadata = StackSubstateMetadata::new(u64::MAX, &config);
+        let state = MemoryStackState::new(metadata, &self.storage_backend);
+        let mut exec = StackExecutor::new_with_precompiles(state, &config, &());
+
+        let res = op(&mut exec);
+
+        let state = exec.into_state();
+        let (changes, logs) = state.deconstruct();
+        self.storage_backend.apply(changes, logs, false);
+
+        res
     }
 
     /// Create a contract and return the contract address if successful.
@@ -46,28 +126,48 @@ impl<'v> Executor<'v> {
         caller_address: H160,
         contract_code: Vec<u8>,
     ) -> Result<H160, ExitReason> {
-        // TODO: due to some lifetime issues, the following code is duplicated a few times.
-        // Figure out how we can reuse this code.
-        let config = Config::london();
-        let metadata = StackSubstateMetadata::new(u64::MAX, &config);
-        let state = MemoryStackState::new(metadata, &self.storage_backend);
-        let mut exec = StackExecutor::new_with_precompiles(state, &config, &());
+        self.transact(|exec| {
+            let contract_address = exec.create_address(CreateScheme::Legacy {
+                caller: caller_address,
+            });
 
-        let contract_address = exec.create_address(CreateScheme::Legacy {
-            caller: caller_address,
-        });
+            let exit_reason = exec.transact_create(
+                caller_address,
+                U256::zero(), // TODO: allow the caller to specify this.
+                contract_code,
+                u64::MAX,
+                vec![],
+            );
 
-        let exit_reason =
-            exec.transact_create(caller_address, 0.into(), contract_code, u64::MAX, vec![]);
+            match &exit_reason {
+                ExitReason::Succeed(_) => Ok(contract_address),
+                _ => Err(exit_reason),
+            }
+        })
+    }
 
-        let state = exec.into_state();
-        let (changes, logs) = state.deconstruct();
-        self.storage_backend.apply(changes, logs, false);
+    /// Transfer some ETH from one account to another.
+    pub fn transfer_eth(
+        &mut self,
+        sender_address: H160,
+        receipient_address: H160,
+        eth_amount: U256,
+    ) -> Result<(), ExitReason> {
+        self.transact(|exec| {
+            let (exit_reason, _buffer) = exec.transact_call(
+                sender_address,
+                receipient_address,
+                eth_amount,
+                vec![],
+                u64::MAX,
+                vec![],
+            );
 
-        match &exit_reason {
-            ExitReason::Succeed(_) => Ok(contract_address),
-            _ => Err(exit_reason),
-        }
+            match &exit_reason {
+                ExitReason::Succeed(_) => Ok(()),
+                _ => Err(exit_reason),
+            }
+        })
     }
 
     /// Call a contract method with the given signature.
@@ -77,31 +177,54 @@ impl<'v> Executor<'v> {
         &mut self,
         caller_address: H160,
         contract_address: H160,
+        eth_amount: U256,
         method_sig: &str,
         method_args: &[u8],
     ) -> (ExitReason, Vec<u8>) {
-        let config = Config::london();
-        let metadata = StackSubstateMetadata::new(u64::MAX, &config);
-        let state = MemoryStackState::new(metadata, &self.storage_backend);
-        let mut exec = StackExecutor::new_with_precompiles(state, &config, &());
+        self.transact(|exec| {
+            let mut data = vec![];
+            data.extend(derive_method_selector(method_sig));
+            data.extend(method_args);
 
-        let mut data = vec![];
-        data.extend(derive_method_selector(method_sig));
-        data.extend(method_args);
+            let (exit_reason, buffer) = exec.transact_call(
+                caller_address,
+                contract_address,
+                eth_amount,
+                data,
+                u64::MAX,
+                vec![],
+            );
 
-        let (exit_reason, buffer) = exec.transact_call(
-            caller_address,
-            contract_address,
-            U256::zero(),
-            data,
-            u64::MAX,
-            vec![],
-        );
+            (exit_reason, buffer)
+        })
+    }
 
-        let state = exec.into_state();
-        let (changes, logs) = state.deconstruct();
-        self.storage_backend.apply(changes, logs, false);
+    /// Execute custom EVM opecodes.
+    /// You are still required to specify a caller address and a contract address, even though a contract may not exist
+    /// at the specified address.
+    pub fn execute_custom_code(
+        &mut self,
+        caller_address: H160,
+        contract_address: H160,
+        code: Vec<u8>,
+        data: Vec<u8>,
+    ) -> Result<Vec<u8>, ExitReason> {
+        self.transact(|exec| {
+            let context = Context {
+                address: contract_address,
+                caller: caller_address,
+                apparent_value: U256::zero(), // TODO: figure out what this is.
+            };
+            let mut runtime = Runtime::new(Rc::new(code), Rc::new(data), context, exec.config());
 
-        (exit_reason, buffer)
+            // REVIEW: are we handling gas metering correctly?
+            let exit_reason = exec.execute(&mut runtime);
+            let ret = runtime.machine().return_value();
+
+            match &exit_reason {
+                ExitReason::Succeed(_) => Ok(ret),
+                _ => Err(exit_reason),
+            }
+        })
     }
 }

--- a/language/evm/exec-utils/src/tests.rs
+++ b/language/evm/exec-utils/src/tests.rs
@@ -3,7 +3,7 @@
 
 use crate::{compile::solc, exec::Executor};
 use anyhow::Result;
-use evm::{backend::MemoryVicinity, ExitReason};
+use evm::{backend::MemoryVicinity, ExitReason, Opcode};
 use primitive_types::{H160, U256};
 use std::path::{Path, PathBuf};
 
@@ -38,7 +38,8 @@ fn test_hello_world() -> Result<()> {
     let vicinity = test_vincinity();
     let mut exec = Executor::new(&vicinity);
 
-    assert!(exec.create_contract(H160::zero(), contract_code).is_ok());
+    let res = exec.create_contract(H160::zero(), contract_code);
+    assert!(res.is_ok());
 
     Ok(())
 }
@@ -57,11 +58,17 @@ fn test_two_functions() -> Result<()> {
         .create_contract(H160::zero(), contract_code)
         .expect("failed to create contract");
 
-    let (exit_reason, _buffer) =
-        exec.call_function(H160::zero(), contract_address, "do_nothing()", &[]);
+    let (exit_reason, _buffer) = exec.call_function(
+        H160::zero(),
+        contract_address,
+        0.into(),
+        "do_nothing()",
+        &[],
+    );
     assert!(matches!(exit_reason, ExitReason::Succeed(_)));
 
-    let (exit_reason, _buffer) = exec.call_function(H160::zero(), contract_address, "panic()", &[]);
+    let (exit_reason, _buffer) =
+        exec.call_function(H160::zero(), contract_address, 0.into(), "panic()", &[]);
     assert!(matches!(exit_reason, ExitReason::Revert(_)));
 
     Ok(())
@@ -88,6 +95,7 @@ fn test_a_plus_b() -> Result<()> {
     let (exit_reason, buffer) = exec.call_function(
         H160::zero(),
         contract_address,
+        0.into(),
         "plus(uint256,uint256)",
         &args,
     );
@@ -117,17 +125,82 @@ fn test_stateful() -> Result<()> {
 
     for _ in 0..7 {
         let (exit_reason, _buffer) =
-            exec.call_function(H160::zero(), contract_address, "inc()", &[]);
+            exec.call_function(H160::zero(), contract_address, 0.into(), "inc()", &[]);
         assert!(matches!(exit_reason, ExitReason::Succeed(_)));
     }
 
-    let (exit_reason, buffer) = exec.call_function(H160::zero(), contract_address, "get()", &[]);
+    let (exit_reason, buffer) =
+        exec.call_function(H160::zero(), contract_address, 0.into(), "get()", &[]);
     assert!(matches!(exit_reason, ExitReason::Succeed(_)));
 
     assert!(buffer.len() >= 32);
     let mut expected = [0u8; 32];
     expected[31] = 0x7;
     assert_eq!(&buffer[..32], &expected);
+
+    Ok(())
+}
+
+#[test]
+fn test_custom_code_add_two_numbers() -> Result<()> {
+    let vicinity = test_vincinity();
+    let mut exec = Executor::new(&vicinity);
+
+    let mut code = vec![];
+
+    // push 1
+    // push 2
+    // add
+    // push 0
+    // mstore
+    // push 32
+    // push 0
+    // return
+
+    code.extend([Opcode::PUSH1.0, 0x1, Opcode::PUSH1.0, 0x2, Opcode::ADD.0]);
+
+    code.push(Opcode::PUSH32.0);
+    code.extend([0; 32]);
+    code.push(Opcode::MSTORE.0);
+
+    let mut length = [0; 32];
+    length[31] = 32;
+    code.push(Opcode::PUSH32.0);
+    code.extend(length);
+    code.push(Opcode::PUSH32.0);
+    code.extend([0; 32]);
+    code.push(Opcode::RETURN.0);
+
+    let ret = exec
+        .execute_custom_code(H160::zero(), H160::zero(), code, vec![])
+        .expect("failed to execute code");
+
+    let mut expected = [0; 32];
+    expected[31] = 0x3;
+    assert_eq!(&ret, &expected);
+
+    Ok(())
+}
+
+#[test]
+fn test_transfer_eth() -> Result<()> {
+    let vicinity = test_vincinity();
+    let mut exec = Executor::new(&vicinity);
+
+    let alice_addr = H160::from([0x1; 20]);
+    let bob_addr = H160::from([0x2; 20]);
+
+    exec.mint(alice_addr, U256::from(5000))?;
+    exec.mint(bob_addr, U256::from(5000))?;
+
+    assert_eq!(exec.account_balance(alice_addr).unwrap(), U256::from(5000));
+    assert_eq!(exec.account_balance(bob_addr).unwrap(), U256::from(5000));
+
+    exec.transfer_eth(alice_addr, bob_addr, U256::from(1000))
+        .expect("failed to transfer eth");
+
+    assert_eq!(exec.account_balance(alice_addr).unwrap(), U256::from(4000));
+    assert_eq!(exec.account_balance(bob_addr).unwrap(), U256::from(6000));
 
     Ok(())
 }


### PR DESCRIPTION
This implements some of the essential functionalities `evm-exec-utils` currently misses:
  - minting
  - transfer eth
  - ability to execute custom code without creating a contract
