### PR TITLE
[move-to-yul] Fixes to memory primitives & passing basic reference and struct tests

### DIFF
--- a/language/evm/move-to-yul/tests/Arithm.exp
+++ b/language/evm/move-to-yul/tests/Arithm.exp
@@ -14,7 +14,7 @@ object "A2_M" {
             mstore(0, memoryguard(160))
             if iszero(lt(calldatasize(), 4))
             {
-                let selector := $ShiftRight(224, calldataload(0))
+                let selector := $Shr(calldataload(0), 224)
                 switch selector
                 case 0x27a15f43
                 {
@@ -389,6 +389,9 @@ object "A2_M" {
                 if eq(y, 0) { $AbortBuiltin() }
                 r := mod(x, y)
             }
+            function $Shr(x, y) -> r {
+                r := shr(y, x)
+            }
             function $Gt(x, y) -> r {
                 r := gt(x, y)
             }
@@ -406,9 +409,6 @@ object "A2_M" {
             }
             function $LogicalNot(x) -> r {
                 r := not(x)
-            }
-            function $ShiftRight(bits, value) -> r {
-                r := shr(bits, value) // evm version >= constantinople
             }
         }
     }
@@ -686,6 +686,7 @@ object "A2_M" {
 
 object "test_A2_M_test_add_two_number" {
     code {
+        mstore(0, memoryguard(160))
         A2_M_test_add_two_number()
         return (0, 0)
         function A2_M_test_add_two_number() {
@@ -786,7 +787,7 @@ object "test_A2_M_test_add_two_number" {
         }
     }
 }
-===> Succeed(Stopped) (used_gas=343): []
+===> Succeed(Stopped) (used_gas=355): []
 
 // test of M::test_add_two_number_overflow
 /* =======================================
@@ -797,6 +798,7 @@ object "test_A2_M_test_add_two_number" {
 
 object "test_A2_M_test_add_two_number_overflow" {
     code {
+        mstore(0, memoryguard(160))
         A2_M_test_add_two_number_overflow()
         return (0, 0)
         function A2_M_test_add_two_number_overflow() {
@@ -856,6 +858,7 @@ object "test_A2_M_test_add_two_number_overflow" {
 
 object "test_A2_M_test_add_two_number_wrong_assert" {
     code {
+        mstore(0, memoryguard(160))
         A2_M_test_add_two_number_wrong_assert()
         return (0, 0)
         function A2_M_test_add_two_number_wrong_assert() {
@@ -956,7 +959,7 @@ object "test_A2_M_test_add_two_number_wrong_assert" {
         }
     }
 }
-===> Revert(Reverted) (used_gas=347): [0, 0, 0, 0, 0, 0, 0, 101]
+===> Revert(Reverted) (used_gas=356): [0, 0, 0, 0, 0, 0, 0, 101]
 
 // test of M::test_arithmetic_ops_aborts
 /* =======================================
@@ -967,6 +970,7 @@ object "test_A2_M_test_add_two_number_wrong_assert" {
 
 object "test_A2_M_test_arithmetic_ops_aborts" {
     code {
+        mstore(0, memoryguard(160))
         A2_M_test_arithmetic_ops_aborts()
         return (0, 0)
         function A2_M_test_arithmetic_ops_aborts() {
@@ -1087,7 +1091,7 @@ object "test_A2_M_test_arithmetic_ops_aborts" {
         }
     }
 }
-===> Revert(Reverted) (used_gas=276): [0, 0, 0, 0, 0, 0, 0, 42]
+===> Revert(Reverted) (used_gas=285): [0, 0, 0, 0, 0, 0, 0, 42]
 
 // test of M::test_bool_ops
 /* =======================================
@@ -1098,6 +1102,7 @@ object "test_A2_M_test_arithmetic_ops_aborts" {
 
 object "test_A2_M_test_bool_ops" {
     code {
+        mstore(0, memoryguard(160))
         A2_M_test_bool_ops()
         return (0, 0)
         function A2_M_test_bool_ops() {
@@ -1297,7 +1302,7 @@ object "test_A2_M_test_bool_ops" {
         }
     }
 }
-===> Succeed(Stopped) (used_gas=1216): []
+===> Succeed(Stopped) (used_gas=1228): []
 
 // test of M::test_div
 /* =======================================
@@ -1308,6 +1313,7 @@ object "test_A2_M_test_bool_ops" {
 
 object "test_A2_M_test_div" {
     code {
+        mstore(0, memoryguard(160))
         A2_M_test_div()
         return (0, 0)
         function A2_M_test_div() {
@@ -1412,7 +1418,7 @@ object "test_A2_M_test_div" {
         }
     }
 }
-===> Succeed(Stopped) (used_gas=343): []
+===> Succeed(Stopped) (used_gas=355): []
 
 // test of M::test_div_by_zero
 /* =======================================
@@ -1423,6 +1429,7 @@ object "test_A2_M_test_div" {
 
 object "test_A2_M_test_div_by_zero" {
     code {
+        mstore(0, memoryguard(160))
         A2_M_test_div_by_zero()
         return (0, 0)
         function A2_M_test_div_by_zero() {
@@ -1486,6 +1493,7 @@ object "test_A2_M_test_div_by_zero" {
 
 object "test_A2_M_test_div_wrong_assert" {
     code {
+        mstore(0, memoryguard(160))
         A2_M_test_div_wrong_assert()
         return (0, 0)
         function A2_M_test_div_wrong_assert() {
@@ -1590,7 +1598,7 @@ object "test_A2_M_test_div_wrong_assert" {
         }
     }
 }
-===> Revert(Reverted) (used_gas=339): [0, 0, 0, 0, 0, 0, 0, 101]
+===> Revert(Reverted) (used_gas=348): [0, 0, 0, 0, 0, 0, 0, 101]
 
 // test of M::test_multiple_ops
 /* =======================================
@@ -1601,6 +1609,7 @@ object "test_A2_M_test_div_wrong_assert" {
 
 object "test_A2_M_test_multiple_ops" {
     code {
+        mstore(0, memoryguard(160))
         A2_M_test_multiple_ops()
         return (0, 0)
         function A2_M_test_multiple_ops() {
@@ -1684,7 +1693,7 @@ object "test_A2_M_test_multiple_ops" {
         }
     }
 }
-===> Succeed(Stopped) (used_gas=164): []
+===> Succeed(Stopped) (used_gas=176): []
 
 // test of M::test_multiple_overflow
 /* =======================================
@@ -1695,6 +1704,7 @@ object "test_A2_M_test_multiple_ops" {
 
 object "test_A2_M_test_multiple_overflow" {
     code {
+        mstore(0, memoryguard(160))
         A2_M_test_multiple_overflow()
         return (0, 0)
         function A2_M_test_multiple_overflow() {
@@ -1789,6 +1799,7 @@ object "test_A2_M_test_multiple_overflow" {
 
 object "test_A2_M_test_underflow" {
     code {
+        mstore(0, memoryguard(160))
         A2_M_test_underflow()
         return (0, 0)
         function A2_M_test_underflow() {

--- a/language/evm/move-to-yul/tests/ControlStructures.exp
+++ b/language/evm/move-to-yul/tests/ControlStructures.exp
@@ -14,7 +14,7 @@ object "A2_M" {
             mstore(0, memoryguard(160))
             if iszero(lt(calldatasize(), 4))
             {
-                let selector := $ShiftRight(224, calldataload(0))
+                let selector := $Shr(calldataload(0), 224)
                 switch selector
                 case 0x70e8dbcb
                 {
@@ -337,6 +337,9 @@ object "A2_M" {
                 if eq(y, 0) { $AbortBuiltin() }
                 r := mod(x, y)
             }
+            function $Shr(x, y) -> r {
+                r := shr(y, x)
+            }
             function $Gt(x, y) -> r {
                 r := gt(x, y)
             }
@@ -345,9 +348,6 @@ object "A2_M" {
             }
             function $Eq(x, y) -> r {
                 r := eq(x, y)
-            }
-            function $ShiftRight(bits, value) -> r {
-                r := shr(bits, value) // evm version >= constantinople
             }
         }
     }

--- a/language/evm/move-to-yul/tests/Locals.exp
+++ b/language/evm/move-to-yul/tests/Locals.exp
@@ -14,7 +14,7 @@ object "A2_M" {
             mstore(0, memoryguard(160))
             if iszero(lt(calldatasize(), 4))
             {
-                let selector := $ShiftRight(224, calldataload(0))
+                let selector := $Shr(calldataload(0), 224)
                 switch selector
                 case 0xc11ae395
                 {
@@ -37,43 +37,43 @@ object "A2_M" {
                 let $locals := $Malloc(64)
                 mstore($locals, a)
                 // $t6 := copy($t0)
-                /// @src 2:109:110
+                /// @src 2:115:116
                 $t6 := mload($locals)
                 // $t3 := $t6
-                /// @src 2:105:106
+                /// @src 2:111:112
                 mstore(add($locals, 32), $t6)
                 // $t7 := copy($t3)
-                /// @src 2:125:126
+                /// @src 2:134:135
                 $t7 := mload(add($locals, 32))
                 // $t8 := +($t7, $t1)
-                /// @src 2:127:128
+                /// @src 2:136:137
                 $t8 := $AddU64($t7, b)
                 // $t9 := borrow_local($t0)
-                /// @src 2:146:152
-                $t9 := $MakePtr(false, $locals)
+                /// @src 2:158:164
+                $t9 := $MakePtr(false, add($locals, 24))
                 // $t10 := borrow_local($t3)
-                /// @src 2:168:170
-                $t10 := $MakePtr(false, add($locals, 32))
+                /// @src 2:183:185
+                $t10 := $MakePtr(false, add($locals, 56))
                 // $t11 := read_ref($t10)
-                /// @src 2:183:186
+                /// @src 2:201:204
                 $t11 := $LoadU64($t10)
                 // $t12 := 1
-                /// @src 2:189:190
+                /// @src 2:207:208
                 $t12 := 1
                 // $t13 := +($t11, $t12)
-                /// @src 2:187:188
+                /// @src 2:205:206
                 $t13 := $AddU64($t11, $t12)
                 // write_ref($t9, $t13)
-                /// @src 2:177:190
+                /// @src 2:195:208
                 $StoreU64($t9, $t13)
                 // $t14 := copy($t0)
-                /// @src 2:198:199
+                /// @src 2:219:220
                 $t14 := mload($locals)
                 // $t15 := copy($t3)
-                /// @src 2:204:205
+                /// @src 2:225:226
                 $t15 := mload(add($locals, 32))
                 // return ($t14, $t1, $t15, $t8)
-                /// @src 2:197:209
+                /// @src 2:218:230
                 $result0 := $t14
                 $result1 := b
                 $result2 := $t15
@@ -122,22 +122,96 @@ object "A2_M" {
             function $Malloc(size) -> offs {
                 offs := mload(0)
                 // pad to word size
-                mstore(0, add(offs, shr(add(size, 31), 5)))
+                mstore(0, add(offs, shl(5, shr(5, add(size, 31)))))
             }
             function $Free(offs, size) {
             }
             function $MakePtr(is_storage, offs) -> ptr {
-              ptr := or(is_storage, shl(offs, 1))
+              ptr := or(is_storage, shl(1, offs))
             }
             function $IsStoragePtr(ptr) -> b {
               b := and(ptr, 0x1)
             }
             function $OffsetPtr(ptr) -> offs {
-              offs := shr(ptr, 1)
+              offs := shr(1, ptr)
             }
-            function $ToWordOffs(offs) -> word_offs, bit_offs {
-              word_offs := shr(offs, 5)
-              bit_offs := shl(and(offs, 0x1F), 3)
+            function $MaskForSize(size) -> mask {
+              mask := sub(shl(shl(size, 3), 1), 1)
+            }
+            function $ExtractBytes(word, start, size) -> bytes {
+               switch size
+               case 1 {
+                  // use the faster byte primitive
+                  bytes := byte(start, word)
+               }
+               default {
+                  // As we have big endian, we need to right shift the value from
+                  // where the highest byte starts in the word (32 - start), minus
+                  // the size.
+                  let shift_bits := shl(3, sub(sub(32, start), size))
+                  bytes := and(shr(shift_bits, word), $MaskForSize(size))
+               }
+            }
+            function $InjectBytes(word, start, size, bytes) -> new_word {
+               let shift_bits := shl(3, sub(sub(32, start), size))
+               // Blend out the bits which we inject
+               let neg_mask := not(shl(shift_bits, $MaskForSize(size)))
+               word := and(word, neg_mask)
+               // Overlay the bits we inject
+               new_word := or(word, shl(shift_bits, bytes))
+            }
+            function $ToWordOffs(offs) -> word_offs, byte_offset {
+              word_offs := shr(5, offs)
+              byte_offset := and(offs, 0x1F)
+            }
+            function $OverflowBytes(byte_offset, size) -> overflow_bytes {
+              let available_bytes := sub(32, byte_offset)
+              switch gt(size, available_bytes)
+              case 0 {
+                overflow_bytes := 0
+              }
+              default {
+                overflow_bytes := sub(size, available_bytes)
+              }
+            }
+            function $MemoryLoadBytes(offs, size) -> val {
+              // Lower bit where the value in the higher bytes ends
+              let bit_end := shl(3, sub(32, size))
+              val := shr(bit_end, mload(offs))
+            }
+            function $MemoryStoreBytes(offs, size, val) {
+              let bit_end := shl(3, sub(32, size))
+              let mask := shl(bit_end, $MaskForSize(size))
+              mstore(offs, or(and(mload(offs), not(mask)), shl(bit_end, val)))
+            }
+            function $StorageLoadBytes(offs, size) -> val {
+              let word_offs, byte_offs := $ToWordOffs(offs)
+              let key := $StorageKey(0, word_offs)
+              val := $ExtractBytes(sload(key), byte_offs, size)
+              let overflow_bytes := $OverflowBytes(byte_offs, size)
+              if not(iszero(overflow_bytes)) {
+                key := $StorageKey(0, add(word_offs, 1))
+                let extra_bytes := $ExtractBytes(sload(key), 0, overflow_bytes)
+                val := or(shl(shl(3, overflow_bytes), val), extra_bytes)
+              }
+            }
+            function $StorageStoreBytes(offs, size, bytes) {
+              let word_offs, byte_offs := $ToWordOffs(offs)
+              let key := $StorageKey(0, word_offs)
+              let overflow_bytes := $OverflowBytes(byte_offs, size)
+              switch overflow_bytes
+              case 0 {
+                sstore(key, $InjectBytes(sload(key), byte_offs, size, bytes))
+              }
+              default {
+                // Shift the higher bytes to the right
+                let used_bytes := sub(size, overflow_bytes)
+                let higher_bytes := shr(used_bytes, bytes)
+                let lower_bytes := and(bytes, $MaskForSize(overflow_bytes))
+                sstore(key, $InjectBytes(sload(key), byte_offs, used_bytes, higher_bytes))
+                key := $StorageKey(0, add(word_offs, 1))
+                sstore(key, $InjectBytes(sload(key), 0, overflow_bytes, lower_bytes))
+              }
             }
             function $StorageKey(group, word) -> key {
               mstore(32, word)
@@ -155,19 +229,10 @@ object "A2_M" {
               }
             }
             function $MemoryLoadU64(offs) -> val {
-              val := and(mload(offs), 0xffffffffffffffff)
+              val := $MemoryLoadBytes(offs, 8)
             }
             function $StorageLoadU64(offs) -> val {
-              let word_offs, bit_offs := $ToWordOffs(offs)
-              let key := $StorageKey(0, word_offs)
-              val := and(shr(sload(key), bit_offs), 0xffffffffffffffff)
-              let used_bits := sub(256, bit_offs)
-              if lt(used_bits, 64) {
-                let overflow_bits := sub(64, used_bits)
-                let mask := sub(shl(1, overflow_bits), 1)
-                key := $StorageKey(0, add(word_offs, 1))
-                val := or(val, shl(and(sload(key), mask), used_bits))
-              }
+              val := $StorageLoadBytes(offs, 8)
             }
             function $StoreU64(ptr, val) {
               let offs := $OffsetPtr(ptr)
@@ -180,28 +245,17 @@ object "A2_M" {
               }
             }
             function $MemoryStoreU64(offs, val) {
-              mstore(offs, or(and(mload(offs), not(0xffffffffffffffff)), val))
+              $MemoryStoreBytes(offs, 8, val)
             }
             function $StorageStoreU64(offs, val) {
-              let word_offs, bit_offs := $ToWordOffs(offs)
-              let key := $StorageKey(0, word_offs)
-              let word := sload(key)
-              word := or(and(word, not(shl(0xffffffffffffffff, bit_offs))), shl(val, bit_offs))
-              mstore(key, word)
-              let used_bits := sub(256, bit_offs)
-              if lt(used_bits, 64) {
-                let overflow_bits := sub(64, used_bits)
-                let mask := sub(shl(1, overflow_bits), 1)
-                key := $StorageKey(0, add(word_offs, 1))
-                sstore(key, or(and(sload(key), not(mask)), shr(val, used_bits)))
-              }
+              $StorageStoreBytes(offs, 8, val)
             }
             function $AddU64(x, y) -> r {
                 if lt(sub(0xffffffffffffffff, x), y) { $AbortBuiltin() }
                 r := add(x, y)
             }
-            function $ShiftRight(bits, value) -> r {
-                r := shr(bits, value) // evm version >= constantinople
+            function $Shr(x, y) -> r {
+                r := shr(y, x)
             }
         }
     }
@@ -255,35 +309,35 @@ object "A2_M" {
             {
                 let _1 := 0
                 let offs := mload(_1)
-                mstore(_1, offs)
+                mstore(_1, add(offs, 64))
                 mstore(offs, a)
                 let _2 := add(offs, 32)
                 mstore(_2, a)
                 let $t8 := $AddU64(a, b)
-                let _3 := 1
-                let _4 := or(false, shl(_2, _3))
+                let _3 := or(false, shl(1, add(offs, 56)))
                 let val := _1
-                let offs_1 := shr(_4, _3)
-                switch and(_4, _3)
+                let offs_1 := shr(1, _3)
+                switch and(_3, 1)
                 case 0 {
-                    val := and(mload(offs_1), 0xffffffffffffffff)
+                    val := shr(192, mload(offs_1))
                 }
                 default {
                     let val_1 := _1
-                    let word_offs, bit_offs := $ToWordOffs(offs_1)
+                    let word_offs := shr(6, _3)
+                    let byte_offset := and(offs_1, 31)
                     mstore(32, word_offs)
                     mstore(64, _1)
-                    val_1 := and(shr(sload(keccak256(32, 36)), bit_offs), 0xffffffffffffffff)
-                    let used_bits := sub(256, bit_offs)
-                    if lt(used_bits, 64)
+                    val_1 := $ExtractBytes_947(sload(keccak256(32, 36)), byte_offset)
+                    let overflow_bytes := $OverflowBytes(byte_offset)
+                    if not(iszero(overflow_bytes))
                     {
-                        mstore(32, add(word_offs, _3))
+                        mstore(32, add(word_offs, 1))
                         mstore(64, _1)
-                        val_1 := or(val_1, shl(and(sload(keccak256(32, 36)), add(shl(_3, add(bit_offs, not(191))), not(0))), used_bits))
+                        val_1 := or(shl(shl(3, overflow_bytes), val_1), $ExtractBytes(sload(keccak256(32, 36)), overflow_bytes))
                     }
                     val := val_1
                 }
-                $StoreU64(or(false, shl(offs, _3)), $AddU64_686(val))
+                $StoreU64(or(false, shl(1, add(offs, 24))), $AddU64_950(val))
                 let $t14 := mload(offs)
                 let $t15 := mload(_2)
                 $result0 := $t14
@@ -314,36 +368,70 @@ object "A2_M" {
                 mstore(0, 97)
                 revert(24, 8)
             }
-            function $ToWordOffs(offs) -> word_offs, bit_offs
+            function $ExtractBytes_947(word, start) -> bytes
             {
-                word_offs := shr(offs, 5)
-                bit_offs := shl(and(offs, 0x1F), 3)
+                bytes := shr(shl(3, add(sub(32, start), not(7))), word)
+            }
+            function $ExtractBytes(word, size) -> bytes
+            {
+                switch size
+                case 1 { bytes := byte(0, word) }
+                default {
+                    bytes := and(shr(shl(3, sub(32, size)), word), add(shl(shl(size, 3), 1), not(0)))
+                }
+            }
+            function $InjectBytes_957(word, start, bytes) -> new_word
+            {
+                let shift_bits := shl(3, add(sub(32, start), not(7)))
+                new_word := or(and(word, not(shl(shift_bits, not(0)))), shl(shift_bits, bytes))
+            }
+            function $InjectBytes_958(word, size, bytes) -> new_word
+            {
+                let shift_bits := shl(3, sub(32, size))
+                new_word := or(and(word, not(shl(shift_bits, add(shl(shl(size, 3), 1), not(0))))), shl(shift_bits, bytes))
+            }
+            function $InjectBytes(word, start, size, bytes) -> new_word
+            {
+                let shift_bits := shl(3, sub(32, add(start, size)))
+                new_word := or(and(word, not(shl(shift_bits, add(shl(shl(size, 3), 1), not(0))))), shl(shift_bits, bytes))
+            }
+            function $OverflowBytes(byte_offset) -> overflow_bytes
+            {
+                switch gt(8, sub(32, byte_offset))
+                case 0 { overflow_bytes := 0 }
+                default {
+                    overflow_bytes := add(byte_offset, not(23))
+                }
             }
             function $StoreU64(ptr, val)
             {
-                let offs := shr(ptr, 1)
+                let offs := shr(1, ptr)
                 switch and(ptr, 1)
                 case 0 {
-                    mstore(offs, or(and(mload(offs), not(0xffffffffffffffff)), val))
+                    mstore(offs, or(and(mload(offs), sub(shl(192, 1), 1)), shl(192, val)))
                 }
                 default {
-                    let word_offs, bit_offs := $ToWordOffs(offs)
+                    let word_offs := shr(6, ptr)
+                    let byte_offset := and(offs, 0x1F)
                     mstore(32, word_offs)
                     mstore(64, 0)
                     let key := keccak256(32, 36)
-                    let word := sload(key)
-                    mstore(key, or(word, shl(val, bit_offs)))
-                    let used_bits := sub(256, bit_offs)
-                    if lt(used_bits, 64)
-                    {
+                    let overflow_bytes := $OverflowBytes(byte_offset)
+                    switch overflow_bytes
+                    case 0 {
+                        sstore(key, $InjectBytes_957(sload(key), byte_offset, val))
+                    }
+                    default {
+                        let used_bytes := sub(8, overflow_bytes)
+                        sstore(key, $InjectBytes(sload(key), byte_offset, used_bytes, shr(used_bytes, val)))
                         mstore(32, add(word_offs, 1))
                         mstore(64, 0)
                         let key_1 := keccak256(32, 36)
-                        sstore(key_1, or(and(sload(key_1), not(add(shl(1, add(bit_offs, not(191))), not(0)))), shr(val, used_bits)))
+                        sstore(key_1, $InjectBytes_958(sload(key_1), overflow_bytes, and(val, add(shl(shl(overflow_bytes, 3), 1), not(0)))))
                     }
                 }
             }
-            function $AddU64_686(x) -> r
+            function $AddU64_950(x) -> r
             {
                 if lt(sub(0xffffffffffffffff, x), 1)
                 {
@@ -364,3 +452,502 @@ object "A2_M" {
         }
     }
 }
+
+!! Unit tests
+
+// test of M::test_call_by_ref
+/* =======================================
+ * Generated by Move-To-Yul compiler v0.0
+ * ======================================= */
+
+/// @use-src 2:"tests/Locals.move"
+
+object "test_A2_M_test_call_by_ref" {
+    code {
+        mstore(0, memoryguard(160))
+        A2_M_test_call_by_ref()
+        return (0, 0)
+        function A2_M_test_call_by_ref() {
+            let $t1, $t2, $t3, $t4, $t5, $t6
+            let $locals := $Malloc(32)
+            let $block := 4
+            for {} true {} {
+                switch $block
+                case 2 {
+                    // label L1
+                    // $t6 := 101
+                    /// @src 2:653:656
+                    $t6 := 101
+                    // abort($t6)
+                    /// @src 2:637:657
+                    $Abort($t6)
+                }
+                case 3 {
+                    // label L0
+                    // return ()
+                    /// @src 2:657:658
+                    $Free($locals, 32)
+                    leave
+                }
+                case 4 {
+                    // $t1 := 1
+                    /// @src 2:565:566
+                    $t1 := 1
+                    // $t0 := $t1
+                    /// @src 2:561:562
+                    mstore($locals, $t1)
+                    // $t2 := borrow_local($t0)
+                    /// @src 2:620:626
+                    $t2 := $MakePtr(false, add($locals, 24))
+                    // M::call_by_ref($t2)
+                    /// @src 2:608:627
+                    A2_M_call_by_ref($t2)
+                    // $t3 := copy($t0)
+                    /// @src 2:645:646
+                    $t3 := mload($locals)
+                    // $t4 := 2
+                    /// @src 2:650:651
+                    $t4 := 2
+                    // $t5 := ==($t3, $t4)
+                    /// @src 2:647:649
+                    $t5 := $Eq($t3, $t4)
+                    // if ($t5) goto L0 else goto L1
+                    /// @src 2:637:657
+                    switch $t5
+                    case 0  { $block := 2 }
+                    default { $block := 3 }
+                }
+            }
+        }
+
+        function A2_M_call_by_ref(a) {
+            let $t1
+            // $t1 := 2
+            /// @src 2:494:495
+            $t1 := 2
+            // write_ref($t0, $t1)
+            /// @src 2:489:495
+            $StoreU64(a, $t1)
+            // return ()
+            /// @src 2:495:496
+        }
+
+        function $Abort(code) {
+            mstore(0, code)
+            revert(24, 8) // TODO: store code as a string?
+        }
+        function $Malloc(size) -> offs {
+            offs := mload(0)
+            // pad to word size
+            mstore(0, add(offs, shl(5, shr(5, add(size, 31)))))
+        }
+        function $Free(offs, size) {
+        }
+        function $MakePtr(is_storage, offs) -> ptr {
+          ptr := or(is_storage, shl(1, offs))
+        }
+        function $IsStoragePtr(ptr) -> b {
+          b := and(ptr, 0x1)
+        }
+        function $OffsetPtr(ptr) -> offs {
+          offs := shr(1, ptr)
+        }
+        function $MaskForSize(size) -> mask {
+          mask := sub(shl(shl(size, 3), 1), 1)
+        }
+        function $InjectBytes(word, start, size, bytes) -> new_word {
+           let shift_bits := shl(3, sub(sub(32, start), size))
+           // Blend out the bits which we inject
+           let neg_mask := not(shl(shift_bits, $MaskForSize(size)))
+           word := and(word, neg_mask)
+           // Overlay the bits we inject
+           new_word := or(word, shl(shift_bits, bytes))
+        }
+        function $ToWordOffs(offs) -> word_offs, byte_offset {
+          word_offs := shr(5, offs)
+          byte_offset := and(offs, 0x1F)
+        }
+        function $OverflowBytes(byte_offset, size) -> overflow_bytes {
+          let available_bytes := sub(32, byte_offset)
+          switch gt(size, available_bytes)
+          case 0 {
+            overflow_bytes := 0
+          }
+          default {
+            overflow_bytes := sub(size, available_bytes)
+          }
+        }
+        function $MemoryStoreBytes(offs, size, val) {
+          let bit_end := shl(3, sub(32, size))
+          let mask := shl(bit_end, $MaskForSize(size))
+          mstore(offs, or(and(mload(offs), not(mask)), shl(bit_end, val)))
+        }
+        function $StorageStoreBytes(offs, size, bytes) {
+          let word_offs, byte_offs := $ToWordOffs(offs)
+          let key := $StorageKey(0, word_offs)
+          let overflow_bytes := $OverflowBytes(byte_offs, size)
+          switch overflow_bytes
+          case 0 {
+            sstore(key, $InjectBytes(sload(key), byte_offs, size, bytes))
+          }
+          default {
+            // Shift the higher bytes to the right
+            let used_bytes := sub(size, overflow_bytes)
+            let higher_bytes := shr(used_bytes, bytes)
+            let lower_bytes := and(bytes, $MaskForSize(overflow_bytes))
+            sstore(key, $InjectBytes(sload(key), byte_offs, used_bytes, higher_bytes))
+            key := $StorageKey(0, add(word_offs, 1))
+            sstore(key, $InjectBytes(sload(key), 0, overflow_bytes, lower_bytes))
+          }
+        }
+        function $StorageKey(group, word) -> key {
+          mstore(32, word)
+          mstore(64, group)
+          key := keccak256(32, 36)
+        }
+        function $StoreU64(ptr, val) {
+          let offs := $OffsetPtr(ptr)
+          switch $IsStoragePtr(ptr)
+          case 0 {
+            $MemoryStoreU64(offs, val)
+          }
+          default {
+            $StorageStoreU64(offs, val)
+          }
+        }
+        function $MemoryStoreU64(offs, val) {
+          $MemoryStoreBytes(offs, 8, val)
+        }
+        function $StorageStoreU64(offs, val) {
+          $StorageStoreBytes(offs, 8, val)
+        }
+        function $Eq(x, y) -> r {
+            r := eq(x, y)
+        }
+    }
+}
+===> Succeed(Stopped) (used_gas=410): []
+
+// test of M::test_evaded
+/* =======================================
+ * Generated by Move-To-Yul compiler v0.0
+ * ======================================= */
+
+/// @use-src 2:"tests/Locals.move"
+
+object "test_A2_M_test_evaded" {
+    code {
+        mstore(0, memoryguard(160))
+        A2_M_test_evaded()
+        return (0, 0)
+        function A2_M_test_evaded() {
+            let a, b, c, d, $t4, $t5, $t6, $t7, $t8, $t9, $t10, $t11, $t12, $t13, $t14, $t15, $t16, $t17, $t18, $t19, $t20, $t21
+            let $block := 4
+            for {} true {} {
+                switch $block
+                case 2 {
+                    // label L1
+                    // $t12 := 100
+                    /// @src 2:343:346
+                    $t12 := 100
+                    // abort($t12)
+                    /// @src 2:327:347
+                    $Abort($t12)
+                }
+                case 3 {
+                    // label L0
+                    // $t13 := 2
+                    /// @src 2:370:371
+                    $t13 := 2
+                    // $t14 := ==($t7, $t13)
+                    /// @src 2:367:369
+                    $t14 := $Eq($t7, $t13)
+                    // if ($t14) goto L2 else goto L3
+                    /// @src 2:357:377
+                    switch $t14
+                    case 0  { $block := 5 }
+                    default { $block := 6 }
+                }
+                case 4 {
+                    // $t4 := 1
+                    /// @src 2:312:313
+                    $t4 := 1
+                    // $t5 := 2
+                    /// @src 2:315:316
+                    $t5 := 2
+                    // ($t6, $t7, $t8, $t9) := M::evaded($t4, $t5)
+                    /// @src 2:305:317
+                    $t6, $t7, $t8, $t9 := A2_M_evaded($t4, $t5)
+                    // $t10 := 2
+                    /// @src 2:340:341
+                    $t10 := 2
+                    // $t11 := ==($t6, $t10)
+                    /// @src 2:337:339
+                    $t11 := $Eq($t6, $t10)
+                    // if ($t11) goto L0 else goto L1
+                    /// @src 2:327:347
+                    switch $t11
+                    case 0  { $block := 2 }
+                    default { $block := 3 }
+                }
+                case 5 {
+                    // label L3
+                    // $t15 := 101
+                    /// @src 2:373:376
+                    $t15 := 101
+                    // abort($t15)
+                    /// @src 2:357:377
+                    $Abort($t15)
+                }
+                case 6 {
+                    // label L2
+                    // $t16 := 1
+                    /// @src 2:400:401
+                    $t16 := 1
+                    // $t17 := ==($t8, $t16)
+                    /// @src 2:397:399
+                    $t17 := $Eq($t8, $t16)
+                    // if ($t17) goto L4 else goto L5
+                    /// @src 2:387:407
+                    switch $t17
+                    case 0  { $block := 7 }
+                    default { $block := 8 }
+                }
+                case 7 {
+                    // label L5
+                    // $t18 := 102
+                    /// @src 2:403:406
+                    $t18 := 102
+                    // abort($t18)
+                    /// @src 2:387:407
+                    $Abort($t18)
+                }
+                case 8 {
+                    // label L4
+                    // $t19 := 3
+                    /// @src 2:430:431
+                    $t19 := 3
+                    // $t20 := ==($t9, $t19)
+                    /// @src 2:427:429
+                    $t20 := $Eq($t9, $t19)
+                    // if ($t20) goto L6 else goto L7
+                    /// @src 2:417:437
+                    switch $t20
+                    case 0  { $block := 9 }
+                    default { $block := 10 }
+                }
+                case 9 {
+                    // label L7
+                    // $t21 := 103
+                    /// @src 2:433:436
+                    $t21 := 103
+                    // abort($t21)
+                    /// @src 2:417:437
+                    $Abort($t21)
+                }
+                case 10 {
+                    // label L6
+                    // return ()
+                    /// @src 2:437:438
+                    leave
+                }
+            }
+        }
+
+        function A2_M_evaded(a, b) -> $result0, $result1, $result2, $result3 {
+            let ar, cr, d, $t6, $t7, $t8, $t9, $t10, $t11, $t12, $t13, $t14, $t15
+            let $locals := $Malloc(64)
+            mstore($locals, a)
+            // $t6 := copy($t0)
+            /// @src 2:115:116
+            $t6 := mload($locals)
+            // $t3 := $t6
+            /// @src 2:111:112
+            mstore(add($locals, 32), $t6)
+            // $t7 := copy($t3)
+            /// @src 2:134:135
+            $t7 := mload(add($locals, 32))
+            // $t8 := +($t7, $t1)
+            /// @src 2:136:137
+            $t8 := $AddU64($t7, b)
+            // $t9 := borrow_local($t0)
+            /// @src 2:158:164
+            $t9 := $MakePtr(false, add($locals, 24))
+            // $t10 := borrow_local($t3)
+            /// @src 2:183:185
+            $t10 := $MakePtr(false, add($locals, 56))
+            // $t11 := read_ref($t10)
+            /// @src 2:201:204
+            $t11 := $LoadU64($t10)
+            // $t12 := 1
+            /// @src 2:207:208
+            $t12 := 1
+            // $t13 := +($t11, $t12)
+            /// @src 2:205:206
+            $t13 := $AddU64($t11, $t12)
+            // write_ref($t9, $t13)
+            /// @src 2:195:208
+            $StoreU64($t9, $t13)
+            // $t14 := copy($t0)
+            /// @src 2:219:220
+            $t14 := mload($locals)
+            // $t15 := copy($t3)
+            /// @src 2:225:226
+            $t15 := mload(add($locals, 32))
+            // return ($t14, $t1, $t15, $t8)
+            /// @src 2:218:230
+            $result0 := $t14
+            $result1 := b
+            $result2 := $t15
+            $result3 := $t8
+            $Free($locals, 64)
+        }
+
+        function $Abort(code) {
+            mstore(0, code)
+            revert(24, 8) // TODO: store code as a string?
+        }
+        function $AbortBuiltin() {
+            $Abort(sub(0, 1))
+        }
+        function $Malloc(size) -> offs {
+            offs := mload(0)
+            // pad to word size
+            mstore(0, add(offs, shl(5, shr(5, add(size, 31)))))
+        }
+        function $Free(offs, size) {
+        }
+        function $MakePtr(is_storage, offs) -> ptr {
+          ptr := or(is_storage, shl(1, offs))
+        }
+        function $IsStoragePtr(ptr) -> b {
+          b := and(ptr, 0x1)
+        }
+        function $OffsetPtr(ptr) -> offs {
+          offs := shr(1, ptr)
+        }
+        function $MaskForSize(size) -> mask {
+          mask := sub(shl(shl(size, 3), 1), 1)
+        }
+        function $ExtractBytes(word, start, size) -> bytes {
+           switch size
+           case 1 {
+              // use the faster byte primitive
+              bytes := byte(start, word)
+           }
+           default {
+              // As we have big endian, we need to right shift the value from
+              // where the highest byte starts in the word (32 - start), minus
+              // the size.
+              let shift_bits := shl(3, sub(sub(32, start), size))
+              bytes := and(shr(shift_bits, word), $MaskForSize(size))
+           }
+        }
+        function $InjectBytes(word, start, size, bytes) -> new_word {
+           let shift_bits := shl(3, sub(sub(32, start), size))
+           // Blend out the bits which we inject
+           let neg_mask := not(shl(shift_bits, $MaskForSize(size)))
+           word := and(word, neg_mask)
+           // Overlay the bits we inject
+           new_word := or(word, shl(shift_bits, bytes))
+        }
+        function $ToWordOffs(offs) -> word_offs, byte_offset {
+          word_offs := shr(5, offs)
+          byte_offset := and(offs, 0x1F)
+        }
+        function $OverflowBytes(byte_offset, size) -> overflow_bytes {
+          let available_bytes := sub(32, byte_offset)
+          switch gt(size, available_bytes)
+          case 0 {
+            overflow_bytes := 0
+          }
+          default {
+            overflow_bytes := sub(size, available_bytes)
+          }
+        }
+        function $MemoryLoadBytes(offs, size) -> val {
+          // Lower bit where the value in the higher bytes ends
+          let bit_end := shl(3, sub(32, size))
+          val := shr(bit_end, mload(offs))
+        }
+        function $MemoryStoreBytes(offs, size, val) {
+          let bit_end := shl(3, sub(32, size))
+          let mask := shl(bit_end, $MaskForSize(size))
+          mstore(offs, or(and(mload(offs), not(mask)), shl(bit_end, val)))
+        }
+        function $StorageLoadBytes(offs, size) -> val {
+          let word_offs, byte_offs := $ToWordOffs(offs)
+          let key := $StorageKey(0, word_offs)
+          val := $ExtractBytes(sload(key), byte_offs, size)
+          let overflow_bytes := $OverflowBytes(byte_offs, size)
+          if not(iszero(overflow_bytes)) {
+            key := $StorageKey(0, add(word_offs, 1))
+            let extra_bytes := $ExtractBytes(sload(key), 0, overflow_bytes)
+            val := or(shl(shl(3, overflow_bytes), val), extra_bytes)
+          }
+        }
+        function $StorageStoreBytes(offs, size, bytes) {
+          let word_offs, byte_offs := $ToWordOffs(offs)
+          let key := $StorageKey(0, word_offs)
+          let overflow_bytes := $OverflowBytes(byte_offs, size)
+          switch overflow_bytes
+          case 0 {
+            sstore(key, $InjectBytes(sload(key), byte_offs, size, bytes))
+          }
+          default {
+            // Shift the higher bytes to the right
+            let used_bytes := sub(size, overflow_bytes)
+            let higher_bytes := shr(used_bytes, bytes)
+            let lower_bytes := and(bytes, $MaskForSize(overflow_bytes))
+            sstore(key, $InjectBytes(sload(key), byte_offs, used_bytes, higher_bytes))
+            key := $StorageKey(0, add(word_offs, 1))
+            sstore(key, $InjectBytes(sload(key), 0, overflow_bytes, lower_bytes))
+          }
+        }
+        function $StorageKey(group, word) -> key {
+          mstore(32, word)
+          mstore(64, group)
+          key := keccak256(32, 36)
+        }
+        function $LoadU64(ptr) -> val {
+          let offs := $OffsetPtr(ptr)
+          switch $IsStoragePtr(ptr)
+          case 0 {
+            val := $MemoryLoadU64(offs)
+          }
+          default {
+            val := $StorageLoadU64(offs)
+          }
+        }
+        function $MemoryLoadU64(offs) -> val {
+          val := $MemoryLoadBytes(offs, 8)
+        }
+        function $StorageLoadU64(offs) -> val {
+          val := $StorageLoadBytes(offs, 8)
+        }
+        function $StoreU64(ptr, val) {
+          let offs := $OffsetPtr(ptr)
+          switch $IsStoragePtr(ptr)
+          case 0 {
+            $MemoryStoreU64(offs, val)
+          }
+          default {
+            $StorageStoreU64(offs, val)
+          }
+        }
+        function $MemoryStoreU64(offs, val) {
+          $MemoryStoreBytes(offs, 8, val)
+        }
+        function $StorageStoreU64(offs, val) {
+          $StorageStoreBytes(offs, 8, val)
+        }
+        function $AddU64(x, y) -> r {
+            if lt(sub(0xffffffffffffffff, x), y) { $AbortBuiltin() }
+            r := add(x, y)
+        }
+        function $Eq(x, y) -> r {
+            r := eq(x, y)
+        }
+    }
+}
+===> Succeed(Stopped) (used_gas=1261): []

--- a/language/evm/move-to-yul/tests/Locals.move
+++ b/language/evm/move-to-yul/tests/Locals.move
@@ -1,12 +1,33 @@
 #[contract]
 module 0x2::M {
     #[callable]
-	fun evaded(a: u64, b: u64): (u64, u64, u64, u64) {
-	    let c = a;
-	    let d = c + b;
-	    let ar = &mut a;
-	    let cr = &c;
-	    *ar = *cr + 1;
-	    (a, b, c, d)
-	}
+    fun evaded(a: u64, b: u64): (u64, u64, u64, u64) {
+        let c = a;
+        let d = c + b;
+        let ar = &mut a;
+        let cr = &c;
+        *ar = *cr + 1;
+        (a, b, c, d)
+    }
+
+    #[evm_test]
+    fun test_evaded() {
+        let (a, b, c, d) = evaded(1, 2);
+        assert!(a == 2, 100);
+        assert!(b == 2, 101);
+        assert!(c == 1, 102);
+        assert!(d == 3, 103);
+    }
+
+    fun call_by_ref(a: &mut u64) {
+        *a = 2;
+    }
+
+    #[evm_test]
+    fun test_call_by_ref() {
+        let a = 1;
+        //assert!(a == 1, 100);
+        call_by_ref(&mut a);
+        assert!(a == 2, 101);
+    }
 }

--- a/language/evm/move-to-yul/tests/MoveCalls.exp
+++ b/language/evm/move-to-yul/tests/MoveCalls.exp
@@ -14,7 +14,7 @@ object "A2_M" {
             mstore(0, memoryguard(160))
             if iszero(lt(calldatasize(), 4))
             {
-                let selector := $ShiftRight(224, calldataload(0))
+                let selector := $Shr(calldataload(0), 224)
                 switch selector
                 case 0x70e8dbcb
                 {
@@ -121,8 +121,8 @@ object "A2_M" {
                 if lt(x, y) { $AbortBuiltin() }
                 r := sub(x, y)
             }
-            function $ShiftRight(bits, value) -> r {
-                r := shr(bits, value) // evm version >= constantinople
+            function $Shr(x, y) -> r {
+                r := shr(y, x)
             }
         }
     }

--- a/language/evm/move-to-yul/tests/NoGenericCallable.exp
+++ b/language/evm/move-to-yul/tests/NoGenericCallable.exp
@@ -14,7 +14,7 @@ object "A2_M" {
             mstore(0, memoryguard(160))
             if iszero(lt(calldatasize(), 4))
             {
-                let selector := $ShiftRight(224, calldataload(0))
+                let selector := $Shr(calldataload(0), 224)
                 switch selector
                 case 0x70e8dbcb
                 {
@@ -66,8 +66,8 @@ object "A2_M" {
                 mstore(0, code)
                 revert(24, 8) // TODO: store code as a string?
             }
-            function $ShiftRight(bits, value) -> r {
-                r := shr(bits, value) // evm version >= constantinople
+            function $Shr(x, y) -> r {
+                r := shr(y, x)
             }
         }
     }

--- a/language/evm/move-to-yul/tests/Resources.exp
+++ b/language/evm/move-to-yul/tests/Resources.exp
@@ -14,7 +14,7 @@ object "A2_M" {
             mstore(0, memoryguard(160))
             if iszero(lt(calldatasize(), 4))
             {
-                let selector := $ShiftRight(224, calldataload(0))
+                let selector := $Shr(calldataload(0), 224)
                 switch selector
                 case 0x6fd78c6f
                 {
@@ -161,20 +161,94 @@ object "A2_M" {
             function $Malloc(size) -> offs {
                 offs := mload(0)
                 // pad to word size
-                mstore(0, add(offs, shr(add(size, 31), 5)))
+                mstore(0, add(offs, shl(5, shr(5, add(size, 31)))))
             }
             function $MakePtr(is_storage, offs) -> ptr {
-              ptr := or(is_storage, shl(offs, 1))
+              ptr := or(is_storage, shl(1, offs))
             }
             function $IsStoragePtr(ptr) -> b {
               b := and(ptr, 0x1)
             }
             function $OffsetPtr(ptr) -> offs {
-              offs := shr(ptr, 1)
+              offs := shr(1, ptr)
             }
-            function $ToWordOffs(offs) -> word_offs, bit_offs {
-              word_offs := shr(offs, 5)
-              bit_offs := shl(and(offs, 0x1F), 3)
+            function $MaskForSize(size) -> mask {
+              mask := sub(shl(shl(size, 3), 1), 1)
+            }
+            function $ExtractBytes(word, start, size) -> bytes {
+               switch size
+               case 1 {
+                  // use the faster byte primitive
+                  bytes := byte(start, word)
+               }
+               default {
+                  // As we have big endian, we need to right shift the value from
+                  // where the highest byte starts in the word (32 - start), minus
+                  // the size.
+                  let shift_bits := shl(3, sub(sub(32, start), size))
+                  bytes := and(shr(shift_bits, word), $MaskForSize(size))
+               }
+            }
+            function $InjectBytes(word, start, size, bytes) -> new_word {
+               let shift_bits := shl(3, sub(sub(32, start), size))
+               // Blend out the bits which we inject
+               let neg_mask := not(shl(shift_bits, $MaskForSize(size)))
+               word := and(word, neg_mask)
+               // Overlay the bits we inject
+               new_word := or(word, shl(shift_bits, bytes))
+            }
+            function $ToWordOffs(offs) -> word_offs, byte_offset {
+              word_offs := shr(5, offs)
+              byte_offset := and(offs, 0x1F)
+            }
+            function $OverflowBytes(byte_offset, size) -> overflow_bytes {
+              let available_bytes := sub(32, byte_offset)
+              switch gt(size, available_bytes)
+              case 0 {
+                overflow_bytes := 0
+              }
+              default {
+                overflow_bytes := sub(size, available_bytes)
+              }
+            }
+            function $MemoryLoadBytes(offs, size) -> val {
+              // Lower bit where the value in the higher bytes ends
+              let bit_end := shl(3, sub(32, size))
+              val := shr(bit_end, mload(offs))
+            }
+            function $MemoryStoreBytes(offs, size, val) {
+              let bit_end := shl(3, sub(32, size))
+              let mask := shl(bit_end, $MaskForSize(size))
+              mstore(offs, or(and(mload(offs), not(mask)), shl(bit_end, val)))
+            }
+            function $StorageLoadBytes(offs, size) -> val {
+              let word_offs, byte_offs := $ToWordOffs(offs)
+              let key := $StorageKey(0, word_offs)
+              val := $ExtractBytes(sload(key), byte_offs, size)
+              let overflow_bytes := $OverflowBytes(byte_offs, size)
+              if not(iszero(overflow_bytes)) {
+                key := $StorageKey(0, add(word_offs, 1))
+                let extra_bytes := $ExtractBytes(sload(key), 0, overflow_bytes)
+                val := or(shl(shl(3, overflow_bytes), val), extra_bytes)
+              }
+            }
+            function $StorageStoreBytes(offs, size, bytes) {
+              let word_offs, byte_offs := $ToWordOffs(offs)
+              let key := $StorageKey(0, word_offs)
+              let overflow_bytes := $OverflowBytes(byte_offs, size)
+              switch overflow_bytes
+              case 0 {
+                sstore(key, $InjectBytes(sload(key), byte_offs, size, bytes))
+              }
+              default {
+                // Shift the higher bytes to the right
+                let used_bytes := sub(size, overflow_bytes)
+                let higher_bytes := shr(used_bytes, bytes)
+                let lower_bytes := and(bytes, $MaskForSize(overflow_bytes))
+                sstore(key, $InjectBytes(sload(key), byte_offs, used_bytes, higher_bytes))
+                key := $StorageKey(0, add(word_offs, 1))
+                sstore(key, $InjectBytes(sload(key), 0, overflow_bytes, lower_bytes))
+              }
             }
             function $StorageKey(group, word) -> key {
               mstore(32, word)
@@ -182,22 +256,16 @@ object "A2_M" {
               key := keccak256(32, 36)
             }
             function $MakeTypeStorageBase(category, type_hash, id) -> offs {
-              offs := or(shl(category, 252), or(shl(type_hash, 220), shl(id, 60)))
+              offs := or(shl(252, category), or(shl(220, type_hash), shl(60, id)))
             }
             function $IndexPtr(ptr, offs) -> new_ptr {
               new_ptr := $MakePtr($IsStoragePtr(ptr), add($OffsetPtr(ptr), offs))
             }
             function $StorageLoadU8(offs) -> val {
-              let word_offs, bit_offs := $ToWordOffs(offs)
-              let key := $StorageKey(0, word_offs)
-              val := and(shr(sload(key), bit_offs), 0xff)
+              val := $StorageLoadBytes(offs, 1)
             }
             function $StorageStoreU8(offs, val) {
-              let word_offs, bit_offs := $ToWordOffs(offs)
-              let key := $StorageKey(0, word_offs)
-              let word := sload(key)
-              word := or(and(word, not(shl(0xff, bit_offs))), shl(val, bit_offs))
-              mstore(key, word)
+              $StorageStoreBytes(offs, 1, val)
             }
             function $LoadU64(ptr) -> val {
               let offs := $OffsetPtr(ptr)
@@ -210,19 +278,10 @@ object "A2_M" {
               }
             }
             function $MemoryLoadU64(offs) -> val {
-              val := and(mload(offs), 0xffffffffffffffff)
+              val := $MemoryLoadBytes(offs, 8)
             }
             function $StorageLoadU64(offs) -> val {
-              let word_offs, bit_offs := $ToWordOffs(offs)
-              let key := $StorageKey(0, word_offs)
-              val := and(shr(sload(key), bit_offs), 0xffffffffffffffff)
-              let used_bits := sub(256, bit_offs)
-              if lt(used_bits, 64) {
-                let overflow_bits := sub(64, used_bits)
-                let mask := sub(shl(1, overflow_bits), 1)
-                key := $StorageKey(0, add(word_offs, 1))
-                val := or(val, shl(and(sload(key), mask), used_bits))
-              }
+              val := $StorageLoadBytes(offs, 8)
             }
             function $StoreU64(ptr, val) {
               let offs := $OffsetPtr(ptr)
@@ -235,21 +294,10 @@ object "A2_M" {
               }
             }
             function $MemoryStoreU64(offs, val) {
-              mstore(offs, or(and(mload(offs), not(0xffffffffffffffff)), val))
+              $MemoryStoreBytes(offs, 8, val)
             }
             function $StorageStoreU64(offs, val) {
-              let word_offs, bit_offs := $ToWordOffs(offs)
-              let key := $StorageKey(0, word_offs)
-              let word := sload(key)
-              word := or(and(word, not(shl(0xffffffffffffffff, bit_offs))), shl(val, bit_offs))
-              mstore(key, word)
-              let used_bits := sub(256, bit_offs)
-              if lt(used_bits, 64) {
-                let overflow_bits := sub(64, used_bits)
-                let mask := sub(shl(1, overflow_bits), 1)
-                key := $StorageKey(0, add(word_offs, 1))
-                sstore(key, or(and(sload(key), not(mask)), shr(val, used_bits)))
-              }
+              $StorageStoreBytes(offs, 8, val)
             }
             function $LoadU256(ptr) -> val {
               let offs := $OffsetPtr(ptr)
@@ -262,34 +310,25 @@ object "A2_M" {
               }
             }
             function $MemoryLoadU256(offs) -> val {
-              val := mload(offs)
+              val := $MemoryLoadBytes(offs, 32)
             }
             function $StorageLoadU256(offs) -> val {
-              let word_offs, bit_offs := $ToWordOffs(offs)
-              let key := $StorageKey(0, word_offs)
-              val := shr(sload(key), bit_offs)
-              let used_bits := sub(256, bit_offs)
-              if lt(used_bits, 256) {
-                let overflow_bits := sub(256, used_bits)
-                let mask := sub(shl(1, overflow_bits), 1)
-                key := $StorageKey(0, add(word_offs, 1))
-                val := or(val, shl(and(sload(key), mask), used_bits))
-              }
+              val := $StorageLoadBytes(offs, 32)
             }
             function $AlignedStorageLoad(offs) -> val {
-              let word_offs := shr(offs, 5)
+              let word_offs := shr(5, offs)
               val := sload($StorageKey(0, word_offs))
             }
             function $AlignedStorageStore(offs, val) {
-              let word_offs := shr(offs, 5)
+              let word_offs := shr(5, offs)
               sstore($StorageKey(0, word_offs), val)
             }
             function $AddU64(x, y) -> r {
                 if lt(sub(0xffffffffffffffff, x), y) { $AbortBuiltin() }
                 r := add(x, y)
             }
-            function $ShiftRight(bits, value) -> r {
-                r := shr(bits, value) // evm version >= constantinople
+            function $Shr(x, y) -> r {
+                r := shr(y, x)
             }
         }
     }
@@ -321,54 +360,39 @@ object "A2_M" {
                             mstore(_1, 99)
                             revert(24, 8)
                         }
-                        let $base_offset := or(252, shl(abi_decode_address(calldatasize()), 60))
-                        if not($StorageLoadU8($base_offset))
+                        let _2 := or(shl(220, 0x698265eb), shl(60, abi_decode_address(calldatasize())))
+                        if not($StorageLoadBytes(_2))
                         {
                             mstore(_1, not(0))
                             revert(24, 8)
                         }
-                        let _2 := 1
-                        let _3 := 32
-                        let $t2 := or(true, shl(add($base_offset, _3), _2))
+                        let _3 := 1
+                        let $t2 := or(true, shl(_3, add(_2, 32)))
                         let _4 := $LoadU256($t2)
-                        let _5 := shl(add(shr(_4, _2), _3), _2)
-                        let _6 := and(_4, _2)
+                        let _5 := shl(_3, add(shr(_3, _4), 32))
+                        let _6 := and(_4, _3)
                         let val := _1
-                        let offs := shr(or(_6, _5), _2)
-                        switch or(_6, and(_5, _2))
-                        case 0 {
-                            val := and(mload(offs), 0xffffffffffffffff)
-                        }
+                        let offs := shr(_3, or(_6, _5))
+                        switch or(_6, and(_5, _3))
+                        case 0 { val := shr(192, mload(offs)) }
                         default {
-                            let val_1 := _1
-                            let word_offs, bit_offs := $ToWordOffs(offs)
-                            mstore(_3, word_offs)
-                            mstore(64, _1)
-                            val_1 := and(shr(sload(keccak256(_3, 36)), bit_offs), 0xffffffffffffffff)
-                            let used_bits := sub(256, bit_offs)
-                            if lt(used_bits, 64)
-                            {
-                                mstore(_3, add(word_offs, _2))
-                                mstore(64, _1)
-                                val_1 := or(val_1, shl(and(sload(keccak256(_3, 36)), add(shl(_2, add(bit_offs, not(191))), not(0))), used_bits))
-                            }
-                            val := val_1
+                            val := $StorageLoadBytes_919(offs)
                         }
                         $StoreU64($IndexPtr($LoadU256($t2)), $AddU64(val))
                         return(mload(_1), _1)
                     }
                     case 0xbb29998e {
-                        if callvalue() { $Abort() }
+                        if callvalue() { $Abort_922() }
                         let ret := A2_M_test(abi_decode_address(calldatasize()))
                         let memPos := mload(_1)
                         return(memPos, sub(abi_encode_bool$(memPos, ret), memPos))
                     }
                 }
-                $Abort_969()
+                $Abort()
             }
             function A2_M_test(addr) -> $result
             {
-                $result := $StorageLoadU8(or(252, shl(addr, 60)))
+                $result := $StorageLoadBytes(or(shl(220, 0x698265eb), shl(60, addr)))
             }
             function abi_encode_bool$(headStart, value) -> tail
             {
@@ -390,74 +414,151 @@ object "A2_M" {
                 }
                 value := value_1
             }
-            function $Abort()
+            function $Abort_922()
             {
                 mstore(0, 99)
                 revert(24, 8)
             }
-            function $Abort_969()
+            function $Abort()
             {
                 mstore(0, 97)
                 revert(24, 8)
             }
-            function $ToWordOffs(offs) -> word_offs, bit_offs
+            function $ExtractBytes(word, size) -> bytes
             {
-                word_offs := shr(offs, 5)
-                bit_offs := shl(and(offs, 0x1F), 3)
+                switch size
+                case 1 { bytes := byte(0, word) }
+                default {
+                    bytes := and(shr(shl(3, sub(32, size)), word), add(shl(shl(size, 3), 1), not(0)))
+                }
+            }
+            function $InjectBytes_934(word, start, bytes) -> new_word
+            {
+                let shift_bits := shl(3, add(sub(32, start), not(7)))
+                new_word := or(and(word, not(shl(shift_bits, not(0)))), shl(shift_bits, bytes))
+            }
+            function $InjectBytes_935(word, size, bytes) -> new_word
+            {
+                let shift_bits := shl(3, sub(32, size))
+                new_word := or(and(word, not(shl(shift_bits, add(shl(shl(size, 3), 1), not(0))))), shl(shift_bits, bytes))
+            }
+            function $InjectBytes(word, start, size, bytes) -> new_word
+            {
+                let shift_bits := shl(3, sub(32, add(start, size)))
+                new_word := or(and(word, not(shl(shift_bits, add(shl(shl(size, 3), 1), not(0))))), shl(shift_bits, bytes))
+            }
+            function $OverflowBytes(byte_offset) -> overflow_bytes
+            {
+                switch gt(8, sub(32, byte_offset))
+                case 0 { overflow_bytes := 0 }
+                default {
+                    overflow_bytes := add(byte_offset, not(23))
+                }
+            }
+            function $StorageLoadBytes(offs) -> val
+            {
+                let word_offs := shr(5, offs)
+                let byte_offset := and(offs, 0x1F)
+                mstore(32, word_offs)
+                mstore(64, 0)
+                val := byte(byte_offset, sload(keccak256(32, 36)))
+                let overflow_bytes := 0
+                switch gt(1, sub(32, byte_offset))
+                case 0 {
+                    overflow_bytes := overflow_bytes
+                }
+                default {
+                    overflow_bytes := add(byte_offset, not(30))
+                }
+                if not(iszero(overflow_bytes))
+                {
+                    mstore(32, add(word_offs, 1))
+                    mstore(64, 0)
+                    val := or(shl(shl(3, overflow_bytes), val), $ExtractBytes(sload(keccak256(32, 36)), overflow_bytes))
+                }
+            }
+            function $StorageLoadBytes_919(offs) -> val
+            {
+                let word_offs := shr(5, offs)
+                let byte_offset := and(offs, 0x1F)
+                mstore(32, word_offs)
+                mstore(64, 0)
+                let _1 := sload(keccak256(32, 36))
+                let _2 := sub(32, byte_offset)
+                val := shr(shl(3, add(_2, not(7))), _1)
+                let overflow_bytes := 0
+                switch gt(8, _2)
+                case 0 {
+                    overflow_bytes := overflow_bytes
+                }
+                default {
+                    overflow_bytes := add(byte_offset, not(23))
+                }
+                if not(iszero(overflow_bytes))
+                {
+                    mstore(32, add(word_offs, 1))
+                    mstore(64, 0)
+                    val := or(shl(shl(3, overflow_bytes), val), $ExtractBytes(sload(keccak256(32, 36)), overflow_bytes))
+                }
             }
             function $IndexPtr(ptr) -> new_ptr
             {
-                new_ptr := or(and(ptr, 1), shl(add(shr(ptr, 1), 32), 1))
-            }
-            function $StorageLoadU8(offs) -> val
-            {
-                let word_offs, bit_offs := $ToWordOffs(offs)
-                mstore(32, word_offs)
-                mstore(64, 0)
-                val := and(shr(sload(keccak256(32, 36)), bit_offs), 0xff)
+                new_ptr := or(and(ptr, 1), shl(1, add(shr(1, ptr), 32)))
             }
             function $StoreU64(ptr, val)
             {
-                let offs := shr(ptr, 1)
+                let offs := shr(1, ptr)
                 switch and(ptr, 1)
                 case 0 {
-                    mstore(offs, or(and(mload(offs), not(0xffffffffffffffff)), val))
+                    mstore(offs, or(and(mload(offs), sub(shl(192, 1), 1)), shl(192, val)))
                 }
                 default {
-                    let word_offs, bit_offs := $ToWordOffs(offs)
+                    let word_offs := shr(6, ptr)
+                    let byte_offset := and(offs, 0x1F)
                     mstore(32, word_offs)
                     mstore(64, 0)
                     let key := keccak256(32, 36)
-                    let word := sload(key)
-                    mstore(key, or(word, shl(val, bit_offs)))
-                    let used_bits := sub(256, bit_offs)
-                    if lt(used_bits, 64)
-                    {
+                    let overflow_bytes := $OverflowBytes(byte_offset)
+                    switch overflow_bytes
+                    case 0 {
+                        sstore(key, $InjectBytes_934(sload(key), byte_offset, val))
+                    }
+                    default {
+                        let used_bytes := sub(8, overflow_bytes)
+                        sstore(key, $InjectBytes(sload(key), byte_offset, used_bytes, shr(used_bytes, val)))
                         mstore(32, add(word_offs, 1))
                         mstore(64, 0)
                         let key_1 := keccak256(32, 36)
-                        sstore(key_1, or(and(sload(key_1), not(add(shl(1, add(bit_offs, not(191))), not(0)))), shr(val, used_bits)))
+                        sstore(key_1, $InjectBytes_935(sload(key_1), overflow_bytes, and(val, add(shl(shl(overflow_bytes, 3), 1), not(0)))))
                     }
                 }
             }
             function $LoadU256(ptr) -> val
             {
-                let offs := shr(ptr, 1)
+                let offs := shr(1, ptr)
                 switch and(ptr, 1)
                 case 0 { val := mload(offs) }
                 default {
                     let val_1 := 0
-                    let word_offs, bit_offs := $ToWordOffs(offs)
-                    mstore(32, word_offs)
+                    let word_offs := shr(6, ptr)
+                    let byte_offset := and(offs, 0x1F)
+                    let _1 := 32
+                    mstore(_1, word_offs)
                     mstore(64, val_1)
-                    val_1 := shr(sload(keccak256(32, 36)), bit_offs)
-                    let _1 := 256
-                    let used_bits := sub(_1, bit_offs)
-                    if lt(used_bits, _1)
+                    let _2 := sload(keccak256(_1, 36))
+                    let _3 := sub(_1, byte_offset)
+                    val_1 := shr(shl(3, add(_3, not(31))), _2)
+                    let overflow_bytes := 0
+                    switch gt(_1, _3)
+                    case 0 {
+                        overflow_bytes := overflow_bytes
+                    }
+                    default { overflow_bytes := byte_offset }
+                    if not(iszero(overflow_bytes))
                     {
-                        mstore(32, add(word_offs, 1))
+                        mstore(_1, add(word_offs, 1))
                         mstore(64, 0)
-                        val_1 := or(val_1, shl(and(sload(keccak256(32, 36)), add(shl(1, bit_offs), not(0))), used_bits))
+                        val_1 := or(shl(shl(3, overflow_bytes), val_1), $ExtractBytes(sload(keccak256(_1, 36)), overflow_bytes))
                     }
                     val := val_1
                 }

--- a/language/evm/move-to-yul/tests/Structs.exp
+++ b/language/evm/move-to-yul/tests/Structs.exp
@@ -4,389 +4,27 @@
 
 /// @use-src 2:"tests/Structs.move"
 
-object "A2_M" {
+object "Empty" {
     code {
-        codecopy(0, dataoffset("A2_M_deployed"), datasize("A2_M_deployed"))
-        return(0, datasize("A2_M_deployed"))
+        codecopy(0, dataoffset("Empty_deployed"), datasize("Empty_deployed"))
+        return(0, datasize("Empty_deployed"))
     }
-    object "A2_M_deployed" {
+    object "Empty_deployed" {
         code {
             mstore(0, memoryguard(160))
             if iszero(lt(calldatasize(), 4))
             {
-                let selector := $ShiftRight(224, calldataload(0))
+                let selector := $Shr(calldataload(0), 224)
                 switch selector
-                case 0x83197ef0
-                {
-                    // destroy()
-                    if callvalue()
-                    {
-                        $Abort(99)
-                    }
-                    A2_M_destroy()
-                    let memPos := mload(0)
-                    let memEnd := abi_encode_tuple_(memPos)
-                    return(memPos, sub(memEnd, memPos))
-                }
                 default {}
             }
             $Abort(97)
-            function A2_M_destroy() {
-                let _s, $t1, $t2, $t3
-                // $t1 := 1
-                /// @src 2:814:815
-                $t1 := 1
-                // $t2 := false
-                /// @src 2:817:822
-                $t2 := false
-                // $t3 := M::pack_S($t1, $t2)
-                /// @src 2:807:823
-                $t3 := A2_M_pack_S($t1, $t2)
-                // destroy($t3)
-                /// @src 2:802:804
-                {
-                    let $field_ptr := $LoadU256(add($t3, 0))
-                    $Free($field_ptr, 16)
-                }
-                $Free($t3, 41)
-                // return ()
-                /// @src 2:823:824
-            }
-
-            function A2_M_pack_S(a, b) -> $result {
-                let $t2, $t3, $t4
-                // $t2 := (u128)($t0)
-                /// @src 2:287:298
-                $t2 := $CastU128(a)
-                // $t3 := M::pack_S2($t2)
-                /// @src 2:279:299
-                $t3 := A2_M_pack_S2($t2)
-                // $t4 := pack M::S($t0, $t1, $t3)
-                /// @src 2:268:300
-                {
-                    let $mem := $Malloc(41)
-                    $MemoryStoreU64(add($mem, 32), a)
-                    $MemoryStoreU8(add($mem, 40), b)
-                    $MemoryStoreU256(add($mem, 0), $t3)
-                    $t4 := $mem
-                }
-                // return $t4
-                /// @src 2:268:300
-                $result := $t4
-            }
-
-            function A2_M_pack_S2(x) -> $result {
-                let $t1
-                // $t1 := pack M::S2($t0)
-                /// @src 2:197:202
-                {
-                    let $mem := $Malloc(16)
-                    $MemoryStoreU128(add($mem, 0), x)
-                    $t1 := $mem
-                }
-                // return $t1
-                /// @src 2:197:202
-                $result := $t1
-            }
-
-            function A2_M_read_and_write_s() -> $result {
-                let x, $t2, $t3, $t4, $t5, $t6, $t7
-                let $locals := $Malloc(32)
-                // $t2 := 1
-                /// @src 2:574:575
-                $t2 := 1
-                // $t3 := false
-                /// @src 2:577:582
-                $t3 := false
-                // $t0 := M::pack_S($t2, $t3)
-                /// @src 2:567:583
-                mstore(add($locals, 32), A2_M_pack_S($t2, $t3))
-                // $t4 := borrow_local($t0)
-                /// @src 2:608:610
-                $t4 := $MakePtr(false, add($locals, 32))
-                // $t5 := M::read_S($t4)
-                /// @src 2:601:611
-                $t5 := A2_M_read_S($t4)
-                // $t6 := borrow_local($t0)
-                /// @src 2:629:635
-                $t6 := $MakePtr(false, add($locals, 32))
-                // M::write_S($t6, $t5)
-                /// @src 2:621:639
-                A2_M_write_S($t6, $t5)
-                // $t7 := move($t0)
-                /// @src 2:649:650
-                $t7 := mload(add($locals, 32))
-                // return $t7
-                /// @src 2:649:650
-                $result := $t7
-                $Free($locals, 32)
-            }
-
-            function A2_M_unpack(s) -> $result {
-                let _a, _b, c, $t4, $t5, $t6
-                // ($t4, $t5, $t6) := unpack M::S($t0)
-                /// @src 2:713:731
-                $t4 := $MemoryLoadU64(add(s, 32))
-                $t5 := $MemoryLoadU8(add(s, 40))
-                $t6 := $MemoryLoadU256(add(s, 0))
-                $Free(s, 41)
-                // destroy($t5)
-                /// @src 2:725:727
-                // destroy($t4)
-                /// @src 2:718:720
-                // return $t6
-                /// @src 2:745:746
-                $result := $t6
-            }
-
-            function A2_M_write_S(s, v) {
-                let $t2, $t3, $t4, $t5, $t6, $t7
-                // $t2 := borrow_field<M::S>.a($t0)
-                /// @src 2:456:459
-                $t2 := $IndexPtr($LoadU256(s), 32)
-                // write_ref($t2, $t1)
-                /// @src 2:456:463
-                $StoreU64($t2, v)
-                // $t3 := borrow_field<M::S>.a($t0)
-                /// @src 2:482:485
-                $t3 := $IndexPtr($LoadU256(s), 32)
-                // $t4 := read_ref($t3)
-                /// @src 2:482:485
-                $t4 := $LoadU64($t3)
-                // $t5 := (u128)($t4)
-                /// @src 2:481:494
-                $t5 := $CastU128($t4)
-                // $t6 := borrow_field<M::S>.c($t0)
-                /// @src 2:473:476
-                $t6 := $IndexPtr($LoadU256(s), 0)
-                // $t7 := borrow_field<M::S2>.x($t6)
-                /// @src 2:473:478
-                $t7 := $IndexPtr($LoadU256($t6), 0)
-                // write_ref($t7, $t5)
-                /// @src 2:473:494
-                $StoreU128($t7, $t5)
-                // return ()
-                /// @src 2:494:495
-            }
-
-            function A2_M_read_S(s) -> $result {
-                let $t1, $t2, $t3, $t4, $t5, $t6, $t7
-                // $t1 := borrow_field<M::S>.a($t0)
-                /// @src 2:364:367
-                $t1 := $IndexPtr($LoadU256(s), 32)
-                // $t2 := read_ref($t1)
-                /// @src 2:364:367
-                $t2 := $LoadU64($t1)
-                // $t3 := borrow_field<M::S>.c($t0)
-                /// @src 2:371:374
-                $t3 := $IndexPtr($LoadU256(s), 0)
-                // $t4 := borrow_field<M::S2>.x($t3)
-                /// @src 2:371:376
-                $t4 := $IndexPtr($LoadU256($t3), 0)
-                // $t5 := read_ref($t4)
-                /// @src 2:371:376
-                $t5 := $LoadU128($t4)
-                // $t6 := (u64)($t5)
-                /// @src 2:370:384
-                $t6 := $CastU64($t5)
-                // $t7 := +($t2, $t6)
-                /// @src 2:368:369
-                $t7 := $AddU64($t2, $t6)
-                // return $t7
-                /// @src 2:364:384
-                $result := $t7
-            }
-
-            function abi_encode_tuple_(headStart ) -> tail {
-                tail := add(headStart, 0)
-            }
             function $Abort(code) {
                 mstore(0, code)
                 revert(24, 8) // TODO: store code as a string?
             }
-            function $AbortBuiltin() {
-                $Abort(sub(0, 1))
-            }
-            function $Malloc(size) -> offs {
-                offs := mload(0)
-                // pad to word size
-                mstore(0, add(offs, shr(add(size, 31), 5)))
-            }
-            function $Free(offs, size) {
-            }
-            function $MakePtr(is_storage, offs) -> ptr {
-              ptr := or(is_storage, shl(offs, 1))
-            }
-            function $IsStoragePtr(ptr) -> b {
-              b := and(ptr, 0x1)
-            }
-            function $OffsetPtr(ptr) -> offs {
-              offs := shr(ptr, 1)
-            }
-            function $ToWordOffs(offs) -> word_offs, bit_offs {
-              word_offs := shr(offs, 5)
-              bit_offs := shl(and(offs, 0x1F), 3)
-            }
-            function $StorageKey(group, word) -> key {
-              mstore(32, word)
-              mstore(64, group)
-              key := keccak256(32, 36)
-            }
-            function $IndexPtr(ptr, offs) -> new_ptr {
-              new_ptr := $MakePtr($IsStoragePtr(ptr), add($OffsetPtr(ptr), offs))
-            }
-            function $MemoryLoadU8(offs) -> val {
-              val := and(mload(offs), 0xff)
-            }
-            function $MemoryStoreU8(offs, val) {
-              mstore8(offs, val)
-            }
-            function $LoadU64(ptr) -> val {
-              let offs := $OffsetPtr(ptr)
-              switch $IsStoragePtr(ptr)
-              case 0 {
-                val := $MemoryLoadU64(offs)
-              }
-              default {
-                val := $StorageLoadU64(offs)
-              }
-            }
-            function $MemoryLoadU64(offs) -> val {
-              val := and(mload(offs), 0xffffffffffffffff)
-            }
-            function $StorageLoadU64(offs) -> val {
-              let word_offs, bit_offs := $ToWordOffs(offs)
-              let key := $StorageKey(0, word_offs)
-              val := and(shr(sload(key), bit_offs), 0xffffffffffffffff)
-              let used_bits := sub(256, bit_offs)
-              if lt(used_bits, 64) {
-                let overflow_bits := sub(64, used_bits)
-                let mask := sub(shl(1, overflow_bits), 1)
-                key := $StorageKey(0, add(word_offs, 1))
-                val := or(val, shl(and(sload(key), mask), used_bits))
-              }
-            }
-            function $StoreU64(ptr, val) {
-              let offs := $OffsetPtr(ptr)
-              switch $IsStoragePtr(ptr)
-              case 0 {
-                $MemoryStoreU64(offs, val)
-              }
-              default {
-                $StorageStoreU64(offs, val)
-              }
-            }
-            function $MemoryStoreU64(offs, val) {
-              mstore(offs, or(and(mload(offs), not(0xffffffffffffffff)), val))
-            }
-            function $StorageStoreU64(offs, val) {
-              let word_offs, bit_offs := $ToWordOffs(offs)
-              let key := $StorageKey(0, word_offs)
-              let word := sload(key)
-              word := or(and(word, not(shl(0xffffffffffffffff, bit_offs))), shl(val, bit_offs))
-              mstore(key, word)
-              let used_bits := sub(256, bit_offs)
-              if lt(used_bits, 64) {
-                let overflow_bits := sub(64, used_bits)
-                let mask := sub(shl(1, overflow_bits), 1)
-                key := $StorageKey(0, add(word_offs, 1))
-                sstore(key, or(and(sload(key), not(mask)), shr(val, used_bits)))
-              }
-            }
-            function $LoadU128(ptr) -> val {
-              let offs := $OffsetPtr(ptr)
-              switch $IsStoragePtr(ptr)
-              case 0 {
-                val := $MemoryLoadU128(offs)
-              }
-              default {
-                val := $StorageLoadU128(offs)
-              }
-            }
-            function $MemoryLoadU128(offs) -> val {
-              val := and(mload(offs), 0xffffffffffffffffffffffffffffffff)
-            }
-            function $StorageLoadU128(offs) -> val {
-              let word_offs, bit_offs := $ToWordOffs(offs)
-              let key := $StorageKey(0, word_offs)
-              val := and(shr(sload(key), bit_offs), 0xffffffffffffffffffffffffffffffff)
-              let used_bits := sub(256, bit_offs)
-              if lt(used_bits, 128) {
-                let overflow_bits := sub(128, used_bits)
-                let mask := sub(shl(1, overflow_bits), 1)
-                key := $StorageKey(0, add(word_offs, 1))
-                val := or(val, shl(and(sload(key), mask), used_bits))
-              }
-            }
-            function $StoreU128(ptr, val) {
-              let offs := $OffsetPtr(ptr)
-              switch $IsStoragePtr(ptr)
-              case 0 {
-                $MemoryStoreU128(offs, val)
-              }
-              default {
-                $StorageStoreU128(offs, val)
-              }
-            }
-            function $MemoryStoreU128(offs, val) {
-              mstore(offs, or(and(mload(offs), not(0xffffffffffffffffffffffffffffffff)), val))
-            }
-            function $StorageStoreU128(offs, val) {
-              let word_offs, bit_offs := $ToWordOffs(offs)
-              let key := $StorageKey(0, word_offs)
-              let word := sload(key)
-              word := or(and(word, not(shl(0xffffffffffffffffffffffffffffffff, bit_offs))), shl(val, bit_offs))
-              mstore(key, word)
-              let used_bits := sub(256, bit_offs)
-              if lt(used_bits, 128) {
-                let overflow_bits := sub(128, used_bits)
-                let mask := sub(shl(1, overflow_bits), 1)
-                key := $StorageKey(0, add(word_offs, 1))
-                sstore(key, or(and(sload(key), not(mask)), shr(val, used_bits)))
-              }
-            }
-            function $LoadU256(ptr) -> val {
-              let offs := $OffsetPtr(ptr)
-              switch $IsStoragePtr(ptr)
-              case 0 {
-                val := $MemoryLoadU256(offs)
-              }
-              default {
-                val := $StorageLoadU256(offs)
-              }
-            }
-            function $MemoryLoadU256(offs) -> val {
-              val := mload(offs)
-            }
-            function $StorageLoadU256(offs) -> val {
-              let word_offs, bit_offs := $ToWordOffs(offs)
-              let key := $StorageKey(0, word_offs)
-              val := shr(sload(key), bit_offs)
-              let used_bits := sub(256, bit_offs)
-              if lt(used_bits, 256) {
-                let overflow_bits := sub(256, used_bits)
-                let mask := sub(shl(1, overflow_bits), 1)
-                key := $StorageKey(0, add(word_offs, 1))
-                val := or(val, shl(and(sload(key), mask), used_bits))
-              }
-            }
-            function $MemoryStoreU256(offs, val) {
-              mstore(offs, val)
-            }
-            function $AddU64(x, y) -> r {
-                if lt(sub(0xffffffffffffffff, x), y) { $AbortBuiltin() }
-                r := add(x, y)
-            }
-            function $CastU64(x) -> r {
-                if gt(x, 0xffffffffffffffff) { $AbortBuiltin() }
-                r := x
-            }
-            function $CastU128(x) -> r {
-                if gt(x, 0xffffffffffffffffffffffffffffffff) { $AbortBuiltin() }
-                r := x
-            }
-            function $ShiftRight(bits, value) -> r {
-                r := shr(bits, value) // evm version >= constantinople
+            function $Shr(x, y) -> r {
+                r := shr(y, x)
             }
         }
     }
@@ -396,58 +34,18 @@ object "A2_M" {
 !! Optimized Yul
 
 /// @use-src 2:"tests/Structs.move"
-object "A2_M" {
+object "Empty" {
     code {
         {
-            let _1 := datasize("A2_M_deployed")
-            codecopy(0, dataoffset("A2_M_deployed"), _1)
+            let _1 := datasize("Empty_deployed")
+            codecopy(0, dataoffset("Empty_deployed"), _1)
             return(0, _1)
         }
     }
-    object "A2_M_deployed" {
+    object "Empty_deployed" {
         code {
             {
-                let _1 := 0
-                mstore(_1, memoryguard(0xa0))
-                if iszero(lt(calldatasize(), 4))
-                {
-                    if eq(0x83197ef0, shr(224, calldataload(_1)))
-                    {
-                        if callvalue()
-                        {
-                            mstore(_1, 99)
-                            revert(24, 8)
-                        }
-                        let offs := mload(_1)
-                        mstore(_1, offs)
-                        mstore(offs, or(and(mload(offs), not(0xffffffffffffffffffffffffffffffff)), 1))
-                        let offs_1 := mload(_1)
-                        mstore(_1, offs_1)
-                        let _2 := add(offs_1, 32)
-                        mstore(_2, or(and(mload(_2), not(0xffffffffffffffff)), 1))
-                        mstore8(add(offs_1, 40), false)
-                        mstore(offs_1, offs)
-                        let offs_2 := shr(offs_1, 1)
-                        switch and(offs_1, 1)
-                        case 0 { }
-                        default {
-                            let word_offs := shr(offs_2, 5)
-                            mstore(32, word_offs)
-                            mstore(64, _1)
-                            let _3 := 256
-                            if lt(sub(_3, shl(and(offs_2, 31), 3)), _3)
-                            {
-                                mstore(32, add(word_offs, 1))
-                                mstore(64, _1)
-                            }
-                        }
-                        return(mload(_1), _1)
-                    }
-                }
-                $Abort()
-            }
-            function $Abort()
-            {
+                mstore(0, memoryguard(0xa0))
                 mstore(0, 97)
                 revert(24, 8)
             }
@@ -455,39 +53,2133 @@ object "A2_M" {
     }
 }
 
-!! Move-To-Yul Diagnostics:
- warning: cannot dispatch this function because of unsupported parameter types
-   ┌─ tests/Structs.move:19:5
-   │
-19 │ ╭     fun pack_S(a: u64, b: bool): S {
-20 │ │         S{a, b, c: pack_S2((a as u128))}
-21 │ │     }
-   │ ╰─────^
+!! Unit tests
 
-warning: cannot dispatch this function because of unsupported parameter types
-   ┌─ tests/Structs.move:14:2
-   │
-14 │ ╭     fun pack_S2(x: u128): S2 {
-15 │ │         S2{x}
-16 │ │     }
-   │ ╰─────^
+// test of M::test_pack_S
+/* =======================================
+ * Generated by Move-To-Yul compiler v0.0
+ * ======================================= */
 
-warning: cannot dispatch this function because of unsupported parameter types
-   ┌─ tests/Structs.move:35:5
-   │
-35 │ ╭     fun read_and_write_s(): S {
-36 │ │         let s = pack_S(1, false);
-37 │ │         let x = read_S(&s);
-38 │ │         write_S(&mut s, x);
-39 │ │         s
-40 │ │     }
-   │ ╰─────^
+/// @use-src 2:"tests/Structs.move"
 
-warning: cannot dispatch this function because of unsupported parameter types
-   ┌─ tests/Structs.move:43:5
-   │
-43 │ ╭     fun unpack(s: S): S2 {
-44 │ │         let S{a: _a, b: _b, c} = s;
-45 │ │         c
-46 │ │     }
-   │ ╰─────^
+object "test_A2_M_test_pack_S" {
+    code {
+        mstore(0, memoryguard(160))
+        A2_M_test_pack_S()
+        return (0, 0)
+        function A2_M_test_pack_S() {
+            let $t1, $t2, $t3, $t4, $t5, $t6, $t7, $t8, $t9, $t10, $t11, $t12, $t13, $t14, $t15, $t16, $t17, $t18, $t19, $t20, $t21
+            let $locals := $Malloc(32)
+            let $block := 4
+            for {} true {} {
+                switch $block
+                case 2 {
+                    // label L1
+                    // $t8 := 100
+                    /// @src 2:702:705
+                    $t8 := 100
+                    // abort($t8)
+                    /// @src 2:683:706
+                    $Abort($t8)
+                }
+                case 3 {
+                    // label L0
+                    // $t9 := borrow_local($t0)
+                    /// @src 2:724:725
+                    $t9 := $MakePtr(false, $locals)
+                    // $t10 := borrow_field<M::S>.b($t9)
+                    /// @src 2:724:727
+                    $t10 := $IndexPtr($LoadU256($t9), 40)
+                    // $t11 := read_ref($t10)
+                    /// @src 2:724:727
+                    $t11 := $LoadU8($t10)
+                    // $t12 := true
+                    /// @src 2:731:735
+                    $t12 := true
+                    // $t13 := ==($t11, $t12)
+                    /// @src 2:728:730
+                    $t13 := $Eq($t11, $t12)
+                    // if ($t13) goto L2 else goto L3
+                    /// @src 2:716:741
+                    switch $t13
+                    case 0  { $block := 5 }
+                    default { $block := 6 }
+                }
+                case 4 {
+                    // $t1 := 42
+                    /// @src 2:664:666
+                    $t1 := 42
+                    // $t2 := true
+                    /// @src 2:668:672
+                    $t2 := true
+                    // $t0 := M::pack_S($t1, $t2)
+                    /// @src 2:657:673
+                    mstore($locals, A2_M_pack_S($t1, $t2))
+                    // $t3 := borrow_local($t0)
+                    /// @src 2:691:692
+                    $t3 := $MakePtr(false, $locals)
+                    // $t4 := borrow_field<M::S>.a($t3)
+                    /// @src 2:691:694
+                    $t4 := $IndexPtr($LoadU256($t3), 32)
+                    // $t5 := read_ref($t4)
+                    /// @src 2:691:694
+                    $t5 := $LoadU64($t4)
+                    // $t6 := 42
+                    /// @src 2:698:700
+                    $t6 := 42
+                    // $t7 := ==($t5, $t6)
+                    /// @src 2:695:697
+                    $t7 := $Eq($t5, $t6)
+                    // if ($t7) goto L0 else goto L1
+                    /// @src 2:683:706
+                    switch $t7
+                    case 0  { $block := 2 }
+                    default { $block := 3 }
+                }
+                case 5 {
+                    // label L3
+                    // $t14 := 101
+                    /// @src 2:737:740
+                    $t14 := 101
+                    // abort($t14)
+                    /// @src 2:716:741
+                    $Abort($t14)
+                }
+                case 6 {
+                    // label L2
+                    // $t15 := borrow_local($t0)
+                    /// @src 2:759:760
+                    $t15 := $MakePtr(false, $locals)
+                    // $t16 := borrow_field<M::S>.c($t15)
+                    /// @src 2:759:762
+                    $t16 := $IndexPtr($LoadU256($t15), 0)
+                    // $t17 := borrow_field<M::S2>.x($t16)
+                    /// @src 2:759:764
+                    $t17 := $IndexPtr($LoadU256($t16), 0)
+                    // $t18 := read_ref($t17)
+                    /// @src 2:759:764
+                    $t18 := $LoadU128($t17)
+                    // $t19 := 42
+                    /// @src 2:768:770
+                    $t19 := 42
+                    // $t20 := ==($t18, $t19)
+                    /// @src 2:765:767
+                    $t20 := $Eq($t18, $t19)
+                    // if ($t20) goto L4 else goto L5
+                    /// @src 2:751:776
+                    switch $t20
+                    case 0  { $block := 7 }
+                    default { $block := 8 }
+                }
+                case 7 {
+                    // label L5
+                    // $t21 := 102
+                    /// @src 2:772:775
+                    $t21 := 102
+                    // abort($t21)
+                    /// @src 2:751:776
+                    $Abort($t21)
+                }
+                case 8 {
+                    // label L4
+                    // return ()
+                    /// @src 2:776:777
+                    $Free($locals, 32)
+                    leave
+                }
+            }
+        }
+
+        function A2_M_pack_S(a, b) -> $result {
+            let $t2, $t3, $t4
+            // $t2 := (u128)($t0)
+            /// @src 2:581:592
+            $t2 := $CastU128(a)
+            // $t3 := M::pack_S2($t2)
+            /// @src 2:573:593
+            $t3 := A2_M_pack_S2($t2)
+            // $t4 := pack M::S($t0, $t1, $t3)
+            /// @src 2:562:594
+            {
+                let $mem := $Malloc(41)
+                $MemoryStoreU64(add($mem, 32), a)
+                $MemoryStoreU8(add($mem, 40), b)
+                $MemoryStoreU256(add($mem, 0), $t3)
+                $t4 := $MakePtr(false, $mem)
+            }
+            // return $t4
+            /// @src 2:562:594
+            $result := $t4
+        }
+
+        function A2_M_pack_S2(x) -> $result {
+            let $t1
+            // $t1 := pack M::S2($t0)
+            /// @src 2:229:234
+            {
+                let $mem := $Malloc(16)
+                $MemoryStoreU128(add($mem, 0), x)
+                $t1 := $MakePtr(false, $mem)
+            }
+            // return $t1
+            /// @src 2:229:234
+            $result := $t1
+        }
+
+        function $Abort(code) {
+            mstore(0, code)
+            revert(24, 8) // TODO: store code as a string?
+        }
+        function $AbortBuiltin() {
+            $Abort(sub(0, 1))
+        }
+        function $Malloc(size) -> offs {
+            offs := mload(0)
+            // pad to word size
+            mstore(0, add(offs, shl(5, shr(5, add(size, 31)))))
+        }
+        function $Free(offs, size) {
+        }
+        function $MakePtr(is_storage, offs) -> ptr {
+          ptr := or(is_storage, shl(1, offs))
+        }
+        function $IsStoragePtr(ptr) -> b {
+          b := and(ptr, 0x1)
+        }
+        function $OffsetPtr(ptr) -> offs {
+          offs := shr(1, ptr)
+        }
+        function $MaskForSize(size) -> mask {
+          mask := sub(shl(shl(size, 3), 1), 1)
+        }
+        function $ExtractBytes(word, start, size) -> bytes {
+           switch size
+           case 1 {
+              // use the faster byte primitive
+              bytes := byte(start, word)
+           }
+           default {
+              // As we have big endian, we need to right shift the value from
+              // where the highest byte starts in the word (32 - start), minus
+              // the size.
+              let shift_bits := shl(3, sub(sub(32, start), size))
+              bytes := and(shr(shift_bits, word), $MaskForSize(size))
+           }
+        }
+        function $ToWordOffs(offs) -> word_offs, byte_offset {
+          word_offs := shr(5, offs)
+          byte_offset := and(offs, 0x1F)
+        }
+        function $OverflowBytes(byte_offset, size) -> overflow_bytes {
+          let available_bytes := sub(32, byte_offset)
+          switch gt(size, available_bytes)
+          case 0 {
+            overflow_bytes := 0
+          }
+          default {
+            overflow_bytes := sub(size, available_bytes)
+          }
+        }
+        function $MemoryLoadBytes(offs, size) -> val {
+          // Lower bit where the value in the higher bytes ends
+          let bit_end := shl(3, sub(32, size))
+          val := shr(bit_end, mload(offs))
+        }
+        function $MemoryStoreBytes(offs, size, val) {
+          let bit_end := shl(3, sub(32, size))
+          let mask := shl(bit_end, $MaskForSize(size))
+          mstore(offs, or(and(mload(offs), not(mask)), shl(bit_end, val)))
+        }
+        function $StorageLoadBytes(offs, size) -> val {
+          let word_offs, byte_offs := $ToWordOffs(offs)
+          let key := $StorageKey(0, word_offs)
+          val := $ExtractBytes(sload(key), byte_offs, size)
+          let overflow_bytes := $OverflowBytes(byte_offs, size)
+          if not(iszero(overflow_bytes)) {
+            key := $StorageKey(0, add(word_offs, 1))
+            let extra_bytes := $ExtractBytes(sload(key), 0, overflow_bytes)
+            val := or(shl(shl(3, overflow_bytes), val), extra_bytes)
+          }
+        }
+        function $StorageKey(group, word) -> key {
+          mstore(32, word)
+          mstore(64, group)
+          key := keccak256(32, 36)
+        }
+        function $IndexPtr(ptr, offs) -> new_ptr {
+          new_ptr := $MakePtr($IsStoragePtr(ptr), add($OffsetPtr(ptr), offs))
+        }
+        function $LoadU8(ptr) -> val {
+          let offs := $OffsetPtr(ptr)
+          switch $IsStoragePtr(ptr)
+          case 0 {
+            val := $MemoryLoadU8(offs)
+          }
+          default {
+            val := $StorageLoadU8(offs)
+          }
+        }
+        function $MemoryLoadU8(offs) -> val {
+          val := $MemoryLoadBytes(offs, 1)
+        }
+        function $StorageLoadU8(offs) -> val {
+          val := $StorageLoadBytes(offs, 1)
+        }
+        function $MemoryStoreU8(offs, val) {
+          // Shortcut via special instruction
+          mstore8(offs, val)
+        }
+        function $LoadU64(ptr) -> val {
+          let offs := $OffsetPtr(ptr)
+          switch $IsStoragePtr(ptr)
+          case 0 {
+            val := $MemoryLoadU64(offs)
+          }
+          default {
+            val := $StorageLoadU64(offs)
+          }
+        }
+        function $MemoryLoadU64(offs) -> val {
+          val := $MemoryLoadBytes(offs, 8)
+        }
+        function $StorageLoadU64(offs) -> val {
+          val := $StorageLoadBytes(offs, 8)
+        }
+        function $MemoryStoreU64(offs, val) {
+          $MemoryStoreBytes(offs, 8, val)
+        }
+        function $LoadU128(ptr) -> val {
+          let offs := $OffsetPtr(ptr)
+          switch $IsStoragePtr(ptr)
+          case 0 {
+            val := $MemoryLoadU128(offs)
+          }
+          default {
+            val := $StorageLoadU128(offs)
+          }
+        }
+        function $MemoryLoadU128(offs) -> val {
+          val := $MemoryLoadBytes(offs, 16)
+        }
+        function $StorageLoadU128(offs) -> val {
+          val := $StorageLoadBytes(offs, 16)
+        }
+        function $MemoryStoreU128(offs, val) {
+          $MemoryStoreBytes(offs, 16, val)
+        }
+        function $LoadU256(ptr) -> val {
+          let offs := $OffsetPtr(ptr)
+          switch $IsStoragePtr(ptr)
+          case 0 {
+            val := $MemoryLoadU256(offs)
+          }
+          default {
+            val := $StorageLoadU256(offs)
+          }
+        }
+        function $MemoryLoadU256(offs) -> val {
+          val := $MemoryLoadBytes(offs, 32)
+        }
+        function $StorageLoadU256(offs) -> val {
+          val := $StorageLoadBytes(offs, 32)
+        }
+        function $MemoryStoreU256(offs, val) {
+          $MemoryStoreBytes(offs, 32, val)
+        }
+        function $Eq(x, y) -> r {
+            r := eq(x, y)
+        }
+        function $CastU128(x) -> r {
+            if gt(x, 0xffffffffffffffffffffffffffffffff) { $AbortBuiltin() }
+            r := x
+        }
+    }
+}
+===> Succeed(Stopped) (used_gas=1569): []
+
+// test of M::test_pack_S2
+/* =======================================
+ * Generated by Move-To-Yul compiler v0.0
+ * ======================================= */
+
+/// @use-src 2:"tests/Structs.move"
+
+object "test_A2_M_test_pack_S2" {
+    code {
+        mstore(0, memoryguard(160))
+        A2_M_test_pack_S2()
+        return (0, 0)
+        function A2_M_test_pack_S2() {
+            let $t1, $t2, $t3, $t4, $t5, $t6, $t7
+            let $locals := $Malloc(32)
+            let $block := 4
+            for {} true {} {
+                switch $block
+                case 2 {
+                    // label L1
+                    // $t7 := 100
+                    /// @src 2:338:341
+                    $t7 := 100
+                    // abort($t7)
+                    /// @src 2:319:342
+                    $Abort($t7)
+                }
+                case 3 {
+                    // label L0
+                    // return ()
+                    /// @src 2:319:342
+                    $Free($locals, 32)
+                    leave
+                }
+                case 4 {
+                    // $t1 := 42
+                    /// @src 2:306:308
+                    $t1 := 42
+                    // $t0 := M::pack_S2($t1)
+                    /// @src 2:298:309
+                    mstore($locals, A2_M_pack_S2($t1))
+                    // $t2 := borrow_local($t0)
+                    /// @src 2:327:328
+                    $t2 := $MakePtr(false, $locals)
+                    // $t3 := borrow_field<M::S2>.x($t2)
+                    /// @src 2:327:330
+                    $t3 := $IndexPtr($LoadU256($t2), 0)
+                    // $t4 := read_ref($t3)
+                    /// @src 2:327:330
+                    $t4 := $LoadU128($t3)
+                    // $t5 := 42
+                    /// @src 2:334:336
+                    $t5 := 42
+                    // $t6 := ==($t4, $t5)
+                    /// @src 2:331:333
+                    $t6 := $Eq($t4, $t5)
+                    // if ($t6) goto L0 else goto L1
+                    /// @src 2:319:342
+                    switch $t6
+                    case 0  { $block := 2 }
+                    default { $block := 3 }
+                }
+            }
+        }
+
+        function A2_M_pack_S2(x) -> $result {
+            let $t1
+            // $t1 := pack M::S2($t0)
+            /// @src 2:229:234
+            {
+                let $mem := $Malloc(16)
+                $MemoryStoreU128(add($mem, 0), x)
+                $t1 := $MakePtr(false, $mem)
+            }
+            // return $t1
+            /// @src 2:229:234
+            $result := $t1
+        }
+
+        function $Abort(code) {
+            mstore(0, code)
+            revert(24, 8) // TODO: store code as a string?
+        }
+        function $Malloc(size) -> offs {
+            offs := mload(0)
+            // pad to word size
+            mstore(0, add(offs, shl(5, shr(5, add(size, 31)))))
+        }
+        function $Free(offs, size) {
+        }
+        function $MakePtr(is_storage, offs) -> ptr {
+          ptr := or(is_storage, shl(1, offs))
+        }
+        function $IsStoragePtr(ptr) -> b {
+          b := and(ptr, 0x1)
+        }
+        function $OffsetPtr(ptr) -> offs {
+          offs := shr(1, ptr)
+        }
+        function $MaskForSize(size) -> mask {
+          mask := sub(shl(shl(size, 3), 1), 1)
+        }
+        function $ExtractBytes(word, start, size) -> bytes {
+           switch size
+           case 1 {
+              // use the faster byte primitive
+              bytes := byte(start, word)
+           }
+           default {
+              // As we have big endian, we need to right shift the value from
+              // where the highest byte starts in the word (32 - start), minus
+              // the size.
+              let shift_bits := shl(3, sub(sub(32, start), size))
+              bytes := and(shr(shift_bits, word), $MaskForSize(size))
+           }
+        }
+        function $ToWordOffs(offs) -> word_offs, byte_offset {
+          word_offs := shr(5, offs)
+          byte_offset := and(offs, 0x1F)
+        }
+        function $OverflowBytes(byte_offset, size) -> overflow_bytes {
+          let available_bytes := sub(32, byte_offset)
+          switch gt(size, available_bytes)
+          case 0 {
+            overflow_bytes := 0
+          }
+          default {
+            overflow_bytes := sub(size, available_bytes)
+          }
+        }
+        function $MemoryLoadBytes(offs, size) -> val {
+          // Lower bit where the value in the higher bytes ends
+          let bit_end := shl(3, sub(32, size))
+          val := shr(bit_end, mload(offs))
+        }
+        function $MemoryStoreBytes(offs, size, val) {
+          let bit_end := shl(3, sub(32, size))
+          let mask := shl(bit_end, $MaskForSize(size))
+          mstore(offs, or(and(mload(offs), not(mask)), shl(bit_end, val)))
+        }
+        function $StorageLoadBytes(offs, size) -> val {
+          let word_offs, byte_offs := $ToWordOffs(offs)
+          let key := $StorageKey(0, word_offs)
+          val := $ExtractBytes(sload(key), byte_offs, size)
+          let overflow_bytes := $OverflowBytes(byte_offs, size)
+          if not(iszero(overflow_bytes)) {
+            key := $StorageKey(0, add(word_offs, 1))
+            let extra_bytes := $ExtractBytes(sload(key), 0, overflow_bytes)
+            val := or(shl(shl(3, overflow_bytes), val), extra_bytes)
+          }
+        }
+        function $StorageKey(group, word) -> key {
+          mstore(32, word)
+          mstore(64, group)
+          key := keccak256(32, 36)
+        }
+        function $IndexPtr(ptr, offs) -> new_ptr {
+          new_ptr := $MakePtr($IsStoragePtr(ptr), add($OffsetPtr(ptr), offs))
+        }
+        function $LoadU128(ptr) -> val {
+          let offs := $OffsetPtr(ptr)
+          switch $IsStoragePtr(ptr)
+          case 0 {
+            val := $MemoryLoadU128(offs)
+          }
+          default {
+            val := $StorageLoadU128(offs)
+          }
+        }
+        function $MemoryLoadU128(offs) -> val {
+          val := $MemoryLoadBytes(offs, 16)
+        }
+        function $StorageLoadU128(offs) -> val {
+          val := $StorageLoadBytes(offs, 16)
+        }
+        function $MemoryStoreU128(offs, val) {
+          $MemoryStoreBytes(offs, 16, val)
+        }
+        function $LoadU256(ptr) -> val {
+          let offs := $OffsetPtr(ptr)
+          switch $IsStoragePtr(ptr)
+          case 0 {
+            val := $MemoryLoadU256(offs)
+          }
+          default {
+            val := $StorageLoadU256(offs)
+          }
+        }
+        function $MemoryLoadU256(offs) -> val {
+          val := $MemoryLoadBytes(offs, 32)
+        }
+        function $StorageLoadU256(offs) -> val {
+          val := $StorageLoadBytes(offs, 32)
+        }
+        function $Eq(x, y) -> r {
+            r := eq(x, y)
+        }
+    }
+}
+===> Succeed(Stopped) (used_gas=551): []
+
+// test of M::test_pack_S2_fail
+/* =======================================
+ * Generated by Move-To-Yul compiler v0.0
+ * ======================================= */
+
+/// @use-src 2:"tests/Structs.move"
+
+object "test_A2_M_test_pack_S2_fail" {
+    code {
+        mstore(0, memoryguard(160))
+        A2_M_test_pack_S2_fail()
+        return (0, 0)
+        function A2_M_test_pack_S2_fail() {
+            let $t1, $t2, $t3, $t4, $t5, $t6, $t7
+            let $locals := $Malloc(32)
+            let $block := 4
+            for {} true {} {
+                switch $block
+                case 2 {
+                    // label L1
+                    // $t7 := 100
+                    /// @src 2:451:454
+                    $t7 := 100
+                    // abort($t7)
+                    /// @src 2:432:455
+                    $Abort($t7)
+                }
+                case 3 {
+                    // label L0
+                    // return ()
+                    /// @src 2:432:455
+                    $Free($locals, 32)
+                    leave
+                }
+                case 4 {
+                    // $t1 := 42
+                    /// @src 2:419:421
+                    $t1 := 42
+                    // $t0 := M::pack_S2($t1)
+                    /// @src 2:411:422
+                    mstore($locals, A2_M_pack_S2($t1))
+                    // $t2 := borrow_local($t0)
+                    /// @src 2:440:441
+                    $t2 := $MakePtr(false, $locals)
+                    // $t3 := borrow_field<M::S2>.x($t2)
+                    /// @src 2:440:443
+                    $t3 := $IndexPtr($LoadU256($t2), 0)
+                    // $t4 := read_ref($t3)
+                    /// @src 2:440:443
+                    $t4 := $LoadU128($t3)
+                    // $t5 := 41
+                    /// @src 2:447:449
+                    $t5 := 41
+                    // $t6 := ==($t4, $t5)
+                    /// @src 2:444:446
+                    $t6 := $Eq($t4, $t5)
+                    // if ($t6) goto L0 else goto L1
+                    /// @src 2:432:455
+                    switch $t6
+                    case 0  { $block := 2 }
+                    default { $block := 3 }
+                }
+            }
+        }
+
+        function A2_M_pack_S2(x) -> $result {
+            let $t1
+            // $t1 := pack M::S2($t0)
+            /// @src 2:229:234
+            {
+                let $mem := $Malloc(16)
+                $MemoryStoreU128(add($mem, 0), x)
+                $t1 := $MakePtr(false, $mem)
+            }
+            // return $t1
+            /// @src 2:229:234
+            $result := $t1
+        }
+
+        function $Abort(code) {
+            mstore(0, code)
+            revert(24, 8) // TODO: store code as a string?
+        }
+        function $Malloc(size) -> offs {
+            offs := mload(0)
+            // pad to word size
+            mstore(0, add(offs, shl(5, shr(5, add(size, 31)))))
+        }
+        function $Free(offs, size) {
+        }
+        function $MakePtr(is_storage, offs) -> ptr {
+          ptr := or(is_storage, shl(1, offs))
+        }
+        function $IsStoragePtr(ptr) -> b {
+          b := and(ptr, 0x1)
+        }
+        function $OffsetPtr(ptr) -> offs {
+          offs := shr(1, ptr)
+        }
+        function $MaskForSize(size) -> mask {
+          mask := sub(shl(shl(size, 3), 1), 1)
+        }
+        function $ExtractBytes(word, start, size) -> bytes {
+           switch size
+           case 1 {
+              // use the faster byte primitive
+              bytes := byte(start, word)
+           }
+           default {
+              // As we have big endian, we need to right shift the value from
+              // where the highest byte starts in the word (32 - start), minus
+              // the size.
+              let shift_bits := shl(3, sub(sub(32, start), size))
+              bytes := and(shr(shift_bits, word), $MaskForSize(size))
+           }
+        }
+        function $ToWordOffs(offs) -> word_offs, byte_offset {
+          word_offs := shr(5, offs)
+          byte_offset := and(offs, 0x1F)
+        }
+        function $OverflowBytes(byte_offset, size) -> overflow_bytes {
+          let available_bytes := sub(32, byte_offset)
+          switch gt(size, available_bytes)
+          case 0 {
+            overflow_bytes := 0
+          }
+          default {
+            overflow_bytes := sub(size, available_bytes)
+          }
+        }
+        function $MemoryLoadBytes(offs, size) -> val {
+          // Lower bit where the value in the higher bytes ends
+          let bit_end := shl(3, sub(32, size))
+          val := shr(bit_end, mload(offs))
+        }
+        function $MemoryStoreBytes(offs, size, val) {
+          let bit_end := shl(3, sub(32, size))
+          let mask := shl(bit_end, $MaskForSize(size))
+          mstore(offs, or(and(mload(offs), not(mask)), shl(bit_end, val)))
+        }
+        function $StorageLoadBytes(offs, size) -> val {
+          let word_offs, byte_offs := $ToWordOffs(offs)
+          let key := $StorageKey(0, word_offs)
+          val := $ExtractBytes(sload(key), byte_offs, size)
+          let overflow_bytes := $OverflowBytes(byte_offs, size)
+          if not(iszero(overflow_bytes)) {
+            key := $StorageKey(0, add(word_offs, 1))
+            let extra_bytes := $ExtractBytes(sload(key), 0, overflow_bytes)
+            val := or(shl(shl(3, overflow_bytes), val), extra_bytes)
+          }
+        }
+        function $StorageKey(group, word) -> key {
+          mstore(32, word)
+          mstore(64, group)
+          key := keccak256(32, 36)
+        }
+        function $IndexPtr(ptr, offs) -> new_ptr {
+          new_ptr := $MakePtr($IsStoragePtr(ptr), add($OffsetPtr(ptr), offs))
+        }
+        function $LoadU128(ptr) -> val {
+          let offs := $OffsetPtr(ptr)
+          switch $IsStoragePtr(ptr)
+          case 0 {
+            val := $MemoryLoadU128(offs)
+          }
+          default {
+            val := $StorageLoadU128(offs)
+          }
+        }
+        function $MemoryLoadU128(offs) -> val {
+          val := $MemoryLoadBytes(offs, 16)
+        }
+        function $StorageLoadU128(offs) -> val {
+          val := $StorageLoadBytes(offs, 16)
+        }
+        function $MemoryStoreU128(offs, val) {
+          $MemoryStoreBytes(offs, 16, val)
+        }
+        function $LoadU256(ptr) -> val {
+          let offs := $OffsetPtr(ptr)
+          switch $IsStoragePtr(ptr)
+          case 0 {
+            val := $MemoryLoadU256(offs)
+          }
+          default {
+            val := $StorageLoadU256(offs)
+          }
+        }
+        function $MemoryLoadU256(offs) -> val {
+          val := $MemoryLoadBytes(offs, 32)
+        }
+        function $StorageLoadU256(offs) -> val {
+          val := $StorageLoadBytes(offs, 32)
+        }
+        function $Eq(x, y) -> r {
+            r := eq(x, y)
+        }
+    }
+}
+===> Revert(Reverted) (used_gas=533): [0, 0, 0, 0, 0, 0, 0, 100]
+
+// test of M::test_read_S
+/* =======================================
+ * Generated by Move-To-Yul compiler v0.0
+ * ======================================= */
+
+/// @use-src 2:"tests/Structs.move"
+
+object "test_A2_M_test_read_S" {
+    code {
+        mstore(0, memoryguard(160))
+        A2_M_test_read_S()
+        return (0, 0)
+        function A2_M_test_read_S() {
+            let $t1, $t2, $t3, $t4, $t5, $t6, $t7
+            let $locals := $Malloc(32)
+            let $block := 4
+            for {} true {} {
+                switch $block
+                case 2 {
+                    // label L1
+                    // $t7 := 100
+                    /// @src 2:1011:1014
+                    $t7 := 100
+                    // abort($t7)
+                    /// @src 2:985:1015
+                    $Abort($t7)
+                }
+                case 3 {
+                    // label L0
+                    // return ()
+                    /// @src 2:1015:1016
+                    $Free($locals, 32)
+                    leave
+                }
+                case 4 {
+                    // $t1 := 42
+                    /// @src 2:966:968
+                    $t1 := 42
+                    // $t2 := true
+                    /// @src 2:970:974
+                    $t2 := true
+                    // $t0 := M::pack_S($t1, $t2)
+                    /// @src 2:959:975
+                    mstore($locals, A2_M_pack_S($t1, $t2))
+                    // $t3 := borrow_local($t0)
+                    /// @src 2:1000:1002
+                    $t3 := $MakePtr(false, $locals)
+                    // $t4 := M::read_S($t3)
+                    /// @src 2:993:1003
+                    $t4 := A2_M_read_S($t3)
+                    // $t5 := 84
+                    /// @src 2:1007:1009
+                    $t5 := 84
+                    // $t6 := ==($t4, $t5)
+                    /// @src 2:1004:1006
+                    $t6 := $Eq($t4, $t5)
+                    // if ($t6) goto L0 else goto L1
+                    /// @src 2:985:1015
+                    switch $t6
+                    case 0  { $block := 2 }
+                    default { $block := 3 }
+                }
+            }
+        }
+
+        function A2_M_read_S(s) -> $result {
+            let $t1, $t2, $t3, $t4, $t5, $t6, $t7
+            // $t1 := borrow_field<M::S>.a($t0)
+            /// @src 2:876:879
+            $t1 := $IndexPtr($LoadU256(s), 32)
+            // $t2 := read_ref($t1)
+            /// @src 2:876:879
+            $t2 := $LoadU64($t1)
+            // $t3 := borrow_field<M::S>.c($t0)
+            /// @src 2:883:886
+            $t3 := $IndexPtr($LoadU256(s), 0)
+            // $t4 := borrow_field<M::S2>.x($t3)
+            /// @src 2:883:888
+            $t4 := $IndexPtr($LoadU256($t3), 0)
+            // $t5 := read_ref($t4)
+            /// @src 2:883:888
+            $t5 := $LoadU128($t4)
+            // $t6 := (u64)($t5)
+            /// @src 2:882:896
+            $t6 := $CastU64($t5)
+            // $t7 := +($t2, $t6)
+            /// @src 2:880:881
+            $t7 := $AddU64($t2, $t6)
+            // return $t7
+            /// @src 2:876:896
+            $result := $t7
+        }
+
+        function A2_M_pack_S(a, b) -> $result {
+            let $t2, $t3, $t4
+            // $t2 := (u128)($t0)
+            /// @src 2:581:592
+            $t2 := $CastU128(a)
+            // $t3 := M::pack_S2($t2)
+            /// @src 2:573:593
+            $t3 := A2_M_pack_S2($t2)
+            // $t4 := pack M::S($t0, $t1, $t3)
+            /// @src 2:562:594
+            {
+                let $mem := $Malloc(41)
+                $MemoryStoreU64(add($mem, 32), a)
+                $MemoryStoreU8(add($mem, 40), b)
+                $MemoryStoreU256(add($mem, 0), $t3)
+                $t4 := $MakePtr(false, $mem)
+            }
+            // return $t4
+            /// @src 2:562:594
+            $result := $t4
+        }
+
+        function A2_M_pack_S2(x) -> $result {
+            let $t1
+            // $t1 := pack M::S2($t0)
+            /// @src 2:229:234
+            {
+                let $mem := $Malloc(16)
+                $MemoryStoreU128(add($mem, 0), x)
+                $t1 := $MakePtr(false, $mem)
+            }
+            // return $t1
+            /// @src 2:229:234
+            $result := $t1
+        }
+
+        function $Abort(code) {
+            mstore(0, code)
+            revert(24, 8) // TODO: store code as a string?
+        }
+        function $AbortBuiltin() {
+            $Abort(sub(0, 1))
+        }
+        function $Malloc(size) -> offs {
+            offs := mload(0)
+            // pad to word size
+            mstore(0, add(offs, shl(5, shr(5, add(size, 31)))))
+        }
+        function $Free(offs, size) {
+        }
+        function $MakePtr(is_storage, offs) -> ptr {
+          ptr := or(is_storage, shl(1, offs))
+        }
+        function $IsStoragePtr(ptr) -> b {
+          b := and(ptr, 0x1)
+        }
+        function $OffsetPtr(ptr) -> offs {
+          offs := shr(1, ptr)
+        }
+        function $MaskForSize(size) -> mask {
+          mask := sub(shl(shl(size, 3), 1), 1)
+        }
+        function $ExtractBytes(word, start, size) -> bytes {
+           switch size
+           case 1 {
+              // use the faster byte primitive
+              bytes := byte(start, word)
+           }
+           default {
+              // As we have big endian, we need to right shift the value from
+              // where the highest byte starts in the word (32 - start), minus
+              // the size.
+              let shift_bits := shl(3, sub(sub(32, start), size))
+              bytes := and(shr(shift_bits, word), $MaskForSize(size))
+           }
+        }
+        function $ToWordOffs(offs) -> word_offs, byte_offset {
+          word_offs := shr(5, offs)
+          byte_offset := and(offs, 0x1F)
+        }
+        function $OverflowBytes(byte_offset, size) -> overflow_bytes {
+          let available_bytes := sub(32, byte_offset)
+          switch gt(size, available_bytes)
+          case 0 {
+            overflow_bytes := 0
+          }
+          default {
+            overflow_bytes := sub(size, available_bytes)
+          }
+        }
+        function $MemoryLoadBytes(offs, size) -> val {
+          // Lower bit where the value in the higher bytes ends
+          let bit_end := shl(3, sub(32, size))
+          val := shr(bit_end, mload(offs))
+        }
+        function $MemoryStoreBytes(offs, size, val) {
+          let bit_end := shl(3, sub(32, size))
+          let mask := shl(bit_end, $MaskForSize(size))
+          mstore(offs, or(and(mload(offs), not(mask)), shl(bit_end, val)))
+        }
+        function $StorageLoadBytes(offs, size) -> val {
+          let word_offs, byte_offs := $ToWordOffs(offs)
+          let key := $StorageKey(0, word_offs)
+          val := $ExtractBytes(sload(key), byte_offs, size)
+          let overflow_bytes := $OverflowBytes(byte_offs, size)
+          if not(iszero(overflow_bytes)) {
+            key := $StorageKey(0, add(word_offs, 1))
+            let extra_bytes := $ExtractBytes(sload(key), 0, overflow_bytes)
+            val := or(shl(shl(3, overflow_bytes), val), extra_bytes)
+          }
+        }
+        function $StorageKey(group, word) -> key {
+          mstore(32, word)
+          mstore(64, group)
+          key := keccak256(32, 36)
+        }
+        function $IndexPtr(ptr, offs) -> new_ptr {
+          new_ptr := $MakePtr($IsStoragePtr(ptr), add($OffsetPtr(ptr), offs))
+        }
+        function $MemoryStoreU8(offs, val) {
+          // Shortcut via special instruction
+          mstore8(offs, val)
+        }
+        function $LoadU64(ptr) -> val {
+          let offs := $OffsetPtr(ptr)
+          switch $IsStoragePtr(ptr)
+          case 0 {
+            val := $MemoryLoadU64(offs)
+          }
+          default {
+            val := $StorageLoadU64(offs)
+          }
+        }
+        function $MemoryLoadU64(offs) -> val {
+          val := $MemoryLoadBytes(offs, 8)
+        }
+        function $StorageLoadU64(offs) -> val {
+          val := $StorageLoadBytes(offs, 8)
+        }
+        function $MemoryStoreU64(offs, val) {
+          $MemoryStoreBytes(offs, 8, val)
+        }
+        function $LoadU128(ptr) -> val {
+          let offs := $OffsetPtr(ptr)
+          switch $IsStoragePtr(ptr)
+          case 0 {
+            val := $MemoryLoadU128(offs)
+          }
+          default {
+            val := $StorageLoadU128(offs)
+          }
+        }
+        function $MemoryLoadU128(offs) -> val {
+          val := $MemoryLoadBytes(offs, 16)
+        }
+        function $StorageLoadU128(offs) -> val {
+          val := $StorageLoadBytes(offs, 16)
+        }
+        function $MemoryStoreU128(offs, val) {
+          $MemoryStoreBytes(offs, 16, val)
+        }
+        function $LoadU256(ptr) -> val {
+          let offs := $OffsetPtr(ptr)
+          switch $IsStoragePtr(ptr)
+          case 0 {
+            val := $MemoryLoadU256(offs)
+          }
+          default {
+            val := $StorageLoadU256(offs)
+          }
+        }
+        function $MemoryLoadU256(offs) -> val {
+          val := $MemoryLoadBytes(offs, 32)
+        }
+        function $StorageLoadU256(offs) -> val {
+          val := $StorageLoadBytes(offs, 32)
+        }
+        function $MemoryStoreU256(offs, val) {
+          $MemoryStoreBytes(offs, 32, val)
+        }
+        function $AddU64(x, y) -> r {
+            if lt(sub(0xffffffffffffffff, x), y) { $AbortBuiltin() }
+            r := add(x, y)
+        }
+        function $Eq(x, y) -> r {
+            r := eq(x, y)
+        }
+        function $CastU64(x) -> r {
+            if gt(x, 0xffffffffffffffff) { $AbortBuiltin() }
+            r := x
+        }
+        function $CastU128(x) -> r {
+            if gt(x, 0xffffffffffffffffffffffffffffffff) { $AbortBuiltin() }
+            r := x
+        }
+    }
+}
+===> Succeed(Stopped) (used_gas=1113): []
+
+// test of M::test_read_and_write_S
+/* =======================================
+ * Generated by Move-To-Yul compiler v0.0
+ * ======================================= */
+
+/// @use-src 2:"tests/Structs.move"
+
+object "test_A2_M_test_read_and_write_S" {
+    code {
+        mstore(0, memoryguard(160))
+        A2_M_test_read_and_write_S()
+        return (0, 0)
+        function A2_M_test_read_and_write_S() {
+            let $t1, $t2, $t3, $t4, $t5, $t6, $t7, $t8, $t9, $t10, $t11, $t12, $t13
+            let $locals := $Malloc(32)
+            let $block := 4
+            for {} true {} {
+                switch $block
+                case 2 {
+                    // label L1
+                    // $t6 := 100
+                    /// @src 2:1652:1655
+                    $t6 := 100
+                    // abort($t6)
+                    /// @src 2:1634:1656
+                    $Abort($t6)
+                }
+                case 3 {
+                    // label L0
+                    // $t7 := borrow_local($t0)
+                    /// @src 2:1674:1675
+                    $t7 := $MakePtr(false, $locals)
+                    // $t8 := borrow_field<M::S>.c($t7)
+                    /// @src 2:1674:1677
+                    $t8 := $IndexPtr($LoadU256($t7), 0)
+                    // $t9 := borrow_field<M::S2>.x($t8)
+                    /// @src 2:1674:1679
+                    $t9 := $IndexPtr($LoadU256($t8), 0)
+                    // $t10 := read_ref($t9)
+                    /// @src 2:1674:1679
+                    $t10 := $LoadU128($t9)
+                    // $t11 := 2
+                    /// @src 2:1683:1684
+                    $t11 := 2
+                    // $t12 := ==($t10, $t11)
+                    /// @src 2:1680:1682
+                    $t12 := $Eq($t10, $t11)
+                    // if ($t12) goto L2 else goto L3
+                    /// @src 2:1666:1690
+                    switch $t12
+                    case 0  { $block := 5 }
+                    default { $block := 6 }
+                }
+                case 4 {
+                    // $t0 := M::read_and_write_S()
+                    /// @src 2:1606:1624
+                    mstore($locals, A2_M_read_and_write_S())
+                    // $t1 := borrow_local($t0)
+                    /// @src 2:1642:1643
+                    $t1 := $MakePtr(false, $locals)
+                    // $t2 := borrow_field<M::S>.a($t1)
+                    /// @src 2:1642:1645
+                    $t2 := $IndexPtr($LoadU256($t1), 32)
+                    // $t3 := read_ref($t2)
+                    /// @src 2:1642:1645
+                    $t3 := $LoadU64($t2)
+                    // $t4 := 2
+                    /// @src 2:1649:1650
+                    $t4 := 2
+                    // $t5 := ==($t3, $t4)
+                    /// @src 2:1646:1648
+                    $t5 := $Eq($t3, $t4)
+                    // if ($t5) goto L0 else goto L1
+                    /// @src 2:1634:1656
+                    switch $t5
+                    case 0  { $block := 2 }
+                    default { $block := 3 }
+                }
+                case 5 {
+                    // label L3
+                    // $t13 := 101
+                    /// @src 2:1686:1689
+                    $t13 := 101
+                    // abort($t13)
+                    /// @src 2:1666:1690
+                    $Abort($t13)
+                }
+                case 6 {
+                    // label L2
+                    // return ()
+                    /// @src 2:1690:1691
+                    $Free($locals, 32)
+                    leave
+                }
+            }
+        }
+
+        function A2_M_read_and_write_S() -> $result {
+            let x, $t2, $t3, $t4, $t5, $t6, $t7
+            let $locals := $Malloc(32)
+            // $t2 := 1
+            /// @src 2:1457:1458
+            $t2 := 1
+            // $t3 := false
+            /// @src 2:1460:1465
+            $t3 := false
+            // $t0 := M::pack_S($t2, $t3)
+            /// @src 2:1450:1466
+            mstore($locals, A2_M_pack_S($t2, $t3))
+            // $t4 := borrow_local($t0)
+            /// @src 2:1491:1493
+            $t4 := $MakePtr(false, $locals)
+            // $t5 := M::read_S($t4)
+            /// @src 2:1484:1494
+            $t5 := A2_M_read_S($t4)
+            // $t6 := borrow_local($t0)
+            /// @src 2:1512:1518
+            $t6 := $MakePtr(false, $locals)
+            // M::write_S($t6, $t5)
+            /// @src 2:1504:1522
+            A2_M_write_S($t6, $t5)
+            // $t7 := move($t0)
+            /// @src 2:1532:1533
+            $t7 := mload($locals)
+            // return $t7
+            /// @src 2:1532:1533
+            $result := $t7
+            $Free($locals, 32)
+        }
+
+        function A2_M_write_S(s, v) {
+            let $t2, $t3, $t4, $t5, $t6, $t7
+            // $t2 := borrow_field<M::S>.a($t0)
+            /// @src 2:1123:1126
+            $t2 := $IndexPtr($LoadU256(s), 32)
+            // write_ref($t2, $t1)
+            /// @src 2:1123:1130
+            $StoreU64($t2, v)
+            // $t3 := borrow_field<M::S>.a($t0)
+            /// @src 2:1149:1152
+            $t3 := $IndexPtr($LoadU256(s), 32)
+            // $t4 := read_ref($t3)
+            /// @src 2:1149:1152
+            $t4 := $LoadU64($t3)
+            // $t5 := (u128)($t4)
+            /// @src 2:1148:1161
+            $t5 := $CastU128($t4)
+            // $t6 := borrow_field<M::S>.c($t0)
+            /// @src 2:1140:1143
+            $t6 := $IndexPtr($LoadU256(s), 0)
+            // $t7 := borrow_field<M::S2>.x($t6)
+            /// @src 2:1140:1145
+            $t7 := $IndexPtr($LoadU256($t6), 0)
+            // write_ref($t7, $t5)
+            /// @src 2:1140:1161
+            $StoreU128($t7, $t5)
+            // return ()
+            /// @src 2:1161:1162
+        }
+
+        function A2_M_read_S(s) -> $result {
+            let $t1, $t2, $t3, $t4, $t5, $t6, $t7
+            // $t1 := borrow_field<M::S>.a($t0)
+            /// @src 2:876:879
+            $t1 := $IndexPtr($LoadU256(s), 32)
+            // $t2 := read_ref($t1)
+            /// @src 2:876:879
+            $t2 := $LoadU64($t1)
+            // $t3 := borrow_field<M::S>.c($t0)
+            /// @src 2:883:886
+            $t3 := $IndexPtr($LoadU256(s), 0)
+            // $t4 := borrow_field<M::S2>.x($t3)
+            /// @src 2:883:888
+            $t4 := $IndexPtr($LoadU256($t3), 0)
+            // $t5 := read_ref($t4)
+            /// @src 2:883:888
+            $t5 := $LoadU128($t4)
+            // $t6 := (u64)($t5)
+            /// @src 2:882:896
+            $t6 := $CastU64($t5)
+            // $t7 := +($t2, $t6)
+            /// @src 2:880:881
+            $t7 := $AddU64($t2, $t6)
+            // return $t7
+            /// @src 2:876:896
+            $result := $t7
+        }
+
+        function A2_M_pack_S(a, b) -> $result {
+            let $t2, $t3, $t4
+            // $t2 := (u128)($t0)
+            /// @src 2:581:592
+            $t2 := $CastU128(a)
+            // $t3 := M::pack_S2($t2)
+            /// @src 2:573:593
+            $t3 := A2_M_pack_S2($t2)
+            // $t4 := pack M::S($t0, $t1, $t3)
+            /// @src 2:562:594
+            {
+                let $mem := $Malloc(41)
+                $MemoryStoreU64(add($mem, 32), a)
+                $MemoryStoreU8(add($mem, 40), b)
+                $MemoryStoreU256(add($mem, 0), $t3)
+                $t4 := $MakePtr(false, $mem)
+            }
+            // return $t4
+            /// @src 2:562:594
+            $result := $t4
+        }
+
+        function A2_M_pack_S2(x) -> $result {
+            let $t1
+            // $t1 := pack M::S2($t0)
+            /// @src 2:229:234
+            {
+                let $mem := $Malloc(16)
+                $MemoryStoreU128(add($mem, 0), x)
+                $t1 := $MakePtr(false, $mem)
+            }
+            // return $t1
+            /// @src 2:229:234
+            $result := $t1
+        }
+
+        function $Abort(code) {
+            mstore(0, code)
+            revert(24, 8) // TODO: store code as a string?
+        }
+        function $AbortBuiltin() {
+            $Abort(sub(0, 1))
+        }
+        function $Malloc(size) -> offs {
+            offs := mload(0)
+            // pad to word size
+            mstore(0, add(offs, shl(5, shr(5, add(size, 31)))))
+        }
+        function $Free(offs, size) {
+        }
+        function $MakePtr(is_storage, offs) -> ptr {
+          ptr := or(is_storage, shl(1, offs))
+        }
+        function $IsStoragePtr(ptr) -> b {
+          b := and(ptr, 0x1)
+        }
+        function $OffsetPtr(ptr) -> offs {
+          offs := shr(1, ptr)
+        }
+        function $MaskForSize(size) -> mask {
+          mask := sub(shl(shl(size, 3), 1), 1)
+        }
+        function $ExtractBytes(word, start, size) -> bytes {
+           switch size
+           case 1 {
+              // use the faster byte primitive
+              bytes := byte(start, word)
+           }
+           default {
+              // As we have big endian, we need to right shift the value from
+              // where the highest byte starts in the word (32 - start), minus
+              // the size.
+              let shift_bits := shl(3, sub(sub(32, start), size))
+              bytes := and(shr(shift_bits, word), $MaskForSize(size))
+           }
+        }
+        function $InjectBytes(word, start, size, bytes) -> new_word {
+           let shift_bits := shl(3, sub(sub(32, start), size))
+           // Blend out the bits which we inject
+           let neg_mask := not(shl(shift_bits, $MaskForSize(size)))
+           word := and(word, neg_mask)
+           // Overlay the bits we inject
+           new_word := or(word, shl(shift_bits, bytes))
+        }
+        function $ToWordOffs(offs) -> word_offs, byte_offset {
+          word_offs := shr(5, offs)
+          byte_offset := and(offs, 0x1F)
+        }
+        function $OverflowBytes(byte_offset, size) -> overflow_bytes {
+          let available_bytes := sub(32, byte_offset)
+          switch gt(size, available_bytes)
+          case 0 {
+            overflow_bytes := 0
+          }
+          default {
+            overflow_bytes := sub(size, available_bytes)
+          }
+        }
+        function $MemoryLoadBytes(offs, size) -> val {
+          // Lower bit where the value in the higher bytes ends
+          let bit_end := shl(3, sub(32, size))
+          val := shr(bit_end, mload(offs))
+        }
+        function $MemoryStoreBytes(offs, size, val) {
+          let bit_end := shl(3, sub(32, size))
+          let mask := shl(bit_end, $MaskForSize(size))
+          mstore(offs, or(and(mload(offs), not(mask)), shl(bit_end, val)))
+        }
+        function $StorageLoadBytes(offs, size) -> val {
+          let word_offs, byte_offs := $ToWordOffs(offs)
+          let key := $StorageKey(0, word_offs)
+          val := $ExtractBytes(sload(key), byte_offs, size)
+          let overflow_bytes := $OverflowBytes(byte_offs, size)
+          if not(iszero(overflow_bytes)) {
+            key := $StorageKey(0, add(word_offs, 1))
+            let extra_bytes := $ExtractBytes(sload(key), 0, overflow_bytes)
+            val := or(shl(shl(3, overflow_bytes), val), extra_bytes)
+          }
+        }
+        function $StorageStoreBytes(offs, size, bytes) {
+          let word_offs, byte_offs := $ToWordOffs(offs)
+          let key := $StorageKey(0, word_offs)
+          let overflow_bytes := $OverflowBytes(byte_offs, size)
+          switch overflow_bytes
+          case 0 {
+            sstore(key, $InjectBytes(sload(key), byte_offs, size, bytes))
+          }
+          default {
+            // Shift the higher bytes to the right
+            let used_bytes := sub(size, overflow_bytes)
+            let higher_bytes := shr(used_bytes, bytes)
+            let lower_bytes := and(bytes, $MaskForSize(overflow_bytes))
+            sstore(key, $InjectBytes(sload(key), byte_offs, used_bytes, higher_bytes))
+            key := $StorageKey(0, add(word_offs, 1))
+            sstore(key, $InjectBytes(sload(key), 0, overflow_bytes, lower_bytes))
+          }
+        }
+        function $StorageKey(group, word) -> key {
+          mstore(32, word)
+          mstore(64, group)
+          key := keccak256(32, 36)
+        }
+        function $IndexPtr(ptr, offs) -> new_ptr {
+          new_ptr := $MakePtr($IsStoragePtr(ptr), add($OffsetPtr(ptr), offs))
+        }
+        function $MemoryStoreU8(offs, val) {
+          // Shortcut via special instruction
+          mstore8(offs, val)
+        }
+        function $LoadU64(ptr) -> val {
+          let offs := $OffsetPtr(ptr)
+          switch $IsStoragePtr(ptr)
+          case 0 {
+            val := $MemoryLoadU64(offs)
+          }
+          default {
+            val := $StorageLoadU64(offs)
+          }
+        }
+        function $MemoryLoadU64(offs) -> val {
+          val := $MemoryLoadBytes(offs, 8)
+        }
+        function $StorageLoadU64(offs) -> val {
+          val := $StorageLoadBytes(offs, 8)
+        }
+        function $StoreU64(ptr, val) {
+          let offs := $OffsetPtr(ptr)
+          switch $IsStoragePtr(ptr)
+          case 0 {
+            $MemoryStoreU64(offs, val)
+          }
+          default {
+            $StorageStoreU64(offs, val)
+          }
+        }
+        function $MemoryStoreU64(offs, val) {
+          $MemoryStoreBytes(offs, 8, val)
+        }
+        function $StorageStoreU64(offs, val) {
+          $StorageStoreBytes(offs, 8, val)
+        }
+        function $LoadU128(ptr) -> val {
+          let offs := $OffsetPtr(ptr)
+          switch $IsStoragePtr(ptr)
+          case 0 {
+            val := $MemoryLoadU128(offs)
+          }
+          default {
+            val := $StorageLoadU128(offs)
+          }
+        }
+        function $MemoryLoadU128(offs) -> val {
+          val := $MemoryLoadBytes(offs, 16)
+        }
+        function $StorageLoadU128(offs) -> val {
+          val := $StorageLoadBytes(offs, 16)
+        }
+        function $StoreU128(ptr, val) {
+          let offs := $OffsetPtr(ptr)
+          switch $IsStoragePtr(ptr)
+          case 0 {
+            $MemoryStoreU128(offs, val)
+          }
+          default {
+            $StorageStoreU128(offs, val)
+          }
+        }
+        function $MemoryStoreU128(offs, val) {
+          $MemoryStoreBytes(offs, 16, val)
+        }
+        function $StorageStoreU128(offs, val) {
+          $StorageStoreBytes(offs, 16, val)
+        }
+        function $LoadU256(ptr) -> val {
+          let offs := $OffsetPtr(ptr)
+          switch $IsStoragePtr(ptr)
+          case 0 {
+            val := $MemoryLoadU256(offs)
+          }
+          default {
+            val := $StorageLoadU256(offs)
+          }
+        }
+        function $MemoryLoadU256(offs) -> val {
+          val := $MemoryLoadBytes(offs, 32)
+        }
+        function $StorageLoadU256(offs) -> val {
+          val := $StorageLoadBytes(offs, 32)
+        }
+        function $MemoryStoreU256(offs, val) {
+          $MemoryStoreBytes(offs, 32, val)
+        }
+        function $AddU64(x, y) -> r {
+            if lt(sub(0xffffffffffffffff, x), y) { $AbortBuiltin() }
+            r := add(x, y)
+        }
+        function $Eq(x, y) -> r {
+            r := eq(x, y)
+        }
+        function $CastU64(x) -> r {
+            if gt(x, 0xffffffffffffffff) { $AbortBuiltin() }
+            r := x
+        }
+        function $CastU128(x) -> r {
+            if gt(x, 0xffffffffffffffffffffffffffffffff) { $AbortBuiltin() }
+            r := x
+        }
+    }
+}
+===> Succeed(Stopped) (used_gas=2593): []
+
+// test of M::test_unpack
+/* =======================================
+ * Generated by Move-To-Yul compiler v0.0
+ * ======================================= */
+
+/// @use-src 2:"tests/Structs.move"
+
+object "test_A2_M_test_unpack" {
+    code {
+        mstore(0, memoryguard(160))
+        A2_M_test_unpack()
+        return (0, 0)
+        function A2_M_test_unpack() {
+            let s, $t2, $t3, $t4, $t5, $t6, $t7, $t8, $t9, $t10
+            let $locals := $Malloc(32)
+            let $block := 4
+            for {} true {} {
+                switch $block
+                case 2 {
+                    // label L1
+                    // $t10 := 101
+                    /// @src 2:1964:1967
+                    $t10 := 101
+                    // abort($t10)
+                    /// @src 2:1944:1968
+                    $Abort($t10)
+                }
+                case 3 {
+                    // label L0
+                    // return ()
+                    /// @src 2:1968:1969
+                    $Free($locals, 32)
+                    leave
+                }
+                case 4 {
+                    // $t2 := 33
+                    /// @src 2:1896:1898
+                    $t2 := 33
+                    // $t3 := false
+                    /// @src 2:1900:1905
+                    $t3 := false
+                    // $t4 := M::pack_S($t2, $t3)
+                    /// @src 2:1889:1906
+                    $t4 := A2_M_pack_S($t2, $t3)
+                    // $t1 := M::unpack($t4)
+                    /// @src 2:1925:1934
+                    mstore($locals, A2_M_unpack($t4))
+                    // $t5 := borrow_local($t1)
+                    /// @src 2:1952:1954
+                    $t5 := $MakePtr(false, $locals)
+                    // $t6 := borrow_field<M::S2>.x($t5)
+                    /// @src 2:1952:1956
+                    $t6 := $IndexPtr($LoadU256($t5), 0)
+                    // $t7 := read_ref($t6)
+                    /// @src 2:1952:1956
+                    $t7 := $LoadU128($t6)
+                    // $t8 := 33
+                    /// @src 2:1960:1962
+                    $t8 := 33
+                    // $t9 := ==($t7, $t8)
+                    /// @src 2:1957:1959
+                    $t9 := $Eq($t7, $t8)
+                    // if ($t9) goto L0 else goto L1
+                    /// @src 2:1944:1968
+                    switch $t9
+                    case 0  { $block := 2 }
+                    default { $block := 3 }
+                }
+            }
+        }
+
+        function A2_M_unpack(s) -> $result {
+            let _a, _b, c, $t4, $t5, $t6
+            // ($t4, $t5, $t6) := unpack M::S($t0)
+            /// @src 2:1793:1811
+            $t4 := $MemoryLoadU64(add(s, 32))
+            $t5 := $MemoryLoadU8(add(s, 40))
+            $t6 := $MemoryLoadU256(add(s, 0))
+            $Free(s, 41)
+            // destroy($t5)
+            /// @src 2:1805:1807
+            // destroy($t4)
+            /// @src 2:1798:1800
+            // return $t6
+            /// @src 2:1825:1826
+            $result := $t6
+        }
+
+        function A2_M_pack_S(a, b) -> $result {
+            let $t2, $t3, $t4
+            // $t2 := (u128)($t0)
+            /// @src 2:581:592
+            $t2 := $CastU128(a)
+            // $t3 := M::pack_S2($t2)
+            /// @src 2:573:593
+            $t3 := A2_M_pack_S2($t2)
+            // $t4 := pack M::S($t0, $t1, $t3)
+            /// @src 2:562:594
+            {
+                let $mem := $Malloc(41)
+                $MemoryStoreU64(add($mem, 32), a)
+                $MemoryStoreU8(add($mem, 40), b)
+                $MemoryStoreU256(add($mem, 0), $t3)
+                $t4 := $MakePtr(false, $mem)
+            }
+            // return $t4
+            /// @src 2:562:594
+            $result := $t4
+        }
+
+        function A2_M_pack_S2(x) -> $result {
+            let $t1
+            // $t1 := pack M::S2($t0)
+            /// @src 2:229:234
+            {
+                let $mem := $Malloc(16)
+                $MemoryStoreU128(add($mem, 0), x)
+                $t1 := $MakePtr(false, $mem)
+            }
+            // return $t1
+            /// @src 2:229:234
+            $result := $t1
+        }
+
+        function $Abort(code) {
+            mstore(0, code)
+            revert(24, 8) // TODO: store code as a string?
+        }
+        function $AbortBuiltin() {
+            $Abort(sub(0, 1))
+        }
+        function $Malloc(size) -> offs {
+            offs := mload(0)
+            // pad to word size
+            mstore(0, add(offs, shl(5, shr(5, add(size, 31)))))
+        }
+        function $Free(offs, size) {
+        }
+        function $MakePtr(is_storage, offs) -> ptr {
+          ptr := or(is_storage, shl(1, offs))
+        }
+        function $IsStoragePtr(ptr) -> b {
+          b := and(ptr, 0x1)
+        }
+        function $OffsetPtr(ptr) -> offs {
+          offs := shr(1, ptr)
+        }
+        function $MaskForSize(size) -> mask {
+          mask := sub(shl(shl(size, 3), 1), 1)
+        }
+        function $ExtractBytes(word, start, size) -> bytes {
+           switch size
+           case 1 {
+              // use the faster byte primitive
+              bytes := byte(start, word)
+           }
+           default {
+              // As we have big endian, we need to right shift the value from
+              // where the highest byte starts in the word (32 - start), minus
+              // the size.
+              let shift_bits := shl(3, sub(sub(32, start), size))
+              bytes := and(shr(shift_bits, word), $MaskForSize(size))
+           }
+        }
+        function $ToWordOffs(offs) -> word_offs, byte_offset {
+          word_offs := shr(5, offs)
+          byte_offset := and(offs, 0x1F)
+        }
+        function $OverflowBytes(byte_offset, size) -> overflow_bytes {
+          let available_bytes := sub(32, byte_offset)
+          switch gt(size, available_bytes)
+          case 0 {
+            overflow_bytes := 0
+          }
+          default {
+            overflow_bytes := sub(size, available_bytes)
+          }
+        }
+        function $MemoryLoadBytes(offs, size) -> val {
+          // Lower bit where the value in the higher bytes ends
+          let bit_end := shl(3, sub(32, size))
+          val := shr(bit_end, mload(offs))
+        }
+        function $MemoryStoreBytes(offs, size, val) {
+          let bit_end := shl(3, sub(32, size))
+          let mask := shl(bit_end, $MaskForSize(size))
+          mstore(offs, or(and(mload(offs), not(mask)), shl(bit_end, val)))
+        }
+        function $StorageLoadBytes(offs, size) -> val {
+          let word_offs, byte_offs := $ToWordOffs(offs)
+          let key := $StorageKey(0, word_offs)
+          val := $ExtractBytes(sload(key), byte_offs, size)
+          let overflow_bytes := $OverflowBytes(byte_offs, size)
+          if not(iszero(overflow_bytes)) {
+            key := $StorageKey(0, add(word_offs, 1))
+            let extra_bytes := $ExtractBytes(sload(key), 0, overflow_bytes)
+            val := or(shl(shl(3, overflow_bytes), val), extra_bytes)
+          }
+        }
+        function $StorageKey(group, word) -> key {
+          mstore(32, word)
+          mstore(64, group)
+          key := keccak256(32, 36)
+        }
+        function $IndexPtr(ptr, offs) -> new_ptr {
+          new_ptr := $MakePtr($IsStoragePtr(ptr), add($OffsetPtr(ptr), offs))
+        }
+        function $MemoryLoadU8(offs) -> val {
+          val := $MemoryLoadBytes(offs, 1)
+        }
+        function $MemoryStoreU8(offs, val) {
+          // Shortcut via special instruction
+          mstore8(offs, val)
+        }
+        function $MemoryLoadU64(offs) -> val {
+          val := $MemoryLoadBytes(offs, 8)
+        }
+        function $MemoryStoreU64(offs, val) {
+          $MemoryStoreBytes(offs, 8, val)
+        }
+        function $LoadU128(ptr) -> val {
+          let offs := $OffsetPtr(ptr)
+          switch $IsStoragePtr(ptr)
+          case 0 {
+            val := $MemoryLoadU128(offs)
+          }
+          default {
+            val := $StorageLoadU128(offs)
+          }
+        }
+        function $MemoryLoadU128(offs) -> val {
+          val := $MemoryLoadBytes(offs, 16)
+        }
+        function $StorageLoadU128(offs) -> val {
+          val := $StorageLoadBytes(offs, 16)
+        }
+        function $MemoryStoreU128(offs, val) {
+          $MemoryStoreBytes(offs, 16, val)
+        }
+        function $LoadU256(ptr) -> val {
+          let offs := $OffsetPtr(ptr)
+          switch $IsStoragePtr(ptr)
+          case 0 {
+            val := $MemoryLoadU256(offs)
+          }
+          default {
+            val := $StorageLoadU256(offs)
+          }
+        }
+        function $MemoryLoadU256(offs) -> val {
+          val := $MemoryLoadBytes(offs, 32)
+        }
+        function $StorageLoadU256(offs) -> val {
+          val := $StorageLoadBytes(offs, 32)
+        }
+        function $MemoryStoreU256(offs, val) {
+          $MemoryStoreBytes(offs, 32, val)
+        }
+        function $Eq(x, y) -> r {
+            r := eq(x, y)
+        }
+        function $CastU128(x) -> r {
+            if gt(x, 0xffffffffffffffffffffffffffffffff) { $AbortBuiltin() }
+            r := x
+        }
+    }
+}
+===> Revert(Reverted) (used_gas=680): [0, 0, 0, 0, 0, 0, 0, 101]
+
+// test of M::test_write_S
+/* =======================================
+ * Generated by Move-To-Yul compiler v0.0
+ * ======================================= */
+
+/// @use-src 2:"tests/Structs.move"
+
+object "test_A2_M_test_write_S" {
+    code {
+        mstore(0, memoryguard(160))
+        A2_M_test_write_S()
+        return (0, 0)
+        function A2_M_test_write_S() {
+            let $t1, $t2, $t3, $t4, $t5, $t6, $t7, $t8, $t9, $t10, $t11, $t12, $t13, $t14, $t15, $t16, $t17
+            let $locals := $Malloc(32)
+            let $block := 4
+            for {} true {} {
+                switch $block
+                case 2 {
+                    // label L1
+                    // $t10 := 100
+                    /// @src 2:1300:1303
+                    $t10 := 100
+                    // abort($t10)
+                    /// @src 2:1281:1304
+                    $Abort($t10)
+                }
+                case 3 {
+                    // label L0
+                    // $t11 := borrow_local($t0)
+                    /// @src 2:1322:1323
+                    $t11 := $MakePtr(false, $locals)
+                    // $t12 := borrow_field<M::S>.c($t11)
+                    /// @src 2:1322:1325
+                    $t12 := $IndexPtr($LoadU256($t11), 0)
+                    // $t13 := borrow_field<M::S2>.x($t12)
+                    /// @src 2:1322:1327
+                    $t13 := $IndexPtr($LoadU256($t12), 0)
+                    // $t14 := read_ref($t13)
+                    /// @src 2:1322:1327
+                    $t14 := $LoadU128($t13)
+                    // $t15 := 43
+                    /// @src 2:1331:1333
+                    $t15 := 43
+                    // $t16 := ==($t14, $t15)
+                    /// @src 2:1328:1330
+                    $t16 := $Eq($t14, $t15)
+                    // if ($t16) goto L2 else goto L3
+                    /// @src 2:1314:1339
+                    switch $t16
+                    case 0  { $block := 5 }
+                    default { $block := 6 }
+                }
+                case 4 {
+                    // $t1 := 42
+                    /// @src 2:1233:1235
+                    $t1 := 42
+                    // $t2 := true
+                    /// @src 2:1237:1241
+                    $t2 := true
+                    // $t0 := M::pack_S($t1, $t2)
+                    /// @src 2:1226:1242
+                    mstore($locals, A2_M_pack_S($t1, $t2))
+                    // $t3 := borrow_local($t0)
+                    /// @src 2:1260:1266
+                    $t3 := $MakePtr(false, $locals)
+                    // $t4 := 43
+                    /// @src 2:1268:1270
+                    $t4 := 43
+                    // M::write_S($t3, $t4)
+                    /// @src 2:1252:1271
+                    A2_M_write_S($t3, $t4)
+                    // $t5 := borrow_local($t0)
+                    /// @src 2:1289:1290
+                    $t5 := $MakePtr(false, $locals)
+                    // $t6 := borrow_field<M::S>.a($t5)
+                    /// @src 2:1289:1292
+                    $t6 := $IndexPtr($LoadU256($t5), 32)
+                    // $t7 := read_ref($t6)
+                    /// @src 2:1289:1292
+                    $t7 := $LoadU64($t6)
+                    // $t8 := 43
+                    /// @src 2:1296:1298
+                    $t8 := 43
+                    // $t9 := ==($t7, $t8)
+                    /// @src 2:1293:1295
+                    $t9 := $Eq($t7, $t8)
+                    // if ($t9) goto L0 else goto L1
+                    /// @src 2:1281:1304
+                    switch $t9
+                    case 0  { $block := 2 }
+                    default { $block := 3 }
+                }
+                case 5 {
+                    // label L3
+                    // $t17 := 101
+                    /// @src 2:1335:1338
+                    $t17 := 101
+                    // abort($t17)
+                    /// @src 2:1314:1339
+                    $Abort($t17)
+                }
+                case 6 {
+                    // label L2
+                    // return ()
+                    /// @src 2:1339:1340
+                    $Free($locals, 32)
+                    leave
+                }
+            }
+        }
+
+        function A2_M_write_S(s, v) {
+            let $t2, $t3, $t4, $t5, $t6, $t7
+            // $t2 := borrow_field<M::S>.a($t0)
+            /// @src 2:1123:1126
+            $t2 := $IndexPtr($LoadU256(s), 32)
+            // write_ref($t2, $t1)
+            /// @src 2:1123:1130
+            $StoreU64($t2, v)
+            // $t3 := borrow_field<M::S>.a($t0)
+            /// @src 2:1149:1152
+            $t3 := $IndexPtr($LoadU256(s), 32)
+            // $t4 := read_ref($t3)
+            /// @src 2:1149:1152
+            $t4 := $LoadU64($t3)
+            // $t5 := (u128)($t4)
+            /// @src 2:1148:1161
+            $t5 := $CastU128($t4)
+            // $t6 := borrow_field<M::S>.c($t0)
+            /// @src 2:1140:1143
+            $t6 := $IndexPtr($LoadU256(s), 0)
+            // $t7 := borrow_field<M::S2>.x($t6)
+            /// @src 2:1140:1145
+            $t7 := $IndexPtr($LoadU256($t6), 0)
+            // write_ref($t7, $t5)
+            /// @src 2:1140:1161
+            $StoreU128($t7, $t5)
+            // return ()
+            /// @src 2:1161:1162
+        }
+
+        function A2_M_pack_S(a, b) -> $result {
+            let $t2, $t3, $t4
+            // $t2 := (u128)($t0)
+            /// @src 2:581:592
+            $t2 := $CastU128(a)
+            // $t3 := M::pack_S2($t2)
+            /// @src 2:573:593
+            $t3 := A2_M_pack_S2($t2)
+            // $t4 := pack M::S($t0, $t1, $t3)
+            /// @src 2:562:594
+            {
+                let $mem := $Malloc(41)
+                $MemoryStoreU64(add($mem, 32), a)
+                $MemoryStoreU8(add($mem, 40), b)
+                $MemoryStoreU256(add($mem, 0), $t3)
+                $t4 := $MakePtr(false, $mem)
+            }
+            // return $t4
+            /// @src 2:562:594
+            $result := $t4
+        }
+
+        function A2_M_pack_S2(x) -> $result {
+            let $t1
+            // $t1 := pack M::S2($t0)
+            /// @src 2:229:234
+            {
+                let $mem := $Malloc(16)
+                $MemoryStoreU128(add($mem, 0), x)
+                $t1 := $MakePtr(false, $mem)
+            }
+            // return $t1
+            /// @src 2:229:234
+            $result := $t1
+        }
+
+        function $Abort(code) {
+            mstore(0, code)
+            revert(24, 8) // TODO: store code as a string?
+        }
+        function $AbortBuiltin() {
+            $Abort(sub(0, 1))
+        }
+        function $Malloc(size) -> offs {
+            offs := mload(0)
+            // pad to word size
+            mstore(0, add(offs, shl(5, shr(5, add(size, 31)))))
+        }
+        function $Free(offs, size) {
+        }
+        function $MakePtr(is_storage, offs) -> ptr {
+          ptr := or(is_storage, shl(1, offs))
+        }
+        function $IsStoragePtr(ptr) -> b {
+          b := and(ptr, 0x1)
+        }
+        function $OffsetPtr(ptr) -> offs {
+          offs := shr(1, ptr)
+        }
+        function $MaskForSize(size) -> mask {
+          mask := sub(shl(shl(size, 3), 1), 1)
+        }
+        function $ExtractBytes(word, start, size) -> bytes {
+           switch size
+           case 1 {
+              // use the faster byte primitive
+              bytes := byte(start, word)
+           }
+           default {
+              // As we have big endian, we need to right shift the value from
+              // where the highest byte starts in the word (32 - start), minus
+              // the size.
+              let shift_bits := shl(3, sub(sub(32, start), size))
+              bytes := and(shr(shift_bits, word), $MaskForSize(size))
+           }
+        }
+        function $InjectBytes(word, start, size, bytes) -> new_word {
+           let shift_bits := shl(3, sub(sub(32, start), size))
+           // Blend out the bits which we inject
+           let neg_mask := not(shl(shift_bits, $MaskForSize(size)))
+           word := and(word, neg_mask)
+           // Overlay the bits we inject
+           new_word := or(word, shl(shift_bits, bytes))
+        }
+        function $ToWordOffs(offs) -> word_offs, byte_offset {
+          word_offs := shr(5, offs)
+          byte_offset := and(offs, 0x1F)
+        }
+        function $OverflowBytes(byte_offset, size) -> overflow_bytes {
+          let available_bytes := sub(32, byte_offset)
+          switch gt(size, available_bytes)
+          case 0 {
+            overflow_bytes := 0
+          }
+          default {
+            overflow_bytes := sub(size, available_bytes)
+          }
+        }
+        function $MemoryLoadBytes(offs, size) -> val {
+          // Lower bit where the value in the higher bytes ends
+          let bit_end := shl(3, sub(32, size))
+          val := shr(bit_end, mload(offs))
+        }
+        function $MemoryStoreBytes(offs, size, val) {
+          let bit_end := shl(3, sub(32, size))
+          let mask := shl(bit_end, $MaskForSize(size))
+          mstore(offs, or(and(mload(offs), not(mask)), shl(bit_end, val)))
+        }
+        function $StorageLoadBytes(offs, size) -> val {
+          let word_offs, byte_offs := $ToWordOffs(offs)
+          let key := $StorageKey(0, word_offs)
+          val := $ExtractBytes(sload(key), byte_offs, size)
+          let overflow_bytes := $OverflowBytes(byte_offs, size)
+          if not(iszero(overflow_bytes)) {
+            key := $StorageKey(0, add(word_offs, 1))
+            let extra_bytes := $ExtractBytes(sload(key), 0, overflow_bytes)
+            val := or(shl(shl(3, overflow_bytes), val), extra_bytes)
+          }
+        }
+        function $StorageStoreBytes(offs, size, bytes) {
+          let word_offs, byte_offs := $ToWordOffs(offs)
+          let key := $StorageKey(0, word_offs)
+          let overflow_bytes := $OverflowBytes(byte_offs, size)
+          switch overflow_bytes
+          case 0 {
+            sstore(key, $InjectBytes(sload(key), byte_offs, size, bytes))
+          }
+          default {
+            // Shift the higher bytes to the right
+            let used_bytes := sub(size, overflow_bytes)
+            let higher_bytes := shr(used_bytes, bytes)
+            let lower_bytes := and(bytes, $MaskForSize(overflow_bytes))
+            sstore(key, $InjectBytes(sload(key), byte_offs, used_bytes, higher_bytes))
+            key := $StorageKey(0, add(word_offs, 1))
+            sstore(key, $InjectBytes(sload(key), 0, overflow_bytes, lower_bytes))
+          }
+        }
+        function $StorageKey(group, word) -> key {
+          mstore(32, word)
+          mstore(64, group)
+          key := keccak256(32, 36)
+        }
+        function $IndexPtr(ptr, offs) -> new_ptr {
+          new_ptr := $MakePtr($IsStoragePtr(ptr), add($OffsetPtr(ptr), offs))
+        }
+        function $MemoryStoreU8(offs, val) {
+          // Shortcut via special instruction
+          mstore8(offs, val)
+        }
+        function $LoadU64(ptr) -> val {
+          let offs := $OffsetPtr(ptr)
+          switch $IsStoragePtr(ptr)
+          case 0 {
+            val := $MemoryLoadU64(offs)
+          }
+          default {
+            val := $StorageLoadU64(offs)
+          }
+        }
+        function $MemoryLoadU64(offs) -> val {
+          val := $MemoryLoadBytes(offs, 8)
+        }
+        function $StorageLoadU64(offs) -> val {
+          val := $StorageLoadBytes(offs, 8)
+        }
+        function $StoreU64(ptr, val) {
+          let offs := $OffsetPtr(ptr)
+          switch $IsStoragePtr(ptr)
+          case 0 {
+            $MemoryStoreU64(offs, val)
+          }
+          default {
+            $StorageStoreU64(offs, val)
+          }
+        }
+        function $MemoryStoreU64(offs, val) {
+          $MemoryStoreBytes(offs, 8, val)
+        }
+        function $StorageStoreU64(offs, val) {
+          $StorageStoreBytes(offs, 8, val)
+        }
+        function $LoadU128(ptr) -> val {
+          let offs := $OffsetPtr(ptr)
+          switch $IsStoragePtr(ptr)
+          case 0 {
+            val := $MemoryLoadU128(offs)
+          }
+          default {
+            val := $StorageLoadU128(offs)
+          }
+        }
+        function $MemoryLoadU128(offs) -> val {
+          val := $MemoryLoadBytes(offs, 16)
+        }
+        function $StorageLoadU128(offs) -> val {
+          val := $StorageLoadBytes(offs, 16)
+        }
+        function $StoreU128(ptr, val) {
+          let offs := $OffsetPtr(ptr)
+          switch $IsStoragePtr(ptr)
+          case 0 {
+            $MemoryStoreU128(offs, val)
+          }
+          default {
+            $StorageStoreU128(offs, val)
+          }
+        }
+        function $MemoryStoreU128(offs, val) {
+          $MemoryStoreBytes(offs, 16, val)
+        }
+        function $StorageStoreU128(offs, val) {
+          $StorageStoreBytes(offs, 16, val)
+        }
+        function $LoadU256(ptr) -> val {
+          let offs := $OffsetPtr(ptr)
+          switch $IsStoragePtr(ptr)
+          case 0 {
+            val := $MemoryLoadU256(offs)
+          }
+          default {
+            val := $StorageLoadU256(offs)
+          }
+        }
+        function $MemoryLoadU256(offs) -> val {
+          val := $MemoryLoadBytes(offs, 32)
+        }
+        function $StorageLoadU256(offs) -> val {
+          val := $StorageLoadBytes(offs, 32)
+        }
+        function $MemoryStoreU256(offs, val) {
+          $MemoryStoreBytes(offs, 32, val)
+        }
+        function $Eq(x, y) -> r {
+            r := eq(x, y)
+        }
+        function $CastU128(x) -> r {
+            if gt(x, 0xffffffffffffffffffffffffffffffff) { $AbortBuiltin() }
+            r := x
+        }
+    }
+}
+===> Succeed(Stopped) (used_gas=1981): []

--- a/language/evm/move-to-yul/tests/Structs.move
+++ b/language/evm/move-to-yul/tests/Structs.move
@@ -1,4 +1,3 @@
-#[contract]
 module 0x2::M {
     struct S has drop {
       a: u64,
@@ -10,44 +9,86 @@ module 0x2::M {
         x: u128
     }
 
-    #[callable]
-	fun pack_S2(x: u128): S2 {
-	    S2{x}
-	}
+    // =============================================
 
-    #[callable]
+    fun pack_S2(x: u128): S2 {
+        S2{x}
+    }
+    #[evm_test]
+    fun test_pack_S2() {
+        let s = pack_S2(42);
+        assert!(s.x == 42, 100)
+    }
+    #[evm_test]
+    fun test_pack_S2_fail() {
+        let s = pack_S2(42);
+        assert!(s.x == 41, 100)
+    }
+
+    // =============================================
+
     fun pack_S(a: u64, b: bool): S {
         S{a, b, c: pack_S2((a as u128))}
     }
+    #[evm_test]
+    fun test_pack_S() {
+        let s = pack_S(42, true);
+        assert!(s.a == 42, 100);
+        assert!(s.b == true, 101);
+        assert!(s.c.x == 42, 102);
+    }
 
-    // #[callable]
+    // =============================================
+
     fun read_S(s: &S): u64 {
         s.a + (s.c.x as u64)
     }
+    #[evm_test]
+    fun test_read_S() {
+        let s = pack_S(42, true);
+        assert!(read_S(&s) == 84, 100);
+    }
 
-    // #[callable]
+    // =============================================
+
     fun write_S(s: &mut S, v: u64) {
         s.a = v;
         s.c.x = (s.a as u128);
     }
+    #[evm_test]
+    fun test_write_S() {
+        let s = pack_S(42, true);
+        write_S(&mut s, 43);
+        assert!(s.a == 43, 100);
+        assert!(s.c.x == 43, 101);
+    }
 
-    #[callable]
-    fun read_and_write_s(): S {
+    // =============================================
+
+    fun read_and_write_S(): S {
         let s = pack_S(1, false);
         let x = read_S(&s);
         write_S(&mut s, x);
         s
     }
+    #[evm_test]
+    fun test_read_and_write_S() {
+        let s = read_and_write_S();
+        assert!(s.a == 2, 100);
+        assert!(s.c.x == 2, 101);
+    }
 
-    #[callable]
+
+    // =============================================
+
     fun unpack(s: S): S2 {
         let S{a: _a, b: _b, c} = s;
         c
     }
-
-    #[callable]
-    fun destroy() {
-        let _s = pack_S(1, false);
+    #[evm_test]
+    fun test_unpack() {
+        let s = pack_S(33, false);
+        let s1 = unpack(s);
+        assert!(s1.x == 33, 101);
     }
-
 }

--- a/language/evm/move-to-yul/tests/U256Arith.exp
+++ b/language/evm/move-to-yul/tests/U256Arith.exp
@@ -15,7 +15,7 @@ object "A2_U256Arith" {
             mstore(0, memoryguard(160))
             if iszero(lt(calldatasize(), 4))
             {
-                let selector := $ShiftRight(224, calldataload(0))
+                let selector := $Shr(calldataload(0), 224)
                 switch selector
                 case 0x4f2be91f
                 {
@@ -466,10 +466,10 @@ object "A2_U256Arith" {
                 r := mod(x, y)
             }
             function $Shr(x, y) -> r {
-                r := shr(x, y)
+                r := shr(y, x)
             }
             function $ShlU256(x, y) -> r {
-                r := and(shl(x, y), 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff)
+                r := and(shl(y, x), 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff)
             }
             function $Gt(x, y) -> r {
                 r := gt(x, y)
@@ -492,10 +492,7 @@ object "A2_U256Arith" {
             function $CastU256(hi, lo) -> r {
                 if gt(hi, 0xffffffffffffffffffffffffffffffff) { $AbortBuiltin() }
                 if gt(lo, 0xffffffffffffffffffffffffffffffff) { $AbortBuiltin() }
-                r := add(shl(hi, 128), lo)
-            }
-            function $ShiftRight(bits, value) -> r {
-                r := shr(bits, value) // evm version >= constantinople
+                r := add(shl(128, hi), lo)
             }
         }
     }

--- a/language/evm/move-to-yul/tests/fallback-receive-test/FallbackOnly.exp
+++ b/language/evm/move-to-yul/tests/fallback-receive-test/FallbackOnly.exp
@@ -14,7 +14,7 @@ object "A2_M" {
             mstore(0, memoryguard(160))
             if iszero(lt(calldatasize(), 4))
             {
-                let selector := $ShiftRight(224, calldataload(0))
+                let selector := $Shr(calldataload(0), 224)
                 switch selector
                 default {}
             }
@@ -32,8 +32,8 @@ object "A2_M" {
                 mstore(0, code)
                 revert(24, 8) // TODO: store code as a string?
             }
-            function $ShiftRight(bits, value) -> r {
-                r := shr(bits, value) // evm version >= constantinople
+            function $Shr(x, y) -> r {
+                r := shr(y, x)
             }
         }
     }

--- a/language/evm/move-to-yul/tests/fallback-receive-test/FallbackPayableOnly.exp
+++ b/language/evm/move-to-yul/tests/fallback-receive-test/FallbackPayableOnly.exp
@@ -14,7 +14,7 @@ object "A2_M" {
             mstore(0, memoryguard(160))
             if iszero(lt(calldatasize(), 4))
             {
-                let selector := $ShiftRight(224, calldataload(0))
+                let selector := $Shr(calldataload(0), 224)
                 switch selector
                 default {}
             }
@@ -24,8 +24,8 @@ object "A2_M" {
                 /// @src 2:73:80
             }
 
-            function $ShiftRight(bits, value) -> r {
-                r := shr(bits, value) // evm version >= constantinople
+            function $Shr(x, y) -> r {
+                r := shr(y, x)
             }
         }
     }

--- a/language/evm/move-to-yul/tests/fallback-receive-test/ReceiveFallback.exp
+++ b/language/evm/move-to-yul/tests/fallback-receive-test/ReceiveFallback.exp
@@ -14,7 +14,7 @@ object "A2_M" {
             mstore(0, memoryguard(160))
             if iszero(lt(calldatasize(), 4))
             {
-                let selector := $ShiftRight(224, calldataload(0))
+                let selector := $Shr(calldataload(0), 224)
                 switch selector
                 default {}
             }
@@ -54,8 +54,8 @@ object "A2_M" {
                 if lt(sub(0xffffffffffffffff, x), y) { $AbortBuiltin() }
                 r := add(x, y)
             }
-            function $ShiftRight(bits, value) -> r {
-                r := shr(bits, value) // evm version >= constantinople
+            function $Shr(x, y) -> r {
+                r := shr(y, x)
             }
         }
     }

--- a/language/evm/move-to-yul/tests/fallback-receive-test/ReceiveOnly.exp
+++ b/language/evm/move-to-yul/tests/fallback-receive-test/ReceiveOnly.exp
@@ -14,7 +14,7 @@ object "A2_M" {
             mstore(0, memoryguard(160))
             if iszero(lt(calldatasize(), 4))
             {
-                let selector := $ShiftRight(224, calldataload(0))
+                let selector := $Shr(calldataload(0), 224)
                 switch selector
                 default {}
             }
@@ -29,8 +29,8 @@ object "A2_M" {
                 mstore(0, code)
                 revert(24, 8) // TODO: store code as a string?
             }
-            function $ShiftRight(bits, value) -> r {
-                r := shr(bits, value) // evm version >= constantinople
+            function $Shr(x, y) -> r {
+                r := shr(y, x)
             }
         }
     }

--- a/language/evm/move-to-yul/tests/fallback-receive-test/expect-failure/FallbackMultipleParams.exp
+++ b/language/evm/move-to-yul/tests/fallback-receive-test/expect-failure/FallbackMultipleParams.exp
@@ -14,7 +14,7 @@ object "A2_M" {
             mstore(0, memoryguard(160))
             if iszero(lt(calldatasize(), 4))
             {
-                let selector := $ShiftRight(224, calldataload(0))
+                let selector := $Shr(calldataload(0), 224)
                 switch selector
                 default {}
             }
@@ -43,8 +43,8 @@ object "A2_M" {
                 if lt(sub(0xffffffffffffffff, x), y) { $AbortBuiltin() }
                 r := add(x, y)
             }
-            function $ShiftRight(bits, value) -> r {
-                r := shr(bits, value) // evm version >= constantinople
+            function $Shr(x, y) -> r {
+                r := shr(y, x)
             }
         }
     }

--- a/language/evm/move-to-yul/tests/fallback-receive-test/expect-failure/FallbackReciveFailure.exp
+++ b/language/evm/move-to-yul/tests/fallback-receive-test/expect-failure/FallbackReciveFailure.exp
@@ -14,7 +14,7 @@ object "A2_M" {
             mstore(0, memoryguard(160))
             if iszero(lt(calldatasize(), 4))
             {
-                let selector := $ShiftRight(224, calldataload(0))
+                let selector := $Shr(calldataload(0), 224)
                 switch selector
                 case 0x847c345a
                 {
@@ -91,8 +91,8 @@ object "A2_M" {
                 mstore(0, code)
                 revert(24, 8) // TODO: store code as a string?
             }
-            function $ShiftRight(bits, value) -> r {
-                r := shr(bits, value) // evm version >= constantinople
+            function $Shr(x, y) -> r {
+                r := shr(y, x)
             }
         }
     }

--- a/language/evm/move-to-yul/tests/test-dispatcher/DispatcherBasic.exp
+++ b/language/evm/move-to-yul/tests/test-dispatcher/DispatcherBasic.exp
@@ -14,7 +14,7 @@ object "A2_M" {
             mstore(0, memoryguard(160))
             if iszero(lt(calldatasize(), 4))
             {
-                let selector := $ShiftRight(224, calldataload(0))
+                let selector := $Shr(calldataload(0), 224)
                 switch selector
                 case 0xe44f11ec
                 {
@@ -99,8 +99,8 @@ object "A2_M" {
                 mstore(0, code)
                 revert(24, 8) // TODO: store code as a string?
             }
-            function $ShiftRight(bits, value) -> r {
-                r := shr(bits, value) // evm version >= constantinople
+            function $Shr(x, y) -> r {
+                r := shr(y, x)
             }
         }
     }

--- a/language/evm/move-to-yul/tests/test-dispatcher/DispatcherFallback.exp
+++ b/language/evm/move-to-yul/tests/test-dispatcher/DispatcherFallback.exp
@@ -14,7 +14,7 @@ object "A2_M" {
             mstore(0, memoryguard(160))
             if iszero(lt(calldatasize(), 4))
             {
-                let selector := $ShiftRight(224, calldataload(0))
+                let selector := $Shr(calldataload(0), 224)
                 switch selector
                 case 0xe44f11ec
                 {
@@ -64,8 +64,8 @@ object "A2_M" {
                 mstore(0, code)
                 revert(24, 8) // TODO: store code as a string?
             }
-            function $ShiftRight(bits, value) -> r {
-                r := shr(bits, value) // evm version >= constantinople
+            function $Shr(x, y) -> r {
+                r := shr(y, x)
             }
         }
     }

--- a/language/evm/move-to-yul/tests/test-dispatcher/DispatcherRevert.exp
+++ b/language/evm/move-to-yul/tests/test-dispatcher/DispatcherRevert.exp
@@ -14,7 +14,7 @@ object "A2_M" {
             mstore(0, memoryguard(160))
             if iszero(lt(calldatasize(), 4))
             {
-                let selector := $ShiftRight(224, calldataload(0))
+                let selector := $Shr(calldataload(0), 224)
                 switch selector
                 case 0xe44f11ec
                 {
@@ -55,8 +55,8 @@ object "A2_M" {
                 mstore(0, code)
                 revert(24, 8) // TODO: store code as a string?
             }
-            function $ShiftRight(bits, value) -> r {
-                r := shr(bits, value) // evm version >= constantinople
+            function $Shr(x, y) -> r {
+                r := shr(y, x)
             }
         }
     }


### PR DESCRIPTION
This turns the code examples in `tests/Structs.move` and `tests/Locals.move` into tests, and fixes bugs on the way in the handling of references and structs. At this point, we have basic things like packing and unpacking structs, and working with references to locals and to fields working.

There where two major bugs in the memory primitives: (a) calling `shl` and `shr` with wrong parameter order (b) wrongly assuming low endian architecture for packing bytes in words. Unfortunately, the big endian architecture makes things a bit more tricky. So most of the primitives around LoadUNN and StoreUNN are rewritten. Notice this does not yet test storage, only memory.



## Motivation

EVM

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

New tests

