### PR TITLE
[move-lang] Typed macros: parsing and type checking

### DIFF
--- a/language/move-compiler/src/attr_derivation/mod.rs
+++ b/language/move-compiler/src/attr_derivation/mod.rs
@@ -101,6 +101,7 @@ pub fn new_native_fun(
         signature,
         acquires: vec![],
         name,
+        is_macro: false,
         body: sp(loc, FunctionBody_::Native),
     }
 }
@@ -121,6 +122,7 @@ pub fn new_fun(
         signature,
         acquires: vec![],
         name,
+        is_macro: false,
         body: sp(
             loc,
             FunctionBody_::Defined((vec![], vec![], None, Box::new(Some(def)))),

--- a/language/move-compiler/src/diagnostics/codes.rs
+++ b/language/move-compiler/src/diagnostics/codes.rs
@@ -149,7 +149,6 @@ codes!(
         UnboundVariable: { msg: "unbound variable", severity: BlockingError },
         UnboundField: { msg: "unbound field", severity: BlockingError },
         ReservedName: { msg: "invalid use of reserved name", severity: BlockingError },
-        UnboundMacro: { msg: "unbound macro", severity: BlockingError },
     ],
     // errors for typing rules. mostly typing/translate
     TypeSafety: [
@@ -181,6 +180,8 @@ codes!(
                 (NOTE: this may become an error in the future)",
             severity: Warning
         },
+        InvalidCallTarget: { msg: "invalid call target", severity: BlockingError },
+        InvalidFunctionType: { msg: "invalid usage of function type", severity: BlockingError },
     ],
     // errors for ability rules. mostly typing/translate
     AbilitySafety: [
@@ -230,6 +231,7 @@ codes!(
     Bug: [
         BytecodeGeneration: { msg: "BYTECODE GENERATION FAILED", severity: Bug },
         BytecodeVerification: { msg: "BYTECODE VERIFICATION FAILED", severity: Bug },
+        Unimplemented: { msg: "Not yet implemented", severity: BlockingError },
     ],
     Derivation: [
         DeriveFailed: { msg: "attribute derivation failed", severity: BlockingError }

--- a/language/move-compiler/src/expansion/translate.rs
+++ b/language/move-compiler/src/expansion/translate.rs
@@ -1115,6 +1115,7 @@ fn function_(context: &mut Context, pfunction: P::Function) -> (FunctionName, E:
     let P::Function {
         attributes: pattributes,
         loc,
+        is_macro,
         name,
         visibility,
         signature: psignature,
@@ -1133,6 +1134,7 @@ fn function_(context: &mut Context, pfunction: P::Function) -> (FunctionName, E:
     let fdef = E::Function {
         attributes,
         loc,
+        is_macro,
         visibility,
         signature,
         acquires,
@@ -1490,17 +1492,9 @@ fn type_(context: &mut Context, sp!(loc, pt_): P::Type) -> E::Type {
         }
         PT::Ref(mut_, inner) => ET::Ref(mut_, Box::new(type_(context, *inner))),
         PT::Fun(args, result) => {
-            if context.in_spec_context {
-                let args = types(context, args);
-                let result = type_(context, *result);
-                ET::Fun(args, Box::new(result))
-            } else {
-                context.env.add_diag(diag!(
-                    Syntax::SpecContextRestricted,
-                    (loc, "`|_|_` function type only allowed in specifications")
-                ));
-                ET::UnresolvedError
-            }
+            let args = types(context, args);
+            let result = type_(context, *result);
+            ET::Fun(args, Box::new(result))
         }
     };
     sp(loc, t_)
@@ -1784,21 +1778,13 @@ fn exp_(context: &mut Context, sp!(loc, pe_): P::Exp) -> E::Exp {
         PE::Loop(ploop) => EE::Loop(exp(context, *ploop)),
         PE::Block(seq) => EE::Block(sequence(context, loc, seq)),
         PE::Lambda(pbs, pe) => {
-            if !context.in_spec_context {
-                context.env.add_diag(diag!(
-                    Syntax::SpecContextRestricted,
-                    (loc, "lambda expression only allowed in specifications"),
-                ));
-                EE::UnresolvedError
-            } else {
-                let bs_opt = bind_list(context, pbs);
-                let e = exp_(context, *pe);
-                match bs_opt {
-                    Some(bs) => EE::Lambda(bs, Box::new(e)),
-                    None => {
-                        assert!(context.env.has_diags());
-                        EE::UnresolvedError
-                    }
+            let bs_opt = bind_list(context, pbs);
+            let e = exp_(context, *pe);
+            match bs_opt {
+                Some(bs) => EE::Lambda(bs, Box::new(e)),
+                None => {
+                    assert!(context.env.has_diags());
+                    EE::UnresolvedError
                 }
             }
         }

--- a/language/move-compiler/src/hlir/ast.rs
+++ b/language/move-compiler/src/hlir/ast.rs
@@ -437,6 +437,7 @@ impl BaseType_ {
                 )
                 .unwrap()
             }
+            Fun => panic!("ICE unexpected function type"),
         };
         let n = sp(loc, TypeName_::Builtin(sp(loc, b_)));
         sp(loc, BaseType_::Apply(kind, n, ty_args))

--- a/language/move-compiler/src/naming/ast.rs
+++ b/language/move-compiler/src/naming/ast.rs
@@ -158,7 +158,7 @@ pub type TypeName = Spanned<TypeName_>;
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
 pub enum Variance {
-    CoVariant,
+    Covariant,
     ContraVariant,
 }
 
@@ -394,7 +394,7 @@ impl BuiltinTypeName_ {
             // Function variance: given g: T1 -> R1 and f: T2 -> R2, then
             // f can substitute g if T2 >= T1 && R1 <= R2
             BuiltinTypeName_::Fun if pos < arity - 1 => Variance::ContraVariant,
-            _ => Variance::CoVariant,
+            _ => Variance::Covariant,
         }
     }
 }
@@ -403,7 +403,7 @@ impl TypeName_ {
     pub fn variance(&self, pos: usize, arity: usize) -> Variance {
         match self {
             TypeName_::Builtin(bn) => bn.value.variance(pos, arity),
-            _ => Variance::CoVariant,
+            _ => Variance::Covariant,
         }
     }
 }

--- a/language/move-compiler/src/naming/ast.rs
+++ b/language/move-compiler/src/naming/ast.rs
@@ -102,6 +102,7 @@ pub type FunctionBody = Spanned<FunctionBody_>;
 #[derive(PartialEq, Debug, Clone)]
 pub struct Function {
     pub attributes: Attributes,
+    pub is_macro: bool,
     pub visibility: Visibility,
     pub signature: FunctionSignature,
     pub acquires: BTreeMap<StructName, Loc>,
@@ -140,6 +141,8 @@ pub enum BuiltinTypeName_ {
     Vector,
     // bool
     Bool,
+    // Function (last type arg is result type)
+    Fun,
 }
 pub type BuiltinTypeName = Spanned<BuiltinTypeName_>;
 
@@ -152,6 +155,12 @@ pub enum TypeName_ {
     ModuleType(ModuleIdent, StructName),
 }
 pub type TypeName = Spanned<TypeName_>;
+
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
+pub enum Variance {
+    CoVariant,
+    ContraVariant,
+}
 
 #[derive(Debug, Hash, Eq, PartialEq, Ord, PartialOrd, Copy, Clone)]
 pub struct TParamID(pub u64);
@@ -225,9 +234,11 @@ pub enum Exp_ {
     ModuleCall(
         ModuleIdent,
         FunctionName,
+        bool,
         Option<Vec<Type>>,
         Spanned<Vec<Exp>>,
     ),
+    VarCall(Var, Spanned<Vec<Exp>>),
     Builtin(BuiltinFunction, Spanned<Vec<Exp>>),
     Vector(Loc, Option<Type>, Spanned<Vec<Exp>>),
 
@@ -235,6 +246,7 @@ pub enum Exp_ {
     While(Box<Exp>, Box<Exp>),
     Loop(Box<Exp>),
     Block(Sequence),
+    Lambda(LValueList, Box<Exp>),
 
     Assign(LValueList, Box<Exp>),
     FieldMutate(ExpDotted, Box<Exp>),
@@ -320,6 +332,7 @@ impl BuiltinTypeName_ {
     pub const U_128: &'static str = "u128";
     pub const BOOL: &'static str = "bool";
     pub const VECTOR: &'static str = "vector";
+    pub const FUN: &'static str = "|..|..";
 
     pub fn all_names() -> &'static BTreeSet<Symbol> {
         &*BUILTIN_TYPE_ALL_NAMES
@@ -362,15 +375,35 @@ impl BuiltinTypeName_ {
             B::Address | B::U8 | B::U64 | B::U128 | B::Bool => AbilitySet::primitives(loc),
             B::Signer => AbilitySet::signer(loc),
             B::Vector => AbilitySet::collection(loc),
+            B::Fun => AbilitySet::functions(),
         }
     }
 
-    pub fn tparam_constraints(&self, _loc: Loc) -> Vec<AbilitySet> {
+    pub fn tparam_constraints(&self, _loc: Loc, arity: usize) -> Vec<AbilitySet> {
         use BuiltinTypeName_ as B;
         // Match here to make sure this function is fixed when collections are added
         match self {
             B::Address | B::Signer | B::U8 | B::U64 | B::U128 | B::Bool => vec![],
             B::Vector => vec![AbilitySet::empty()],
+            B::Fun => (0..arity).map(|_| AbilitySet::empty()).collect(),
+        }
+    }
+
+    pub fn variance(&self, pos: usize, arity: usize) -> Variance {
+        match self {
+            // Function variance: given g: T1 -> R1 and f: T2 -> R2, then
+            // f can substitute g if T2 >= T1 && R1 <= R2
+            BuiltinTypeName_::Fun if pos < arity - 1 => Variance::ContraVariant,
+            _ => Variance::CoVariant,
+        }
+    }
+}
+
+impl TypeName_ {
+    pub fn variance(&self, pos: usize, arity: usize) -> Variance {
+        match self {
+            TypeName_::Builtin(bn) => bn.value.variance(pos, arity),
+            _ => Variance::CoVariant,
         }
     }
 }
@@ -448,7 +481,7 @@ impl Type_ {
         let abilities = match &b.value {
             B::Address | B::U8 | B::U64 | B::U128 | B::Bool => Some(AbilitySet::primitives(b.loc)),
             B::Signer => Some(AbilitySet::signer(b.loc)),
-            B::Vector => None,
+            B::Vector | B::Fun => None,
         };
         let n = sp(b.loc, TypeName_::Builtin(b));
         Type_::Apply(abilities, n, ty_args)
@@ -539,6 +572,7 @@ impl fmt::Display for BuiltinTypeName_ {
                 BT::U128 => BT::U_128,
                 BT::Bool => BT::BOOL,
                 BT::Vector => BT::VECTOR,
+                BT::Fun => BT::FUN,
             }
         )
     }
@@ -668,6 +702,7 @@ impl AstDebug for (FunctionName, &Function) {
             name,
             Function {
                 attributes,
+                is_macro,
                 visibility,
                 signature,
                 acquires,
@@ -679,7 +714,11 @@ impl AstDebug for (FunctionName, &Function) {
         if let FunctionBody_::Native = &body.value {
             w.write("native ");
         }
-        w.write(&format!("fun {}", name));
+        if *is_macro {
+            w.write(&format!("macro {}", name));
+        } else {
+            w.write(&format!("fun {}", name));
+        }
         signature.ast_debug(w);
         if !acquires.is_empty() {
             w.write(" acquires ");
@@ -891,13 +930,22 @@ impl AstDebug for Exp_ {
             E::Use(v) => w.write(&format!("{}", v)),
             E::Constant(None, c) => w.write(&format!("{}", c)),
             E::Constant(Some(m), c) => w.write(&format!("{}::{}", m, c)),
-            E::ModuleCall(m, f, tys_opt, sp!(_, rhs)) => {
+            E::ModuleCall(m, f, is_macro, tys_opt, sp!(_, rhs)) => {
                 w.write(&format!("{}::{}", m, f));
+                if *is_macro {
+                    w.write("!");
+                }
                 if let Some(ss) = tys_opt {
                     w.write("<");
                     ss.ast_debug(w);
                     w.write(">");
                 }
+                w.write("(");
+                w.comma(rhs, |w, e| e.ast_debug(w));
+                w.write(")");
+            }
+            E::VarCall(var, sp!(_, rhs)) => {
+                w.write(&format!("{}", var));
                 w.write("(");
                 w.comma(rhs, |w, e| e.ast_debug(w));
                 w.write(")");
@@ -953,6 +1001,12 @@ impl AstDebug for Exp_ {
                 e.ast_debug(w);
             }
             E::Block(seq) => w.block(|w| seq.ast_debug(w)),
+            E::Lambda(sp!(_, bs), e) => {
+                w.write("|");
+                bs.ast_debug(w);
+                w.write("|");
+                e.ast_debug(w);
+            }
             E::ExpList(es) => {
                 w.write("(");
                 w.comma(es, |w, e| e.ast_debug(w));

--- a/language/move-compiler/src/naming/translate.rs
+++ b/language/move-compiler/src/naming/translate.rs
@@ -477,12 +477,14 @@ fn friend(context: &mut Context, mident: ModuleIdent, friend: E::Friend) -> Opti
 
 fn function(context: &mut Context, _name: FunctionName, f: E::Function) -> N::Function {
     let attributes = f.attributes;
+    let is_macro = f.is_macro;
     let visibility = f.visibility;
     let signature = function_signature(context, f.signature);
     let acquires = function_acquires(context, f.acquires);
     let body = function_body(context, f.body);
     N::Function {
         attributes,
+        is_macro,
         visibility,
         signature,
         acquires,
@@ -742,7 +744,7 @@ fn type_(context: &mut Context, sp!(loc, ety_): E::Type) -> N::Type {
             Some(RT::BuiltinType) => {
                 let bn_ = N::BuiltinTypeName_::resolve(&n.value).unwrap();
                 let name_f = || format!("{}", &bn_);
-                let arity = bn_.tparam_constraints(loc).len();
+                let arity = bn_.tparam_constraints(loc, tys.len()).len();
                 let tys = types(context, tys);
                 let tys = check_type_argument_arity(context, loc, name_f, tys, arity);
                 NT::builtin_(sp(loc, bn_), tys)
@@ -759,6 +761,11 @@ fn type_(context: &mut Context, sp!(loc, ety_): E::Type) -> N::Type {
                 }
             }
         },
+        ET::Fun(args, result) => {
+            let mut args = types(context, args);
+            args.push(type_(context, *result));
+            NT::builtin_(sp(loc, N::BuiltinTypeName_::Fun), args)
+        }
         ET::Apply(sp!(nloc, EN::ModuleAccess(m, n)), tys) => {
             match context.resolve_module_type(nloc, &m, &n) {
                 None => {
@@ -774,7 +781,6 @@ fn type_(context: &mut Context, sp!(loc, ety_): E::Type) -> N::Type {
                 }
             }
         }
-        ET::Fun(_, _) => panic!("ICE only allowed in spec context"),
     };
     sp(loc, ty_)
 }
@@ -889,7 +895,16 @@ fn exp_(context: &mut Context, e: E::Exp) -> N::Exp {
         EE::While(eb, el) => NE::While(exp(context, *eb), exp(context, *el)),
         EE::Loop(el) => NE::Loop(exp(context, *el)),
         EE::Block(seq) => NE::Block(sequence(context, seq)),
-
+        EE::Lambda(args, body) => {
+            let bind_opt = bind_list(context, args);
+            match bind_opt {
+                None => {
+                    assert!(context.env.has_diags());
+                    N::Exp_::UnresolvedError
+                }
+                Some(bind) => NE::Lambda(bind, Box::new(exp_(context, *body))),
+            }
+        }
         EE::Assign(a, e) => {
             let na_opt = assign_list(context, a);
             let ne = exp(context, *e);
@@ -971,25 +986,20 @@ fn exp_(context: &mut Context, e: E::Exp) -> N::Exp {
         EE::Cast(e, t) => NE::Cast(exp(context, *e), type_(context, t)),
         EE::Annotate(e, t) => NE::Annotate(exp(context, *e), type_(context, t)),
 
-        EE::Call(sp!(mloc, ma_), true, tys_opt, rhs) => {
-            use E::ModuleAccess_ as EA;
+        EE::Call(sp!(mloc, E::ModuleAccess_::Name(n)), true, tys_opt, rhs)
+            if n.value.as_str() == N::BuiltinFunction_::ASSERT_MACRO =>
+        {
             use N::BuiltinFunction_ as BF;
-            assert!(tys_opt.is_none(), "ICE macros do not have type arguments");
-            let nes = call_args(context, rhs);
-            match ma_ {
-                EA::Name(n) if n.value.as_str() == BF::ASSERT_MACRO => {
-                    NE::Builtin(sp(mloc, BF::Assert(true)), nes)
-                }
-                ma_ => {
-                    context.env.add_diag(diag!(
-                        NameResolution::UnboundMacro,
-                        (mloc, format!("Unbound macro '{}'", ma_)),
-                    ));
-                    NE::UnresolvedError
-                }
+            if tys_opt.is_some() {
+                context.env.add_diag(diag!(
+                    TypeSafety::TooManyArguments,
+                    (eloc, "expected zero type arguments")
+                ));
             }
+            let nes = call_args(context, rhs);
+            NE::Builtin(sp(mloc, BF::Assert(true)), nes)
         }
-        EE::Call(sp!(mloc, ma_), false, tys_opt, rhs) => {
+        EE::Call(sp!(mloc, ma_), is_macro, tys_opt, rhs) => {
             use E::ModuleAccess_ as EA;
             let ty_args = tys_opt.map(|tys| types(context, tys));
             let nes = call_args(context, rhs);
@@ -1004,19 +1014,13 @@ fn exp_(context: &mut Context, e: E::Exp) -> N::Exp {
                     }
                 }
 
-                EA::Name(n) => {
-                    context.env.add_diag(diag!(
-                        NameResolution::UnboundUnscopedName,
-                        (n.loc, format!("Unbound function '{}' in current scope", n)),
-                    ));
-                    NE::UnresolvedError
-                }
+                EA::Name(n) => NE::VarCall(Var(n), nes),
                 EA::ModuleAccess(m, n) => match context.resolve_module_function(mloc, &m, &n) {
                     None => {
                         assert!(context.env.has_diags());
                         NE::UnresolvedError
                     }
-                    Some(_) => NE::ModuleCall(m, FunctionName(n), ty_args, nes),
+                    Some(_) => NE::ModuleCall(m, FunctionName(n), is_macro, ty_args, nes),
                 },
             }
         }
@@ -1047,8 +1051,8 @@ fn exp_(context: &mut Context, e: E::Exp) -> N::Exp {
             assert!(context.env.has_diags());
             NE::UnresolvedError
         }
-        // `Name` matches name variants only allowed in specs (we handle the allowed ones above)
-        EE::Index(..) | EE::Lambda(..) | EE::Quant(..) | EE::Name(_, Some(_)) => {
+        // Matches variants only allowed in specs (we handle the allowed ones above)
+        EE::Index(..) | EE::Quant(..) | EE::Name(_, Some(_)) => {
             panic!("ICE unexpected specification construct")
         }
     };

--- a/language/move-compiler/src/parser/ast.rs
+++ b/language/move-compiler/src/parser/ast.rs
@@ -256,6 +256,7 @@ pub struct Function {
     pub signature: FunctionSignature,
     pub acquires: Vec<NameAccessChain>,
     pub name: FunctionName,
+    pub is_macro: bool,
     pub body: FunctionBody,
 }
 
@@ -1435,6 +1436,7 @@ impl AstDebug for Function {
             visibility,
             signature,
             acquires,
+            is_macro,
             name,
             body,
         } = self;
@@ -1443,7 +1445,11 @@ impl AstDebug for Function {
         if let FunctionBody_::Native = &body.value {
             w.write("native ");
         }
-        w.write(&format!("fun {}", name));
+        if *is_macro {
+            w.write(&format!("macro {}", name));
+        } else {
+            w.write(&format!("fun {}", name));
+        }
         signature.ast_debug(w);
         if !acquires.is_empty() {
             w.write(" acquires ");
@@ -1731,9 +1737,9 @@ impl AstDebug for Exp_ {
             }
             E::Block(seq) => w.block(|w| seq.ast_debug(w)),
             E::Lambda(sp!(_, bs), e) => {
-                w.write("fun ");
+                w.write("|");
                 bs.ast_debug(w);
-                w.write(" ");
+                w.write("|");
                 e.ast_debug(w);
             }
             E::Quant(kind, sp!(_, rs), trs, c_opt, e) => {

--- a/language/move-compiler/src/parser/lexer.rs
+++ b/language/move-compiler/src/parser/lexer.rs
@@ -79,6 +79,7 @@ pub enum Tok {
     Friend,
     NumSign,
     AtSign,
+    Macro,
 }
 
 impl fmt::Display for Tok {
@@ -133,6 +134,7 @@ impl fmt::Display for Tok {
             Invariant => "invariant",
             Let => "let",
             Loop => "loop",
+            Macro => "macro",
             Module => "module",
             Move => "move",
             Native => "native",
@@ -622,6 +624,7 @@ fn get_name_token(name: &str) -> Tok {
         "invariant" => Tok::Invariant,
         "let" => Tok::Let,
         "loop" => Tok::Loop,
+        "macro" => Tok::Macro,
         "module" => Tok::Module,
         "move" => Tok::Move,
         "native" => Tok::Native,

--- a/language/move-compiler/src/parser/syntax.rs
+++ b/language/move-compiler/src/parser/syntax.rs
@@ -1777,7 +1777,7 @@ fn parse_struct_type_parameters(
 
 // Parse a function declaration:
 //      FunctionDecl =
-//          ( "macro" | "fun" )
+//          [ "macro" ] "fun"
 //          <FunctionDefName> "(" Comma<Parameter> ")"
 //          (":" <Type>)?
 //          ("acquires" <NameAccessChain> ("," <NameAccessChain>)*)?
@@ -1791,14 +1791,14 @@ fn parse_function_decl(
 ) -> Result<Function, Diagnostic> {
     let Modifiers { visibility, native } = modifiers;
 
-    // "macro" | "fun" <FunctionDefName>
+    // [ "macro" ] "fun" <FunctionDefName>
     let is_macro = if context.tokens.peek() == Tok::Macro {
         context.tokens.advance()?;
         true
     } else {
-        consume_token(context.tokens, Tok::Fun)?;
         false
     };
+    consume_token(context.tokens, Tok::Fun)?;
     let name = FunctionName(parse_identifier(context)?);
     let type_parameters = parse_optional_type_parameters(context)?;
 

--- a/language/move-compiler/src/shared/mod.rs
+++ b/language/move-compiler/src/shared/mod.rs
@@ -371,6 +371,10 @@ impl CompilationEnv {
         !self.diags.is_empty()
     }
 
+    pub fn has_blocking_diags(&self) -> bool {
+        self.diags.max_severity().unwrap_or(Severity::MIN) >= Severity::BlockingError
+    }
+
     pub fn count_diags(&self) -> usize {
         self.diags.len()
     }

--- a/language/move-compiler/src/to_bytecode/translate.rs
+++ b/language/move-compiler/src/to_bytecode/translate.rs
@@ -776,6 +776,9 @@ fn base_type(context: &mut Context, sp!(_, bt_): H::BaseType) -> IR::Type {
         B::Unreachable | B::UnresolvedError => {
             panic!("ICE should not have reached compilation if there are errors")
         }
+        B::Apply(_, sp!(_, TN::Builtin(sp!(_, BT::Fun))), _) => {
+            panic!("ICE should not have reached compilation if there are function types")
+        }
         B::Apply(_, sp!(_, TN::Builtin(sp!(_, BT::Address))), _) => IRT::Address,
         B::Apply(_, sp!(_, TN::Builtin(sp!(_, BT::Signer))), _) => IRT::Signer,
         B::Apply(_, sp!(_, TN::Builtin(sp!(_, BT::U8))), _) => IRT::U8,

--- a/language/move-compiler/src/typing/core.rs
+++ b/language/move-compiler/src/typing/core.rs
@@ -7,7 +7,7 @@ use crate::{
     expansion::ast::{AbilitySet, ModuleIdent},
     naming::ast::{
         self as N, BuiltinTypeName_, FunctionSignature, StructDefinition, StructTypeParameter,
-        TParam, TParamID, TVar, Type, TypeName, TypeName_, Type_,
+        TParam, TParamID, TVar, Type, TypeName, TypeName_, Type_, Variance,
     },
     parser::ast::{Ability_, ConstantName, Field, FunctionName, StructName, Var, Visibility},
     shared::{unique_map::UniqueMap, *},
@@ -41,6 +41,7 @@ pub struct FunctionInfo {
     pub visibility: Visibility,
     pub signature: FunctionSignature,
     pub acquires: BTreeMap<StructName, Loc>,
+    pub is_macro: bool,
 }
 
 pub struct ConstantInfo {
@@ -104,6 +105,7 @@ impl<'env> Context<'env> {
                 visibility: fdef.visibility.clone(),
                 signature: fdef.signature.clone(),
                 acquires: fdef.acquires.clone(),
+                is_macro: fdef.is_macro,
             });
             let constants = mdef.constants.ref_map(|cname, cdef| ConstantInfo {
                 defined_loc: cname.loc(),
@@ -494,6 +496,15 @@ fn error_format_impl_(b_: &Type_, subst: &Subst, nested: bool) -> String {
             let inner = format_comma(tys.iter().map(|s| error_format_nested(s, subst)));
             format!("({})", inner)
         }
+        Apply(_, sp!(_, TypeName_::Builtin(sp!(_, BuiltinTypeName_::Fun))), tys) => {
+            assert!(!tys.is_empty(), "ICE invalid function type");
+            let k = tys.len() - 1;
+            format!(
+                "|{}|{}",
+                format_comma((&tys[0..k]).iter().map(|t| error_format_nested(t, subst))),
+                error_format_nested(&tys[k], subst)
+            )
+        }
         Apply(_, n, tys) => {
             let tys_str = if !tys.is_empty() {
                 format!(
@@ -777,6 +788,7 @@ pub fn make_function_type(
     Vec<(Var, Type)>,
     BTreeMap<StructName, Loc>,
     Type,
+    bool,
 ) {
     let in_current_module = match &context.current_module {
         Some(current) => m == current,
@@ -808,6 +820,7 @@ pub fn make_function_type(
     };
 
     let finfo = context.function_info(m, f);
+    let is_macro = finfo.is_macro;
     let tparam_subst = &make_tparam_subst(&finfo.signature.type_parameters, ty_args.clone());
     let params = finfo
         .signature
@@ -865,7 +878,7 @@ pub fn make_function_type(
         }
         Visibility::Public(_) => (),
     };
-    (defined_loc, ty_args, params, acquires, return_ty)
+    (defined_loc, ty_args, params, acquires, return_ty, is_macro)
 }
 
 //**************************************************************************************************
@@ -1228,7 +1241,7 @@ fn instantiate_apply(
     ty_args: Vec<Type>,
 ) -> Type_ {
     let tparam_constraints: Vec<AbilitySet> = match &n {
-        sp!(nloc, N::TypeName_::Builtin(b)) => b.value.tparam_constraints(*nloc),
+        sp!(nloc, N::TypeName_::Builtin(b)) => b.value.tparam_constraints(*nloc, ty_args.len()),
         sp!(_, N::TypeName_::Multiple(len)) => {
             debug_assert!(abilities_opt.is_none(), "ICE instantiated expanded type");
             (0..*len).map(|_| AbilitySet::empty()).collect()
@@ -1265,6 +1278,9 @@ fn instantiate_type_args(
     let tvar_case = match n {
         Some(TypeName_::Multiple(_)) => {
             TVarCase::Single("Invalid expression list type argument".to_owned())
+        }
+        Some(TypeName_::Builtin(sp!(_, BuiltinTypeName_::Fun))) => {
+            TVarCase::SingleButLast("Invalid expression list type argument".to_owned())
         }
         None | Some(TypeName_::Builtin(_)) | Some(TypeName_::ModuleType(_, _)) => TVarCase::Base,
     };
@@ -1326,6 +1342,7 @@ fn check_type_argument_arity<F: FnOnce() -> String>(
 
 enum TVarCase {
     Single(String),
+    SingleButLast(String),
     Base,
 }
 
@@ -1335,13 +1352,20 @@ fn make_tparams(
     case: TVarCase,
     tparam_constraints: Vec<(Loc, AbilitySet)>,
 ) -> Vec<Type> {
+    let arity = tparam_constraints.len();
     tparam_constraints
         .into_iter()
-        .map(|(vloc, constraint)| {
+        .enumerate()
+        .map(|(i, (vloc, constraint))| {
             let tvar = make_tvar(context, vloc);
             context.add_ability_set_constraint(loc, None::<String>, tvar.clone(), constraint);
             match &case {
-                TVarCase::Single(msg) => context.add_single_type_constraint(loc, msg, tvar.clone()),
+                TVarCase::SingleButLast(_) if i + 1 == arity => {
+                    // Last arg (return type of a function): do not add any constraint
+                }
+                TVarCase::SingleButLast(msg) | TVarCase::Single(msg) => {
+                    context.add_single_type_constraint(loc, msg, tvar.clone())
+                }
                 TVarCase::Base => {
                     context.add_base_type_constraint(loc, "Invalid type argument", tvar.clone())
                 }
@@ -1438,7 +1462,9 @@ fn join_impl(
                 k1,
                 k2
             );
-            let (subst, tys) = join_impl_types(subst, case, tys1, tys2)?;
+            let arity = tys1.len();
+            let (subst, tys) =
+                join_impl_types(subst, case, |pos| n1.value.variance(pos, arity), tys1, tys2)?;
             Ok((subst, sp(*loc, Apply(k2.clone(), n2.clone(), tys))))
         }
         (sp!(loc1, Var(id1)), sp!(loc2, Var(id2))) => {
@@ -1492,14 +1518,18 @@ fn join_impl(
 fn join_impl_types(
     mut subst: Subst,
     case: TypingCase,
+    variance: impl Fn(usize) -> Variance,
     tys1: &[Type],
     tys2: &[Type],
 ) -> Result<(Subst, Vec<Type>), TypingError> {
     // if tys1.len() != tys2.len(), we will get an error when instantiating the type elsewhere
     // as all types are instantiated as a sanity check
     let mut tys = vec![];
-    for (ty1, ty2) in tys1.iter().zip(tys2) {
-        let (nsubst, t) = join_impl(subst, case, ty1, ty2)?;
+    for (pos, (ty1, ty2)) in tys1.iter().zip(tys2).enumerate() {
+        let (nsubst, t) = match (case, variance(pos)) {
+            (TypingCase::Subtype, Variance::ContraVariant) => join_impl(subst, case, ty2, ty1)?,
+            _ => join_impl(subst, case, ty1, ty2)?,
+        };
         subst = nsubst;
         tys.push(t)
     }
@@ -1628,5 +1658,25 @@ fn check_num_tvar_(subst: &Subst, loc: Loc, ty: &Type) -> bool {
             }
         }
         _ => false,
+    }
+}
+//**************************************************************************************************
+// Function type check
+//**************************************************************************************************
+
+pub fn check_non_fun(context: &mut Context, ty: &Type) {
+    if let sp!(
+        loc,
+        Type_::Apply(
+            _,
+            sp!(_, TypeName_::Builtin(sp!(_, BuiltinTypeName_::Fun))),
+            _
+        )
+    ) = ty
+    {
+        context.env.add_diag(diag!(
+            TypeSafety::InvalidFunctionType,
+            (*loc, "function type only allowed for macro arguments")
+        ))
     }
 }

--- a/language/move-compiler/src/typing/core.rs
+++ b/language/move-compiler/src/typing/core.rs
@@ -1280,7 +1280,7 @@ fn instantiate_type_args(
             TVarCase::Single("Invalid expression list type argument".to_owned())
         }
         Some(TypeName_::Builtin(sp!(_, BuiltinTypeName_::Fun))) => {
-            TVarCase::SingleButLast("Invalid expression list type argument".to_owned())
+            TVarCase::Function("Invalid expression list type argument".to_owned())
         }
         None | Some(TypeName_::Builtin(_)) | Some(TypeName_::ModuleType(_, _)) => TVarCase::Base,
     };
@@ -1342,7 +1342,7 @@ fn check_type_argument_arity<F: FnOnce() -> String>(
 
 enum TVarCase {
     Single(String),
-    SingleButLast(String),
+    Function(String),
     Base,
 }
 
@@ -1360,10 +1360,10 @@ fn make_tparams(
             let tvar = make_tvar(context, vloc);
             context.add_ability_set_constraint(loc, None::<String>, tvar.clone(), constraint);
             match &case {
-                TVarCase::SingleButLast(_) if i + 1 == arity => {
+                TVarCase::Function(_) if i + 1 == arity => {
                     // Last arg (return type of a function): do not add any constraint
                 }
-                TVarCase::SingleButLast(msg) | TVarCase::Single(msg) => {
+                TVarCase::Function(msg) | TVarCase::Single(msg) => {
                     context.add_single_type_constraint(loc, msg, tvar.clone())
                 }
                 TVarCase::Base => {

--- a/language/move-compiler/src/typing/expand.rs
+++ b/language/move-compiler/src/typing/expand.rs
@@ -26,8 +26,18 @@ pub fn function_body_(context: &mut Context, b_: &mut T::FunctionBody_) {
 pub fn function_signature(context: &mut Context, sig: &mut FunctionSignature) {
     for (_, st) in &mut sig.parameters {
         type_(context, st);
+        core::check_non_fun(context, st)
     }
     type_(context, &mut sig.return_type);
+    core::check_non_fun(context, &sig.return_type)
+}
+
+pub fn macro_signature(context: &mut Context, sig: &mut FunctionSignature) {
+    for (_, st) in &mut sig.parameters {
+        type_(context, st);
+    }
+    type_(context, &mut sig.return_type);
+    core::check_non_fun(context, &sig.return_type)
 }
 
 //**************************************************************************************************
@@ -213,6 +223,7 @@ pub fn exp(context: &mut Context, e: &mut T::Exp) {
         | E::UnresolvedError => (),
 
         E::ModuleCall(call) => module_call(context, call),
+        E::VarCall(_, args) => exp(context, args),
         E::Builtin(b, args) => {
             builtin_function(context, b);
             exp(context, args);
@@ -233,6 +244,10 @@ pub fn exp(context: &mut Context, e: &mut T::Exp) {
         }
         E::Loop { body: eloop, .. } => exp(context, eloop),
         E::Block(seq) => sequence(context, seq),
+        E::Lambda(args, body) => {
+            lvalues(context, args);
+            exp(context, body);
+        }
         E::Assign(assigns, tys, er) => {
             lvalues(context, assigns);
             expected_types(context, tys);
@@ -282,6 +297,7 @@ fn lvalue(context: &mut Context, b: &mut T::LValue) {
         L::Ignore => (),
         L::Var(_, ty) => {
             type_(context, ty);
+            core::check_non_fun(context, ty.as_ref())
         }
         L::BorrowUnpack(_, _, _, bts, fields) | L::Unpack(_, _, bts, fields) => {
             types(context, bts);

--- a/language/move-compiler/src/typing/globals.rs
+++ b/language/move-compiler/src/typing/globals.rs
@@ -4,7 +4,7 @@
 use super::core::{self, Context, Subst};
 use crate::{
     diag,
-    naming::ast::{self as N, Type, TypeName_, Type_},
+    naming::ast::{self as N, BuiltinTypeName_, Type, TypeName_, Type_},
     parser::ast::{Ability_, StructName},
     typing::ast as T,
 };
@@ -110,6 +110,9 @@ fn exp(
 
             exp(context, annotated_acquires, seen, &call.arguments);
         }
+        E::VarCall(_, args) => {
+            exp(context, annotated_acquires, seen, args);
+        }
         E::Builtin(b, args) => {
             builtin_function(context, annotated_acquires, seen, &e.exp.loc, b);
             exp(context, annotated_acquires, seen, args);
@@ -127,6 +130,7 @@ fn exp(
         }
         E::Loop { body: eloop, .. } => exp(context, annotated_acquires, seen, eloop),
         E::Block(seq) => sequence(context, annotated_acquires, seen, seq),
+        E::Lambda(_, body) => exp(context, annotated_acquires, seen, body.as_ref()),
         E::Assign(_, _, er) => {
             exp(context, annotated_acquires, seen, er);
         }
@@ -272,14 +276,7 @@ where
             assert!(context.env.has_diags());
             return None;
         }
-        T::Apply(Some(abilities), sp!(_, TN::Multiple(_)), _)
-        | T::Apply(Some(abilities), sp!(_, TN::Builtin(_)), _) => {
-            // Key ability is checked by constraints
-            assert!(!abilities.has_ability_(Ability_::Key));
-            assert!(context.env.has_diags());
-            return None;
-        }
-        T::Param(_) => {
+        T::Param(_) | T::Apply(_, sp!(_, TN::Builtin(sp!(_, BuiltinTypeName_::Fun))), _) => {
             let ty_debug = core::error_format(global_type, &Subst::empty());
             let tmsg = format!(
                 "Expected a struct type. Global storage operations are restricted to struct types \
@@ -294,7 +291,13 @@ where
             ));
             return None;
         }
-
+        T::Apply(Some(abilities), sp!(_, TN::Multiple(_)), _)
+        | T::Apply(Some(abilities), sp!(_, TN::Builtin(_)), _) => {
+            // Key ability is checked by constraints
+            assert!(!abilities.has_ability_(Ability_::Key));
+            assert!(context.env.has_diags());
+            return None;
+        }
         T::Apply(Some(_), sp!(_, TN::ModuleType(m, s)), _args) => (*m, s),
     };
 

--- a/language/move-compiler/src/typing/infinite_instantiations.rs
+++ b/language/move-compiler/src/typing/infinite_instantiations.rs
@@ -227,7 +227,7 @@ fn exp(context: &mut Context, e: &T::Exp) {
             context.add_usage(e.exp.loc, &call.module, &call.name, &call.type_arguments);
             exp(context, &call.arguments)
         }
-
+        E::VarCall(_, args) => exp(context, args),
         E::IfElse(eb, et, ef) => {
             exp(context, eb);
             exp(context, et);
@@ -239,6 +239,7 @@ fn exp(context: &mut Context, e: &T::Exp) {
         }
         E::Loop { body: eloop, .. } => exp(context, eloop),
         E::Block(seq) => sequence(context, seq),
+        E::Lambda(_, body) => exp(context, body),
         E::Assign(_, _, er) => exp(context, er),
 
         E::Builtin(_, er)

--- a/language/move-compiler/src/typing/translate.rs
+++ b/language/move-compiler/src/typing/translate.rs
@@ -9,7 +9,7 @@ use crate::{
     diag,
     diagnostics::{codes::*, Diagnostic},
     expansion::ast::{Fields, ModuleIdent, Value_},
-    naming::ast::{self as N, TParam, TParamID, Type, TypeName_, Type_},
+    naming::ast::{self as N, BuiltinTypeName_, TParam, TParamID, Type, TypeName_, Type_},
     parser::ast::{
         Ability_, BinOp_, ConstantName, Field, FunctionName, StructName, UnaryOp_, Var, Visibility,
     },
@@ -185,6 +185,7 @@ fn function(
     let loc = name.loc();
     let N::Function {
         attributes,
+        is_macro,
         visibility,
         mut signature,
         body: n_body,
@@ -246,11 +247,24 @@ fn function(
             }
         }
     }
-    expand::function_signature(context, &mut signature);
+    if is_macro {
+        expand::macro_signature(context, &mut signature);
+    } else {
+        expand::function_signature(context, &mut signature);
+    }
 
     let body = function_body(context, &acquires, n_body);
     context.current_function = None;
+
+    if is_macro && !context.env.has_blocking_diags() {
+        // TODO: remove once macro expansion is implemented
+        // flag as an error so we bail out after typing
+        context
+            .env
+            .add_diag(diag!(Bug::Unimplemented, (loc, "macro expansion")));
+    }
     T::Function {
+        is_macro,
         attributes,
         visibility,
         signature,
@@ -482,10 +496,18 @@ mod check_valid_constant {
                 exp(context, &call.arguments);
                 "Module calls are"
             }
+            E::VarCall(_, args) => {
+                exp(context, args);
+                "Local calls are"
+            }
             E::Builtin(b, args) => {
                 exp(context, args);
                 s = format!("'{}' is", b);
                 &s
+            }
+            E::Lambda(_, args) => {
+                exp(context, args);
+                "lambda expressions are"
             }
             E::IfElse(eb, et, ef) => {
                 exp(context, eb);
@@ -606,6 +628,7 @@ fn struct_def(context: &mut Context, s: &mut N::StructDefinition) {
         let loc = idx_ty.1.loc;
         let subst_ty = core::subst_tparams(tparam_subst, idx_ty.1.clone());
         let inst_ty = core::instantiate(context, subst_ty);
+        core::check_non_fun(context, &inst_ty);
         context.add_base_type_constraint(loc, "Invalid field type", inst_ty.clone());
         for declared_ability in declared_abilities {
             let required = declared_ability.value.requires();
@@ -1020,6 +1043,32 @@ enum SeqCase {
     },
 }
 
+fn lambda(
+    context: &mut Context,
+    loc: Loc,
+    args: N::LValueList,
+    body: N::Exp,
+) -> (N::Type, T::UnannotatedExp_) {
+    let old_locals = context.save_locals_scope();
+    let (declared, args) = bind_list(context, args, None);
+    let body = exp_(context, body);
+    context.close_locals_scope(old_locals, declared);
+    let fun_type_ctor = sp(loc, TypeName_::Builtin(sp(loc, BuiltinTypeName_::Fun)));
+    let fun_type_args = args
+        .value
+        .iter()
+        .filter_map(|lv| match &lv.value {
+            T::LValue_::Var(_, ty) => Some(ty.as_ref().clone()),
+            _ => None,
+        })
+        .chain(std::iter::once(body.ty.clone()))
+        .collect();
+    (
+        sp(loc, N::Type_::Apply(None, fun_type_ctor, fun_type_args)),
+        T::UnannotatedExp_::Lambda(args, Box::new(body)),
+    )
+}
+
 fn sequence(context: &mut Context, seq: N::Sequence) -> T::Sequence {
     use N::SequenceItem_ as NS;
     use T::SequenceItem_ as TS;
@@ -1307,9 +1356,13 @@ fn exp_inner(context: &mut Context, sp!(eloc, ne_): N::Exp) -> T::Exp {
             (ty, TE::Use(var))
         }
 
-        NE::ModuleCall(m, f, ty_args_opt, sp!(argloc, nargs_)) => {
+        NE::ModuleCall(m, f, is_macro, ty_args_opt, sp!(argloc, nargs_)) => {
             let args = exp_vec(context, nargs_);
-            module_call(context, eloc, m, f, ty_args_opt, argloc, args)
+            module_call(context, eloc, m, f, is_macro, ty_args_opt, argloc, args)
+        }
+        NE::VarCall(var, sp!(argloc, nargs_)) => {
+            let args = exp_vec(context, nargs_);
+            var_call(context, eloc, var, argloc, args)
         }
         NE::Builtin(b, sp!(argloc, nargs_)) => {
             let args = exp_vec(context, nargs_);
@@ -1363,7 +1416,7 @@ fn exp_inner(context: &mut Context, sp!(eloc, ne_): N::Exp) -> T::Exp {
             let seq = sequence(context, nseq);
             (sequence_type(&seq).clone(), TE::Block(seq))
         }
-
+        NE::Lambda(args, body) => lambda(context, eloc, args, *body),
         NE::Assign(na, nr) => {
             let er = exp(context, nr);
             let a = assign_list(context, na, er.ty.clone());
@@ -1725,9 +1778,9 @@ fn lvalue(
     ty: Type,
 ) -> T::LValue {
     use LValueCase as C;
-
     use N::LValue_ as NL;
     use T::LValue_ as TL;
+
     let tl_ = match nl_ {
         NL::Ignore => {
             context.add_ability_constraint(
@@ -2075,7 +2128,7 @@ fn exp_dotted_to_owned_value(
 ) -> T::Exp {
     use T::UnannotatedExp_ as TE;
     match edot {
-        // TODO investigate this nonsense
+        // sTODO investigate this nonsense
         sp!(_, ExpDotted_::Exp(lhs)) => *lhs,
         edot => {
             let name = match &edot {
@@ -2121,17 +2174,83 @@ impl crate::shared::ast_debug::AstDebug for ExpDotted_ {
 // Calls
 //**************************************************************************************************
 
+fn var_call(
+    context: &mut Context,
+    loc: Loc,
+    var: Var,
+    argloc: Loc,
+    args: Vec<T::Exp>,
+) -> (Type, T::UnannotatedExp_) {
+    let ty = context.get_local(var.0.loc, "function usage", &var);
+    match ty.value {
+        Type_::UnresolvedError => {
+            assert!(context.env.has_diags());
+            (ty, T::UnannotatedExp_::UnresolvedError)
+        }
+        Type_::Apply(_, sp!(_, TypeName_::Builtin(sp!(_, BuiltinTypeName_::Fun))), targs) => {
+            let (arguments, arg_tys) = call_args(
+                context,
+                loc,
+                || format!("Invalid call of '{}'", var),
+                targs.len() - 1,
+                argloc,
+                args,
+            );
+            assert!(arg_tys.len() == targs.len() - 1);
+            for (arg_ty, param_ty) in arg_tys
+                .into_iter()
+                .zip(targs[0..targs.len() - 1].iter().cloned())
+            {
+                let msg = || format!("Invalid call of '{}'. Invalid argument type", var);
+                subtype(context, loc, msg, arg_ty, param_ty);
+            }
+            (
+                targs[targs.len() - 1].clone(),
+                T::UnannotatedExp_::VarCall(var, arguments),
+            )
+        }
+        ty_ => {
+            let ty_str = core::error_format_(&ty_, &context.subst);
+            context.env.add_diag(diag!(
+                TypeSafety::JoinError,
+                (
+                    var.loc(),
+                    format!("Expected a function type but found {}", ty_str)
+                )
+            ));
+            (
+                context.error_type(ty.loc),
+                T::UnannotatedExp_::UnresolvedError,
+            )
+        }
+    }
+}
+
 fn module_call(
     context: &mut Context,
     loc: Loc,
     m: ModuleIdent,
     f: FunctionName,
+    is_macro: bool,
     ty_args_opt: Option<Vec<Type>>,
     argloc: Loc,
     args: Vec<T::Exp>,
 ) -> (Type, T::UnannotatedExp_) {
-    let (_, ty_args, parameters, acquires, ret_ty) =
+    let (_, ty_args, parameters, acquires, ret_ty, decl_is_macro) =
         core::make_function_type(context, loc, &m, &f, ty_args_opt);
+    if is_macro != decl_is_macro {
+        context.env.add_diag(diag!(
+            TypeSafety::InvalidCallTarget,
+            (
+                loc,
+                if is_macro {
+                    format!("'{}' is not a macro but a function", f)
+                } else {
+                    format!("'{}' is not a function but a macro", f)
+                }
+            )
+        ));
+    }
     let (arguments, arg_tys) = call_args(
         context,
         loc,
@@ -2154,11 +2273,19 @@ fn module_call(
     let call = T::ModuleCall {
         module: m,
         name: f,
+        is_macro,
         type_arguments: ty_args,
         arguments,
         parameter_types: params_ty_list,
         acquires,
     };
+    if is_macro && !context.env.has_blocking_diags() {
+        // TODO: remove once macro expansion is implemented
+        // flag as an error so we bail out after typing
+        context
+            .env
+            .add_diag(diag!(Bug::Unimplemented, (loc, "macro expansion")));
+    }
     (ret_ty, T::UnannotatedExp_::ModuleCall(Box::new(call)))
 }
 

--- a/language/move-compiler/src/unit_test/filter_test_members.rs
+++ b/language/move-compiler/src/unit_test/filter_test_members.rs
@@ -257,6 +257,7 @@ fn insert_test_poison(context: &mut Context, mloc: Loc, members: &mut Vec<P::Mod
         visibility: P::Visibility::Internal,
         acquires: vec![],
         signature,
+        is_macro: false,
         name: P::FunctionName(sp(mloc, "unit_test_poison".into())),
         body: sp(
             mloc,

--- a/language/move-compiler/tests/move_check/expansion/use_function_tparam_shadows.exp
+++ b/language/move-compiler/tests/move_check/expansion/use_function_tparam_shadows.exp
@@ -4,9 +4,9 @@ warning[W09001]: unused alias
 7 │     use 0x2::X::foo;
   │                 ^^^ Unused 'use' of alias 'foo'. Consider removing it
 
-error[E03005]: unbound unscoped name
+error[E03009]: unbound variable
    ┌─ tests/move_check/expansion/use_function_tparam_shadows.move:10:9
    │
 10 │         foo()
-   │         ^^^ Unbound function 'foo' in current scope
+   │         ^^^ Invalid function usage. Unbound variable 'foo'
 

--- a/language/move-compiler/tests/move_check/expansion/use_function_unbound.exp
+++ b/language/move-compiler/tests/move_check/expansion/use_function_unbound.exp
@@ -7,9 +7,9 @@ error[E03003]: unbound module member
 6 │     use 0x2::X::u;
   │                 ^ Invalid 'use'. Unbound member 'u' in module '0x2::X'
 
-error[E03005]: unbound unscoped name
+error[E03009]: unbound variable
   ┌─ tests/move_check/expansion/use_function_unbound.move:9:9
   │
 9 │         u()
-  │         ^ Unbound function 'u' in current scope
+  │         ^ Invalid function usage. Unbound variable 'u'
 

--- a/language/move-compiler/tests/move_check/naming/unbound_builtin.exp
+++ b/language/move-compiler/tests/move_check/naming/unbound_builtin.exp
@@ -1,18 +1,18 @@
-error[E03005]: unbound unscoped name
+error[E03009]: unbound variable
   ┌─ tests/move_check/naming/unbound_builtin.move:3:9
   │
 3 │         global_borrow();
-  │         ^^^^^^^^^^^^^ Unbound function 'global_borrow' in current scope
+  │         ^^^^^^^^^^^^^ Invalid function usage. Unbound variable 'global_borrow'
 
-error[E03005]: unbound unscoped name
+error[E03009]: unbound variable
   ┌─ tests/move_check/naming/unbound_builtin.move:4:9
   │
 4 │         release<u64>();
-  │         ^^^^^^^ Unbound function 'release' in current scope
+  │         ^^^^^^^ Invalid function usage. Unbound variable 'release'
 
-error[E03005]: unbound unscoped name
+error[E03009]: unbound variable
   ┌─ tests/move_check/naming/unbound_builtin.move:5:9
   │
 5 │         sudo(false);
-  │         ^^^^ Unbound function 'sudo' in current scope
+  │         ^^^^ Invalid function usage. Unbound variable 'sudo'
 

--- a/language/move-compiler/tests/move_check/naming/unbound_unqualified_function.exp
+++ b/language/move-compiler/tests/move_check/naming/unbound_unqualified_function.exp
@@ -1,18 +1,18 @@
-error[E03005]: unbound unscoped name
+error[E03009]: unbound variable
   ┌─ tests/move_check/naming/unbound_unqualified_function.move:3:9
   │
 3 │         bar();
-  │         ^^^ Unbound function 'bar' in current scope
+  │         ^^^ Invalid function usage. Unbound variable 'bar'
 
-error[E03005]: unbound unscoped name
+error[E03009]: unbound variable
   ┌─ tests/move_check/naming/unbound_unqualified_function.move:4:17
   │
 4 │         let x = bar();
-  │                 ^^^ Unbound function 'bar' in current scope
+  │                 ^^^ Invalid function usage. Unbound variable 'bar'
 
-error[E03005]: unbound unscoped name
+error[E03009]: unbound variable
   ┌─ tests/move_check/naming/unbound_unqualified_function.move:5:10
   │
 5 │         *bar() = 0;
-  │          ^^^ Unbound function 'bar' in current scope
+  │          ^^^ Invalid function usage. Unbound variable 'bar'
 

--- a/language/move-compiler/tests/move_check/parser/module_missing_rbrace.exp
+++ b/language/move-compiler/tests/move_check/parser/module_missing_rbrace.exp
@@ -5,5 +5,5 @@ error[E01002]: unexpected token
   │ ^
   │ 
   │ Unexpected end-of-file
-  │ Expected a module member: 'spec', 'use', 'friend', 'const', 'fun', or 'struct'
+  │ Expected a module member: 'spec', 'use', 'friend', 'const', 'fun', 'macro', or 'struct'
 

--- a/language/move-compiler/tests/move_check/parser/spec_parsing_fun_type_fail.exp
+++ b/language/move-compiler/tests/move_check/parser/spec_parsing_fun_type_fail.exp
@@ -1,6 +1,6 @@
-error[E01010]: syntax item restricted to spec contexts
+error[E04024]: invalid usage of function type
   ┌─ tests/move_check/parser/spec_parsing_fun_type_fail.move:2:29
   │
 2 │     fun fun_type_in_prog(p: |u64|u64) {
-  │                             ^^^^^^^^ `|_|_` function type only allowed in specifications
+  │                             ^^^^^^^^ function type only allowed for macro arguments
 

--- a/language/move-compiler/tests/move_check/parser/spec_parsing_lambda_fail.exp
+++ b/language/move-compiler/tests/move_check/parser/spec_parsing_lambda_fail.exp
@@ -1,6 +1,0 @@
-error[E01010]: syntax item restricted to spec contexts
-  ┌─ tests/move_check/parser/spec_parsing_lambda_fail.move:3:15
-  │
-3 │       let _ = |y| x + y;
-  │               ^^^^^^^^^ lambda expression only allowed in specifications
-

--- a/language/move-compiler/tests/move_check/parser/spec_parsing_lambda_fail.move
+++ b/language/move-compiler/tests/move_check/parser/spec_parsing_lambda_fail.move
@@ -1,5 +1,0 @@
-module 0x8675309::M {
-    fun lambda_in_prog(x: u64) {
-      let _ = |y| x + y;
-    }
-}

--- a/language/move-compiler/tests/move_check/typing/lambda.exp
+++ b/language/move-compiler/tests/move_check/typing/lambda.exp
@@ -1,0 +1,93 @@
+error[E04017]: too many arguments
+   ┌─ tests/move_check/typing/lambda.move:40:13
+   │
+40 │             action(XVector::borrow(v, i), i); // expected to have wrong argument count
+   │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │             │     │
+   │             │     Found 2 argument(s) here
+   │             Invalid call of 'action'. The call expected 1 argument(s) but got 2
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/lambda.move:48:13
+   │
+45 │     public macro wrong_local_call_arg_type<T>(v: &vector<T>, action: |&T|) {
+   │                                                                       -- Expected: '&T'
+   ·
+48 │             action(i); // expected to have wrong argument type
+   │             ^^^^^^^^^ Invalid call of 'action'. Invalid argument type
+   ·
+96 │     public fun length<T>(v: &vector<T>): u64 { abort(1) }
+   │                                          --- Given: 'u64'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/lambda.move:56:19
+   │
+53 │     public macro wrong_local_call_result_type<T>(v: &vector<T>, action: |&T|) {
+   │                                                                         ---- Found: '()'. It is not compatible with the other type.
+   ·
+56 │             i = i + action(XVector::borrow(v, i)); // expected to have wrong result type
+   │                   ^ Incompatible arguments to '+'
+   ·
+96 │     public fun length<T>(v: &vector<T>): u64 { abort(1) }
+   │                                          --- Found: 'u64'. It is not compatible with the other type.
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/lambda.move:61:9
+   │
+61 │         x(1)
+   │         ^ Expected a function type but found 'u64'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/lambda.move:67:9
+   │
+ 4 │     public macro foreach<T>(v: &vector<T>, action: |&T|) { // expected to be not implemented
+   │                                                     -- Given: '&{integer}'
+   ·
+67 │         foreach!(&v, |e| sum = sum + e) // expected to cannot infer type
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │         │             │
+   │         │             Expected: integer
+   │         Invalid call of '0x8675309::M::foreach'. Invalid argument for parameter 'action'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_check/typing/lambda.move:73:9
+   │
+ 4 │     public macro foreach<T>(v: &vector<T>, action: |&T|) { // expected to be not implemented
+   │                                                    ---- Expected: '()'
+   ·
+73 │         foreach!(&v, |e| { sum = sum + *e; *e }) // expected to have wrong result type of lambda
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │         │                                  │
+   │         │                                  Given: integer
+   │         Invalid call of '0x8675309::M::foreach'. Invalid argument for parameter 'action'
+
+error[E04024]: invalid usage of function type
+   ┌─ tests/move_check/typing/lambda.move:77:18
+   │
+77 │         let _x = |i| i + 1; // expected lambda not allowed
+   │                  ^^^^^^^^^ function type only allowed for macro arguments
+
+error[E04024]: invalid usage of function type
+   ┌─ tests/move_check/typing/lambda.move:81:12
+   │
+81 │         f: |u64|u64, // expected lambda not allowed
+   │            ^^^^^^^^ function type only allowed for macro arguments
+
+error[E04024]: invalid usage of function type
+   ┌─ tests/move_check/typing/lambda.move:84:46
+   │
+84 │     public fun fun_arg_lambda_not_allowed(x: |u64|) {} // expected lambda not allowed
+   │                                              ^^^^^ function type only allowed for macro arguments
+
+error[E04024]: invalid usage of function type
+   ┌─ tests/move_check/typing/lambda.move:86:53
+   │
+86 │     public macro macro_result_lambda_not_allowed(): |u64| {  // expected lambda not allowed
+   │                                                     ^^^^^ function type only allowed for macro arguments
+
+error[E04024]: invalid usage of function type
+   ┌─ tests/move_check/typing/lambda.move:89:49
+   │
+89 │     public fun fun_result_lambda_not_allowed(): |u64| {  // expected lambda not allowed
+   │                                                 ^^^^^ function type only allowed for macro arguments
+

--- a/language/move-compiler/tests/move_check/typing/lambda.exp
+++ b/language/move-compiler/tests/move_check/typing/lambda.exp
@@ -10,8 +10,8 @@ error[E04017]: too many arguments
 error[E04007]: incompatible types
    ┌─ tests/move_check/typing/lambda.move:48:13
    │
-45 │     public macro wrong_local_call_arg_type<T>(v: &vector<T>, action: |&T|) {
-   │                                                                       -- Expected: '&T'
+45 │     public macro fun wrong_local_call_arg_type<T>(v: &vector<T>, action: |&T|) {
+   │                                                                           -- Expected: '&T'
    ·
 48 │             action(i); // expected to have wrong argument type
    │             ^^^^^^^^^ Invalid call of 'action'. Invalid argument type
@@ -22,8 +22,8 @@ error[E04007]: incompatible types
 error[E04007]: incompatible types
    ┌─ tests/move_check/typing/lambda.move:56:19
    │
-53 │     public macro wrong_local_call_result_type<T>(v: &vector<T>, action: |&T|) {
-   │                                                                         ---- Found: '()'. It is not compatible with the other type.
+53 │     public macro fun wrong_local_call_result_type<T>(v: &vector<T>, action: |&T|) {
+   │                                                                             ---- Found: '()'. It is not compatible with the other type.
    ·
 56 │             i = i + action(XVector::borrow(v, i)); // expected to have wrong result type
    │                   ^ Incompatible arguments to '+'
@@ -40,8 +40,8 @@ error[E04007]: incompatible types
 error[E04007]: incompatible types
    ┌─ tests/move_check/typing/lambda.move:67:9
    │
- 4 │     public macro foreach<T>(v: &vector<T>, action: |&T|) { // expected to be not implemented
-   │                                                     -- Given: '&{integer}'
+ 4 │     public macro fun foreach<T>(v: &vector<T>, action: |&T|) { // expected to be not implemented
+   │                                                         -- Given: '&{integer}'
    ·
 67 │         foreach!(&v, |e| sum = sum + e) // expected to cannot infer type
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -52,8 +52,8 @@ error[E04007]: incompatible types
 error[E04007]: incompatible types
    ┌─ tests/move_check/typing/lambda.move:73:9
    │
- 4 │     public macro foreach<T>(v: &vector<T>, action: |&T|) { // expected to be not implemented
-   │                                                    ---- Expected: '()'
+ 4 │     public macro fun foreach<T>(v: &vector<T>, action: |&T|) { // expected to be not implemented
+   │                                                        ---- Expected: '()'
    ·
 73 │         foreach!(&v, |e| { sum = sum + *e; *e }) // expected to have wrong result type of lambda
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -80,10 +80,10 @@ error[E04024]: invalid usage of function type
    │                                              ^^^^^ function type only allowed for macro arguments
 
 error[E04024]: invalid usage of function type
-   ┌─ tests/move_check/typing/lambda.move:86:53
+   ┌─ tests/move_check/typing/lambda.move:86:57
    │
-86 │     public macro macro_result_lambda_not_allowed(): |u64| {  // expected lambda not allowed
-   │                                                     ^^^^^ function type only allowed for macro arguments
+86 │     public macro fun macro_result_lambda_not_allowed(): |u64| {  // expected lambda not allowed
+   │                                                         ^^^^^ function type only allowed for macro arguments
 
 error[E04024]: invalid usage of function type
    ┌─ tests/move_check/typing/lambda.move:89:49

--- a/language/move-compiler/tests/move_check/typing/lambda.move
+++ b/language/move-compiler/tests/move_check/typing/lambda.move
@@ -1,0 +1,100 @@
+module 0x8675309::M {
+    use 0x1::XVector;
+
+    public macro foreach<T>(v: &vector<T>, action: |&T|) { // expected to be not implemented
+        let i = 0;
+        while (i < XVector::length(v)) {
+            action(XVector::borrow(v, i));
+            i = i + 1;
+        }
+    }
+
+    public macro reduce<R, T>(v: vector<T>, accu: R, reducer: |T, R|R): R {
+        while (!XVector::is_empty(&v)) {
+            accu = reducer(XVector::pop_back(&mut v), accu);
+        };
+        accu
+    }
+
+
+    public fun correct_foreach() {
+        let v = vector[1, 2, 3];
+        let sum = 0;
+        foreach!(&v, |e| sum = sum + *e) // expected to be not implemented
+    }
+
+    public fun correct_reduce(): u64 {
+        let v = vector[1, 2, 3];
+        reduce!(v, 0, |t, r| t + r)
+    }
+
+    public fun corrected_nested() {
+        let v = vector[vector[1,2], vector[3]];
+        let sum = 0;
+        foreach!(&v, |e| sum = sum + reduce!(*e, 0, |t, r| t + r));
+    }
+
+    public macro wrong_local_call_arg_count<T>(v: &vector<T>, action: |&T|) {
+        let i = 0;
+        while (i < XVector::length(v)) {
+            action(XVector::borrow(v, i), i); // expected to have wrong argument count
+            i = i + 1;
+        }
+    }
+
+    public macro wrong_local_call_arg_type<T>(v: &vector<T>, action: |&T|) {
+        let i = 0;
+        while (i < XVector::length(v)) {
+            action(i); // expected to have wrong argument type
+            i = i + 1;
+        }
+    }
+
+    public macro wrong_local_call_result_type<T>(v: &vector<T>, action: |&T|) {
+        let i = 0;
+        while (i < XVector::length(v)) {
+            i = i + action(XVector::borrow(v, i)); // expected to have wrong result type
+        }
+    }
+
+    public fun wrong_local_call_no_fun(x: u64) {
+        x(1)
+    }
+
+    public fun wrong_lambda_inferred_type() {
+        let v = vector[1, 2, 3];
+        let sum = 0;
+        foreach!(&v, |e| sum = sum + e) // expected to cannot infer type
+    }
+
+    public fun wrong_lambda_result_type() {
+        let v = vector[1, 2, 3];
+        let sum = 0;
+        foreach!(&v, |e| { sum = sum + *e; *e }) // expected to have wrong result type of lambda
+    }
+
+    public fun lambda_not_allowed() {
+        let _x = |i| i + 1; // expected lambda not allowed
+    }
+
+    struct FieldFunNotAllowed {
+        f: |u64|u64, // expected lambda not allowed
+    }
+
+    public fun fun_arg_lambda_not_allowed(x: |u64|) {} // expected lambda not allowed
+
+    public macro macro_result_lambda_not_allowed(): |u64| {  // expected lambda not allowed
+        abort (1)
+    }
+    public fun fun_result_lambda_not_allowed(): |u64| {  // expected lambda not allowed
+        abort (1)
+    }
+
+}
+
+module 0x1::XVector {
+    public fun length<T>(v: &vector<T>): u64 { abort(1) }
+    public fun is_empty<T>(v: &vector<T>): bool { abort(1) }
+    public fun borrow<T>(v: &vector<T>, i: u64): &T { abort(1) }
+    public fun pop_back<T>(v: &mut vector<T>): T { abort(1) }
+}

--- a/language/move-compiler/tests/move_check/typing/lambda.move
+++ b/language/move-compiler/tests/move_check/typing/lambda.move
@@ -1,7 +1,7 @@
 module 0x8675309::M {
     use 0x1::XVector;
 
-    public macro foreach<T>(v: &vector<T>, action: |&T|) { // expected to be not implemented
+    public macro fun foreach<T>(v: &vector<T>, action: |&T|) { // expected to be not implemented
         let i = 0;
         while (i < XVector::length(v)) {
             action(XVector::borrow(v, i));
@@ -9,7 +9,7 @@ module 0x8675309::M {
         }
     }
 
-    public macro reduce<R, T>(v: vector<T>, accu: R, reducer: |T, R|R): R {
+    public macro fun reduce<R, T>(v: vector<T>, accu: R, reducer: |T, R|R): R {
         while (!XVector::is_empty(&v)) {
             accu = reducer(XVector::pop_back(&mut v), accu);
         };
@@ -34,7 +34,7 @@ module 0x8675309::M {
         foreach!(&v, |e| sum = sum + reduce!(*e, 0, |t, r| t + r));
     }
 
-    public macro wrong_local_call_arg_count<T>(v: &vector<T>, action: |&T|) {
+    public macro fun wrong_local_call_arg_count<T>(v: &vector<T>, action: |&T|) {
         let i = 0;
         while (i < XVector::length(v)) {
             action(XVector::borrow(v, i), i); // expected to have wrong argument count
@@ -42,7 +42,7 @@ module 0x8675309::M {
         }
     }
 
-    public macro wrong_local_call_arg_type<T>(v: &vector<T>, action: |&T|) {
+    public macro fun wrong_local_call_arg_type<T>(v: &vector<T>, action: |&T|) {
         let i = 0;
         while (i < XVector::length(v)) {
             action(i); // expected to have wrong argument type
@@ -50,7 +50,7 @@ module 0x8675309::M {
         }
     }
 
-    public macro wrong_local_call_result_type<T>(v: &vector<T>, action: |&T|) {
+    public macro fun wrong_local_call_result_type<T>(v: &vector<T>, action: |&T|) {
         let i = 0;
         while (i < XVector::length(v)) {
             i = i + action(XVector::borrow(v, i)); // expected to have wrong result type
@@ -83,7 +83,7 @@ module 0x8675309::M {
 
     public fun fun_arg_lambda_not_allowed(x: |u64|) {} // expected lambda not allowed
 
-    public macro macro_result_lambda_not_allowed(): |u64| {  // expected lambda not allowed
+    public macro fun macro_result_lambda_not_allowed(): |u64| {  // expected lambda not allowed
         abort (1)
     }
     public fun fun_result_lambda_not_allowed(): |u64| {  // expected lambda not allowed

--- a/language/move-compiler/tests/move_check/typing/module_call_missing_function.exp
+++ b/language/move-compiler/tests/move_check/typing/module_call_missing_function.exp
@@ -4,11 +4,11 @@ error[E03003]: unbound module member
 13 │         Self::fooo();
    │         ^^^^^^^^^^ Invalid module access. Unbound function 'fooo' in module '0x2::M'
 
-error[E03005]: unbound unscoped name
+error[E03009]: unbound variable
    ┌─ tests/move_check/typing/module_call_missing_function.move:14:9
    │
 14 │         foooo();
-   │         ^^^^^ Unbound function 'foooo' in current scope
+   │         ^^^^^ Invalid function usage. Unbound variable 'foooo'
 
 error[E03003]: unbound module member
    ┌─ tests/move_check/typing/module_call_missing_function.move:15:9

--- a/language/move-compiler/tests/move_check/unit_test/test_filter_function.exp
+++ b/language/move-compiler/tests/move_check/unit_test/test_filter_function.exp
@@ -1,6 +1,6 @@
-error[E03005]: unbound unscoped name
+error[E03009]: unbound variable
   ┌─ tests/move_check/unit_test/test_filter_function.move:6:24
   │
 6 │     public fun foo() { bar() }
-  │                        ^^^ Unbound function 'bar' in current scope
+  │                        ^^^ Invalid function usage. Unbound variable 'bar'
 

--- a/language/move-model/src/builder/exp_translator.rs
+++ b/language/move-model/src/builder/exp_translator.rs
@@ -549,6 +549,10 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
                         U128 => Type::new_prim(PrimitiveType::U128),
                         Vector => Type::Vector(Box::new(self.translate_hlir_base_type(&args[0]))),
                         Bool => Type::new_prim(PrimitiveType::Bool),
+                        Fun => Type::Fun(
+                            self.translate_hlir_base_types(&args[0..args.len() - 1]),
+                            Box::new(self.translate_hlir_base_type(&args[args.len() - 1])),
+                        ),
                     },
                     ModuleType(m, n) => {
                         let addr_bytes = self.parent.parent.resolve_address(&loc, &m.value.address);


### PR DESCRIPTION
(This is a port of [pending Diem PR #1005](https://github.com/diem/diem/pull/10005) from the Diem repo to the Move repo. Mentioned PR was submitted before Move was split off Diem. For the historical discussion see the original version. The port has been created by (a) calling `git format-patch` in the Diem repo (b) calling `git am -3 < patch-file` in the Move repo, so it should be save following the same schema as general git rebasing does.)

This PR realizes the 1st step towards an alternative, high fidelity implementation of user level macros, in contrast to compiler macros suggested in [Diem PR #9930](https://github.com/diem/diem/pull/10005).

In this model, macros can be declared using a new style of function declaration:

```
    public macro foreach<T>(v: &vector<T>, action: |&T|) {
        let i = 0;
        while (i < Vector::length(v)) {
            action(Vector::borrow(v, i));
            i = i + 1;
        }
    }
```

This PR implements parsing and type checking of this style of macros up to the typing AST. Macro expansion is not yet implemented and intended to be added in a followup.

The biggest change is enabling function types, lambda expressions, and calls of function values for naming and typing. Those had been supported before for the spec language, but weren't supported in move-lang beyond expansion. In the design, we represent function types by a new `BuiltinTypeName_::Fun` which allows to minimize changes to the code, as no new type variant needs to be introduced, and existing functionality for inference et. al can be adopted with minimal changes. This consistent e.g. with the treatment of function types in Rust, where they are just type constructors with some syntactic sugar.

A new test case has been added at [lambda.move](https://github.com/diem/move/blob/70cddf1abc124fcc9f606350f520feda829343e7/language/move-compiler/tests/move_check/typing/lambda.move) which shows usage and intends to cover all type check failure scenarios.

After this PR, to complete this style of macros, we still need to:

- Implement actual expansion of macros. This is intended to happen in a new phase after typing.
- Implement representation of macros in compiled, persisted modules. We need to be able to fetch the macro definition from an imported, precompiled module.
- Implement techniques (in the prover) to refer to specifications of passed lambda arguments to macros. (See https://github.com/diem/move/blob/main/language/move-prover/tests/sources/functional/macro_verification.move for what we want to do here.)

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Macros

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Added new tests


