### PR TITLE
Simplify dev_setup script

### DIFF
--- a/.github/actions/build-setup/action.yml
+++ b/.github/actions/build-setup/action.yml
@@ -57,7 +57,7 @@ runs:
         echo '/usr/lib/golang/bin' | tee -a $GITHUB_PATH
     - name: install common dependencies (should be ~ 10 seconds in a linux build, on mac it's a beast.)
       shell: bash
-      run: scripts/dev_setup.sh -t -b -p -y -d -s -n -a
+      run: scripts/dev_setup.sh -t -b -p -y -d -n -a
     - id: rust-environment
       shell: bash
       run: |

--- a/.github/actions/build-setup/action.yml
+++ b/.github/actions/build-setup/action.yml
@@ -57,7 +57,7 @@ runs:
         echo '/usr/lib/golang/bin' | tee -a $GITHUB_PATH
     - name: install common dependencies (should be ~ 10 seconds in a linux build, on mac it's a beast.)
       shell: bash
-      run: scripts/dev_setup.sh -t -b -p -y -d -n -a
+      run: scripts/dev_setup.sh -t -b -p -y -d -n
     - id: rust-environment
       shell: bash
       run: |

--- a/.github/actions/build-setup/action.yml
+++ b/.github/actions/build-setup/action.yml
@@ -57,7 +57,7 @@ runs:
         echo '/usr/lib/golang/bin' | tee -a $GITHUB_PATH
     - name: install common dependencies (should be ~ 10 seconds in a linux build, on mac it's a beast.)
       shell: bash
-      run: scripts/dev_setup.sh -t -o -b -p -y -d -s -n -a
+      run: scripts/dev_setup.sh -t -b -p -y -d -s -n -a
     - id: rust-environment
       shell: bash
       run: |

--- a/docker/ci/github/Dockerfile
+++ b/docker/ci/github/Dockerfile
@@ -14,7 +14,7 @@ ENV RUSTUP_HOME "/opt/rustup"
 RUN mkdir -p /github/home && \
     mkdir -p /opt/cargo/ && \
     mkdir -p /opt/git/ && \
-    /diem/scripts/dev_setup.sh -t -b -p -y -d -s -n -a && \
+    /diem/scripts/dev_setup.sh -t -b -p -y -d -n -a && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
@@ -38,15 +38,12 @@ RUN [ -x "$(set -x; command -v rustup)" ] \
     && [ -x "$(set -x; command -v z3)" ] \
     && [ -x "$(set -x; command -v "$BOOGIE_EXE")" ] \
     && [ -x "$(set -x; xargs rustup which cargo --toolchain < /diem/rust-toolchain )" ] \
-    && [ -x "$(set -x; command -v javac)" ] \
     && [ -x "$(set -x; command -v clang)" ] \
     && [ -x "$(set -x; command -v python3)" ] \
-    && [ -x "$(set -x; command -v go)" ] \
-    && [ -x "$(set -x; command -v npm)" ] \
-    && [ -x "$(set -x; command -v deno)" ]
+    && [ -x "$(set -x; command -v npm)" ]
 
 # should be a no-op
 # sccache builds fine, but is not executable ??? in alpine, ends up being recompiled.  Wierd.
-RUN /diem/scripts/dev_setup.sh -t -y -d -b -p -s -a
+RUN /diem/scripts/dev_setup.sh -t -y -d -b -p -a
 
 FROM setup_ci as build_environment

--- a/docker/ci/github/Dockerfile
+++ b/docker/ci/github/Dockerfile
@@ -14,7 +14,7 @@ ENV RUSTUP_HOME "/opt/rustup"
 RUN mkdir -p /github/home && \
     mkdir -p /opt/cargo/ && \
     mkdir -p /opt/git/ && \
-    /diem/scripts/dev_setup.sh -t -o -b -p -y -d -s -n -a && \
+    /diem/scripts/dev_setup.sh -t -b -p -y -d -s -n -a && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
@@ -29,24 +29,15 @@ FROM setup_ci as tested_ci
 
 # Compile a small rust tool?  But we already have in dev_setup (sccache/grcov)...?
 # Test that all commands we need are installed and on the PATH
-RUN [ -x "$(set -x; command -v shellcheck)" ] \
-    && [ -x "$(set -x; command -v hadolint)" ] \
-    && [ -x "$(set -x; command -v vault)" ] \
-    && [ -x "$(set -x; command -v terraform)" ] \
-    && [ -x "$(set -x; command -v kubectl)" ] \
-    && [ -x "$(set -x; command -v rustup)" ] \
+RUN [ -x "$(set -x; command -v rustup)" ] \
     && [ -x "$(set -x; command -v cargo)" ] \
     && [ -x "$(set -x; command -v cargo-guppy)" ] \
     && [ -x "$(set -x; command -v sccache)" ] \
     && [ -x "$(set -x; command -v grcov)" ] \
-    && [ -x "$(set -x; command -v helm)" ] \
-    && [ -x "$(set -x; command -v aws)" ] \
     && [ -x "$(set -x; command -v solc)" ] \
     && [ -x "$(set -x; command -v z3)" ] \
     && [ -x "$(set -x; command -v "$BOOGIE_EXE")" ] \
     && [ -x "$(set -x; xargs rustup which cargo --toolchain < /diem/rust-toolchain )" ] \
-    && [ -x "$(set -x; command -v tidy)" ] \
-    && [ -x "$(set -x; command -v xsltproc)" ] \
     && [ -x "$(set -x; command -v javac)" ] \
     && [ -x "$(set -x; command -v clang)" ] \
     && [ -x "$(set -x; command -v python3)" ] \
@@ -56,6 +47,6 @@ RUN [ -x "$(set -x; command -v shellcheck)" ] \
 
 # should be a no-op
 # sccache builds fine, but is not executable ??? in alpine, ends up being recompiled.  Wierd.
-RUN /diem/scripts/dev_setup.sh -t -o -y -d -b -p -s -a
+RUN /diem/scripts/dev_setup.sh -t -y -d -b -p -s -a
 
 FROM setup_ci as build_environment

--- a/docker/ci/github/Dockerfile
+++ b/docker/ci/github/Dockerfile
@@ -14,7 +14,7 @@ ENV RUSTUP_HOME "/opt/rustup"
 RUN mkdir -p /github/home && \
     mkdir -p /opt/cargo/ && \
     mkdir -p /opt/git/ && \
-    /diem/scripts/dev_setup.sh -t -b -p -y -d -n -a && \
+    /diem/scripts/dev_setup.sh -t -b -p -y -d -n && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
@@ -39,11 +39,10 @@ RUN [ -x "$(set -x; command -v rustup)" ] \
     && [ -x "$(set -x; command -v "$BOOGIE_EXE")" ] \
     && [ -x "$(set -x; xargs rustup which cargo --toolchain < /diem/rust-toolchain )" ] \
     && [ -x "$(set -x; command -v clang)" ] \
-    && [ -x "$(set -x; command -v python3)" ] \
     && [ -x "$(set -x; command -v npm)" ]
 
 # should be a no-op
 # sccache builds fine, but is not executable ??? in alpine, ends up being recompiled.  Wierd.
-RUN /diem/scripts/dev_setup.sh -t -y -d -b -p -a
+RUN /diem/scripts/dev_setup.sh -t -y -d -b -p
 
 FROM setup_ci as build_environment

--- a/scripts/dev_setup.sh
+++ b/scripts/dev_setup.sh
@@ -35,7 +35,6 @@ function usage {
   echo "-p update ${HOME}/.profile"
   echo "-t install build tools"
   echo "-y installs or updates Move prover tools: z3, cvc5, dotnet, boogie"
-  echo "-a install tools for build and test api"
   echo "-d installs the solidity compiler"
   echo "-v verbose mode"
   echo "-i installs an individual tool by name"
@@ -406,18 +405,6 @@ function install_nodejs {
     install_pkg npm "$PACKAGE_MANAGER"
 }
 
-function install_python3 {
-  if [[ "$PACKAGE_MANAGER" == "apt-get" ]]; then
-    install_pkg python3-all-dev "$PACKAGE_MANAGER"
-    install_pkg python3-setuptools "$PACKAGE_MANAGER"
-    install_pkg python3-pip "$PACKAGE_MANAGER"
-  elif [[ "$PACKAGE_MANAGER" == "apk" ]]; then
-    install_pkg python3-dev "$PACKAGE_MANAGER"
-  else
-    install_pkg python3 "$PACKAGE_MANAGER"
-  fi
-}
-
 function install_solidity {
   echo "Installing Solidity compiler"
   # We fetch the binary from  https://binaries.soliditylang.org
@@ -476,13 +463,6 @@ Solidity compiler (since -d was provided):
 EOF
   fi
 
-  if [[ "$INSTALL_API_BUILD_TOOLS" == "true" ]]; then
-cat <<EOF
-API build and testing tools (since -a was provided):
-  * Python3 (schemathesis)
-EOF
-  fi
-
   if [[ "$INSTALL_PROFILE" == "true" ]]; then
 cat <<EOF
 Moreover, ~/.profile will be updated (since -p was provided).
@@ -501,14 +481,13 @@ INSTALL_BUILD_TOOLS=false;
 INSTALL_PROFILE=false;
 INSTALL_PROVER=false;
 INSTALL_SOLIDITY=false;
-INSTALL_API_BUILD_TOOLS=false;
 INSTALL_INDIVIDUAL=false;
 INSTALL_PACKAGES=();
 INSTALL_DIR="${HOME}/bin/"
 OPT_DIR="false"
 
 #parse args
-while getopts "btpvydah:i:n" arg; do
+while getopts "btpvydh:i:n" arg; do
   case "$arg" in
     b)
       BATCH_MODE="true"
@@ -527,9 +506,6 @@ while getopts "btpvydah:i:n" arg; do
       ;;
     d)
       INSTALL_SOLIDITY="true"
-      ;;
-    a)
-      INSTALL_API_BUILD_TOOLS="true"
       ;;
     i)
       INSTALL_INDIVIDUAL="true"
@@ -554,7 +530,6 @@ if [[ "$INSTALL_BUILD_TOOLS" == "false" ]] && \
    [[ "$INSTALL_PROFILE" == "false" ]] && \
    [[ "$INSTALL_PROVER" == "false" ]] && \
    [[ "$INSTALL_SOLIDITY" == "false" ]] && \
-   [[ "$INSTALL_API_BUILD_TOOLS" == "false" ]] && \
    [[ "$INSTALL_INDIVIDUAL" == "false" ]]; then
    INSTALL_BUILD_TOOLS="true"
 fi
@@ -682,12 +657,6 @@ fi
 
 if [[ "$INSTALL_SOLIDITY" == "true" ]]; then
   install_solidity
-fi
-
-if [[ "$INSTALL_API_BUILD_TOOLS" == "true" ]]; then
-  # python and tools
-  install_python3
-  "${PRE_COMMAND[@]}" python3 -m pip install schemathesis
 fi
 
 if [[ "${BATCH_MODE}" == "false" ]]; then


### PR DESCRIPTION
## Motivation

Per https://github.com/diem/move/issues/25, The dev_setup script installs many things (terraform, kubernetes, awscli, ...) that aren't needed to run Move. 

Aside from above-mentioned, I also looked into the following modules in dev_setup.sh and removed the Codegen tool and API build tool that are only used in `diem/diem`

<table>
<tr>
	<td> Decision
	<td> Module
	<td> Callsites in Diem/move
	<td> Callsites in Diem/Diem
<tr>
	<td> Solidity
	<td> Keep
	<td> https://github.com/diem/move/search?q=solidity
	<td> N/A
<tr>
	<td> Remove
	<td> CodeGen Tool
	<td> [N/A](https://github.com/diem/move/search?q=swift)
	<td> https://github.com/diem/diem/blob/dbbc96c7c3ae936bdf60744fd9055a5835b060d2/diem-move/transaction-builder-generator/README.md
<tr>
	<td> Remove
	<td> API Build Tool
	<td> [N/A](https://github.com/diem/move/search?q=schemathesis)
	<td> https://github.com/diem/diem/search?q=schemathesis
</table>



### Have you read the [Contributing Guidelines on pull requests]

Yes

## Test Plan

Ran docker build locally and verify that the build was successful
```
DOCKER_BUILDKIT=0 docker build -t 666lcz/move-1 .
```

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/diem/diem/tree/main/developers.diem.com, and link to your PR here.)

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
