### PR TITLE
Add option to print stacktrace upon abort during Move tests

### DIFF
--- a/language/move-binary-format/src/errors.rs
+++ b/language/move-binary-format/src/errors.rs
@@ -27,6 +27,7 @@ pub struct VMError {
     major_status: StatusCode,
     sub_status: Option<u64>,
     message: Option<String>,
+    stacktrace: Option<String>,
     location: Location,
     indices: Vec<(IndexKind, TableIndex)>,
     offsets: Vec<(FunctionDefinitionIndex, CodeOffset)>,
@@ -114,6 +115,14 @@ impl VMError {
         self.message.as_ref()
     }
 
+    pub fn stacktrace(&self) -> Option<&String> {
+        self.stacktrace.as_ref()
+    }
+
+    pub fn remove_stacktrace(&mut self) {
+        self.stacktrace = None;
+    }
+
     pub fn location(&self) -> &Location {
         &self.location
     }
@@ -136,6 +145,7 @@ impl VMError {
         StatusCode,
         Option<u64>,
         Option<String>,
+        Option<String>,
         Location,
         Vec<(IndexKind, TableIndex)>,
         Vec<(FunctionDefinitionIndex, CodeOffset)>,
@@ -144,6 +154,7 @@ impl VMError {
             major_status,
             sub_status,
             message,
+            stacktrace,
             location,
             indices,
             offsets,
@@ -152,6 +163,7 @@ impl VMError {
             major_status,
             sub_status,
             message,
+            stacktrace,
             location,
             indices,
             offsets,
@@ -164,6 +176,7 @@ pub struct PartialVMError {
     major_status: StatusCode,
     sub_status: Option<u64>,
     message: Option<String>,
+    stacktrace: Option<String>,
     indices: Vec<(IndexKind, TableIndex)>,
     offsets: Vec<(FunctionDefinitionIndex, CodeOffset)>,
 }
@@ -175,6 +188,7 @@ impl PartialVMError {
         StatusCode,
         Option<u64>,
         Option<String>,
+        Option<String>,
         Vec<(IndexKind, TableIndex)>,
         Vec<(FunctionDefinitionIndex, CodeOffset)>,
     ) {
@@ -182,10 +196,18 @@ impl PartialVMError {
             major_status,
             sub_status,
             message,
+            stacktrace,
             indices,
             offsets,
         } = self;
-        (major_status, sub_status, message, indices, offsets)
+        (
+            major_status,
+            sub_status,
+            message,
+            stacktrace,
+            indices,
+            offsets,
+        )
     }
 
     pub fn finish(self, location: Location) -> VMError {
@@ -193,6 +215,7 @@ impl PartialVMError {
             major_status,
             sub_status,
             message,
+            stacktrace,
             indices,
             offsets,
         } = self;
@@ -200,6 +223,7 @@ impl PartialVMError {
             major_status,
             sub_status,
             message,
+            stacktrace,
             location,
             indices,
             offsets,
@@ -211,6 +235,7 @@ impl PartialVMError {
             major_status,
             sub_status: None,
             message: None,
+            stacktrace: None,
             indices: vec![],
             offsets: vec![],
         }
@@ -232,6 +257,14 @@ impl PartialVMError {
         debug_assert!(self.message.is_none());
         Self {
             message: Some(message),
+            ..self
+        }
+    }
+
+    pub fn with_stacktrace(self, stacktrace: String) -> Self {
+        debug_assert!(self.stacktrace.is_none());
+        Self {
+            stacktrace: Some(stacktrace),
             ..self
         }
     }

--- a/language/move-prover/interpreter-testsuite/tests/concrete_check_testsuite.rs
+++ b/language/move-prover/interpreter-testsuite/tests/concrete_check_testsuite.rs
@@ -20,6 +20,7 @@ fn test_runner(path: &Path) -> datatest_stable::Result<()> {
         dep_files: move_stdlib_files(),
         check_stackless_vm: true,
         report_storage_on_error: false,
+        report_stacktrace_on_abort: false,
         report_statistics: false,
         list: false,
         verbose: read_bool_env_var("VERBOSE"),

--- a/language/move-prover/interpreter/src/shared/bridge.rs
+++ b/language/move-prover/interpreter/src/shared/bridge.rs
@@ -8,7 +8,7 @@ use move_core_types::{effects::ChangeSet, language_storage::ModuleId, resolver::
 /// do cross-vm comparison, we need to adapt the Move VM result by removing these fields.
 pub fn adapt_move_vm_result<T>(result: VMResult<T>) -> VMResult<T> {
     result.map_err(|err| {
-        let (status_code, sub_status, _, location, _, _) = err.all_data();
+        let (status_code, sub_status, _, _, location, _, _) = err.all_data();
         let adapted = PartialVMError::new(status_code);
         let adapted = match sub_status {
             None => adapted,

--- a/language/move-stdlib/src/natives/vector.rs
+++ b/language/move-stdlib/src/natives/vector.rs
@@ -124,7 +124,8 @@ pub fn native_swap(
 }
 
 fn native_error_to_abort(err: PartialVMError) -> PartialVMError {
-    let (major_status, sub_status_opt, message_opt, indices, offsets) = err.all_data();
+    let (major_status, sub_status_opt, message_opt, stacktrace_opt, indices, offsets) =
+        err.all_data();
     let new_err = match major_status {
         StatusCode::VECTOR_OPERATION_ERROR => PartialVMError::new(StatusCode::ABORTED),
         _ => PartialVMError::new(major_status),
@@ -136,6 +137,10 @@ fn native_error_to_abort(err: PartialVMError) -> PartialVMError {
     let new_err = match message_opt {
         None => new_err,
         Some(message) => new_err.with_message(message),
+    };
+    let new_err = match stacktrace_opt {
+        None => new_err,
+        Some(stacktrace) => new_err.with_stacktrace(stacktrace),
     };
     new_err.at_indices(indices).at_code_offsets(offsets)
 }

--- a/language/move-vm/runtime/Cargo.toml
+++ b/language/move-vm/runtime/Cargo.toml
@@ -38,3 +38,4 @@ fuzzing = ["move-vm-types/fuzzing"]
 failpoints = ["fail/failpoints"]
 # Enable tracing and debugging also for release builds. By default, it is only enabled for debug builds.
 debugging = []
+testing = []

--- a/language/move-vm/runtime/src/logging.rs
+++ b/language/move-vm/runtime/src/logging.rs
@@ -16,8 +16,15 @@ pub fn expect_no_verification_errors(err: VMError) -> VMError {
                 stored on chain that is unverifiable!\nError: {:?}",
                 &err
             );
-            let (_old_status, _old_sub_status, _old_message, location, indices, offsets) =
-                err.all_data();
+            let (
+                _old_status,
+                _old_sub_status,
+                _old_message,
+                _stacktrace,
+                location,
+                indices,
+                offsets,
+            ) = err.all_data();
             let major_status = match status_type {
                 StatusType::Deserialization => StatusCode::UNEXPECTED_DESERIALIZATION_ERROR,
                 StatusType::Verification => StatusCode::UNEXPECTED_VERIFIER_ERROR,

--- a/language/move-vm/types/src/natives/function.rs
+++ b/language/move-vm/types/src/natives/function.rs
@@ -69,7 +69,7 @@ impl NativeResult {
         let result = match res {
             Ok(_) => NativeResult::ok(cost, smallvec![]),
             Err(err) if err.major_status() == StatusCode::ABORTED => {
-                let (_, abort_code, _, _, _) = err.all_data();
+                let (_, abort_code, _, _, _, _) = err.all_data();
                 NativeResult::err(
                     cost,
                     abort_code.unwrap_or(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR as u64),
@@ -90,7 +90,7 @@ impl NativeResult {
         let result = match res {
             Ok(val) => NativeResult::ok(cost, smallvec![val]),
             Err(err) if err.major_status() == StatusCode::ABORTED => {
-                let (_, abort_code, _, _, _) = err.all_data();
+                let (_, abort_code, _, _, _, _) = err.all_data();
                 NativeResult::err(
                     cost,
                     abort_code.unwrap_or(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR as u64),

--- a/language/tools/move-unit-test/Cargo.toml
+++ b/language/tools/move-unit-test/Cargo.toml
@@ -22,7 +22,7 @@ move-stdlib = { path = "../../move-stdlib", features = ["testing"] }
 move-core-types = { path = "../../move-core/types" }
 move-compiler = { path = "../../move-compiler" }
 move-vm-types = { path = "../../move-vm/types" }
-move-vm-runtime = { path = "../../move-vm/runtime" }
+move-vm-runtime = { path = "../../move-vm/runtime", features = ["testing"] }
 move-vm-test-utils = { path = "../../move-vm/test-utils" }
 move-resource-viewer = { path = "../move-resource-viewer" }
 move-binary-format = { path = "../../move-binary-format" }

--- a/language/tools/move-unit-test/src/lib.rs
+++ b/language/tools/move-unit-test/src/lib.rs
@@ -64,6 +64,13 @@ pub struct UnitTestingConfig {
     #[structopt(name = "global_state_on_error", short = "g", long = "state_on_error")]
     pub report_storage_on_error: bool,
 
+    #[structopt(
+        name = "report_stacktrace_on_abort",
+        short = "t",
+        long = "stacktrace_on_abort"
+    )]
+    pub report_stacktrace_on_abort: bool,
+
     /// Named address mapping
     #[structopt(
         name = "NAMED_ADDRESSES",
@@ -104,6 +111,7 @@ impl UnitTestingConfig {
             num_threads: 8,
             report_statistics: false,
             report_storage_on_error: false,
+            report_stacktrace_on_abort: false,
             source_files: vec![],
             dep_files: vec![],
             check_stackless_vm: false,
@@ -200,6 +208,7 @@ impl UnitTestingConfig {
             self.check_stackless_vm,
             self.verbose,
             self.report_storage_on_error,
+            self.report_stacktrace_on_abort,
             test_plan,
             native_function_table,
             verify_and_create_named_address_mapping(self.named_address_values.clone()).unwrap(),
@@ -214,6 +223,7 @@ impl UnitTestingConfig {
         if self.report_statistics {
             test_results.report_statistics(&shared_writer)?;
         }
+
         let all_tests_passed = test_results.summarize(&shared_writer)?;
 
         let writer = shared_writer.into_inner().unwrap();

--- a/language/tools/move-unit-test/src/test_reporter.rs
+++ b/language/tools/move-unit-test/src/test_reporter.rs
@@ -219,7 +219,7 @@ impl TestFailure {
             Some(vm_error) => vm_error,
         };
 
-        match vm_error.location() {
+        let diags = match vm_error.location() {
             Location::Module(module_id) => {
                 let diags = vm_error
                     .offsets()
@@ -246,6 +246,10 @@ impl TestFailure {
                 String::from_utf8(report_diagnostics(&test_plan.files, diags)).unwrap()
             }
             _ => base_message,
+        };
+        match vm_error.stacktrace() {
+            None => diags,
+            Some(stacktrace) => format!("{}\n{}", diags, stacktrace),
         }
     }
 }

--- a/language/tools/move-unit-test/tests/move_unit_test_testsuite.rs
+++ b/language/tools/move-unit-test/tests/move_unit_test_testsuite.rs
@@ -81,6 +81,7 @@ fn run_test_impl(path: &Path) -> anyhow::Result<()> {
         verbose: false,
         report_statistics: false,
         report_storage_on_error: false,
+        report_stacktrace_on_abort: false,
         list: false,
         named_address_values: move_stdlib::move_stdlib_named_addresses()
             .into_iter()

--- a/language/tools/move-unit-test/tests/test_sources/missing_data.exp
+++ b/language/tools/move-unit-test/tests/test_sources/missing_data.exp
@@ -19,6 +19,7 @@ Failures in 0x1::MissingData:
 │     major_status: MISSING_DATA,
 │     sub_status: None,
 │     message: None,
+│     stacktrace: None,
 │     location: Module(
 │         ModuleId {
 │             address: 00000000000000000000000000000001,


### PR DESCRIPTION
It can be very useful to see the stacktrace when a test aborted.
Added a stacktrace field to the vm error types, and propagate it if the testing feature is enabled.
Add an option to the test config to turn it on. If the option is not enabled, we remove the stacktrace so it's not printed.