### PR TITLE
[tools] Compile in release mode for CI testing (+ enable move-cli release builds)

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -137,7 +137,7 @@ jobs:
           key: ${{ needs.prepare.outputs.changes-target-branch }}
       - name: run unit tests
         run: |
-          $pre_command && cargo nextest --nextest-profile ci --jobs ${max_threads} --test-threads ${max_threads} --changed-since "origin/$TARGET_BRANCH"
+          $pre_command && cargo nextest --release --nextest-profile ci --jobs ${max_threads} --test-threads ${max_threads} --changed-since "origin/$TARGET_BRANCH"
         env:
           TARGET_BRANCH: ${{ needs.prepare.outputs.changes-target-branch }}
       - name: run doctests

--- a/language/move-vm/runtime/Cargo.toml
+++ b/language/move-vm/runtime/Cargo.toml
@@ -30,7 +30,6 @@ anyhow = "1.0.52"
 hex = "0.4.3"
 proptest = "1.0.0"
 
-
 move-ir-compiler = { path = "../../move-ir-compiler" }
 move-compiler = { path = "../../move-compiler" }
 
@@ -38,3 +37,5 @@ move-compiler = { path = "../../move-compiler" }
 default = []
 fuzzing = ["move-vm-types/fuzzing"]
 failpoints = ["fail/failpoints"]
+# Enable tracing and debugging also for release builds. By default, it is only enabled for debug builds.
+debugging = []

--- a/language/move-vm/runtime/src/lib.rs
+++ b/language/move-vm/runtime/src/lib.rs
@@ -24,7 +24,7 @@ pub mod session;
 mod tracing;
 
 // Only include debugging functionality in debug builds
-#[cfg(debug_assertions)]
+#[cfg(any(debug_assertions, feature = "debugging"))]
 mod debug;
 
 #[cfg(test)]

--- a/language/move-vm/runtime/src/tracing.rs
+++ b/language/move-vm/runtime/src/tracing.rs
@@ -1,10 +1,10 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#[cfg(debug_assertions)]
+#[cfg(any(debug_assertions, feature = "debugging"))]
 use crate::debug::DebugContext;
 
-#[cfg(debug_assertions)]
+#[cfg(any(debug_assertions, feature = "debugging"))]
 use ::{
     move_binary_format::file_format::Bytecode,
     move_vm_types::values::Locals,
@@ -19,31 +19,31 @@ use ::{
     },
 };
 
-#[cfg(debug_assertions)]
+#[cfg(any(debug_assertions, feature = "debugging"))]
 use crate::{
     interpreter::Interpreter,
     loader::{Function, Loader},
 };
 
-#[cfg(debug_assertions)]
+#[cfg(any(debug_assertions, feature = "debugging"))]
 const MOVE_VM_TRACING_ENV_VAR_NAME: &str = "MOVE_VM_TRACE";
 
-#[cfg(debug_assertions)]
+#[cfg(any(debug_assertions, feature = "debugging"))]
 const MOVE_VM_STEPPING_ENV_VAR_NAME: &str = "MOVE_VM_STEP";
 
-#[cfg(debug_assertions)]
+#[cfg(any(debug_assertions, feature = "debugging"))]
 static FILE_PATH: Lazy<String> = Lazy::new(|| {
     env::var(MOVE_VM_TRACING_ENV_VAR_NAME).unwrap_or_else(|_| "move_vm_trace.trace".to_string())
 });
 
-#[cfg(debug_assertions)]
+#[cfg(any(debug_assertions, feature = "debugging"))]
 static TRACING_ENABLED: Lazy<bool> = Lazy::new(|| env::var(MOVE_VM_TRACING_ENV_VAR_NAME).is_ok());
 
-#[cfg(debug_assertions)]
+#[cfg(any(debug_assertions, feature = "debugging"))]
 static DEBUGGING_ENABLED: Lazy<bool> =
     Lazy::new(|| env::var(MOVE_VM_STEPPING_ENV_VAR_NAME).is_ok());
 
-#[cfg(debug_assertions)]
+#[cfg(any(debug_assertions, feature = "debugging"))]
 static LOGGING_FILE: Lazy<Mutex<File>> = Lazy::new(|| {
     Mutex::new(
         OpenOptions::new()
@@ -55,11 +55,11 @@ static LOGGING_FILE: Lazy<Mutex<File>> = Lazy::new(|| {
     )
 });
 
-#[cfg(debug_assertions)]
+#[cfg(any(debug_assertions, feature = "debugging"))]
 static DEBUG_CONTEXT: Lazy<Mutex<DebugContext>> = Lazy::new(|| Mutex::new(DebugContext::new()));
 
 // Only include in debug builds
-#[cfg(debug_assertions)]
+#[cfg(any(debug_assertions, feature = "debugging"))]
 pub(crate) fn trace(
     function_desc: &Function,
     locals: &Locals,
@@ -93,7 +93,7 @@ pub(crate) fn trace(
 macro_rules! trace {
     ($function_desc:expr, $locals:expr, $pc:expr, $instr:tt, $resolver:expr, $interp:expr) => {
         // Only include this code in debug releases
-        #[cfg(debug_assertions)]
+        #[cfg(any(debug_assertions, feature = "debugging"))]
         crate::tracing::trace(
             &$function_desc,
             $locals,

--- a/language/tools/move-cli/Cargo.toml
+++ b/language/tools/move-cli/Cargo.toml
@@ -36,7 +36,7 @@ move-compiler = { path = "../../move-compiler" }
 move-stdlib = { path = "../../move-stdlib", features = ["testing"] }
 move-symbol-pool = { path = "../../move-symbol-pool" }
 move-vm-types = { path = "../../move-vm/types" }
-move-vm-runtime = { path = "../../move-vm/runtime" }
+move-vm-runtime = { path = "../../move-vm/runtime", features = ["debugging"] }
 read-write-set = { path = "../read-write-set" }
 read-write-set-dynamic = { path = "../read-write-set/dynamic" }
 move-resource-viewer = { path = "../move-resource-viewer" }

--- a/language/tools/move-cli/tests/cli_tests.rs
+++ b/language/tools/move-cli/tests/cli_tests.rs
@@ -5,8 +5,12 @@ use move_cli::sandbox::commands::test;
 
 use std::path::PathBuf;
 
-pub const CLI_BINARY_PATH: [&str; 6] = ["..", "..", "..", "target", "debug", "move"];
 pub const CLI_METATEST_PATH: [&str; 3] = ["tests", "metatests", "args.txt"];
+
+#[cfg(debug_assertions)]
+pub const CLI_BINARY_PATH: [&str; 6] = ["..", "..", "..", "target", "debug", "move"];
+#[cfg(not(debug_assertions))]
+pub const CLI_BINARY_PATH: [&str; 6] = ["..", "..", "..", "target", "release", "move"];
 
 fn get_cli_binary_path() -> PathBuf {
     CLI_BINARY_PATH.iter().collect()
@@ -36,14 +40,18 @@ fn run_metatest() {
 
 #[test]
 fn cross_process_locking_git_deps() {
+    #[cfg(debug_assertions)]
+    const CLI_EXE: &str = "../../../../../../target/debug/move";
+    #[cfg(not(debug_assertions))]
+    const CLI_EXE: &str = "../../../../../../target/release/move";
     let handle = std::thread::spawn(|| {
-        std::process::Command::new("../../../../../../target/debug/move")
+        std::process::Command::new(CLI_EXE)
             .current_dir("./tests/cross_process_tests/Package1")
             .args(["package", "build"])
             .output()
             .expect("Package1 failed");
     });
-    std::process::Command::new("../../../../../../target/debug/move")
+    std::process::Command::new(CLI_EXE)
         .current_dir("./tests/cross_process_tests/Package2")
         .args(["package", "build"])
         .output()

--- a/language/tools/move-cli/tests/cli_testsuite.rs
+++ b/language/tools/move-cli/tests/cli_testsuite.rs
@@ -5,11 +5,16 @@ use move_cli::sandbox::commands::test;
 
 use std::path::{Path, PathBuf};
 
+#[cfg(debug_assertions)]
+const CLI_EXE: &str = "../../../target/debug/move";
+#[cfg(not(debug_assertions))]
+const CLI_EXE: &str = "../../../target/release/move";
+
 fn run_all(args_path: &Path) -> datatest_stable::Result<()> {
     let use_temp_dir = !args_path.parent().unwrap().join("NO_TEMPDIR").exists();
     test::run_one(
         args_path,
-        &PathBuf::from("../../../target/debug/move"),
+        &PathBuf::from(CLI_EXE),
         /* use_temp_dir */ use_temp_dir,
         /* track_cov */ false,
     )?;


### PR DESCRIPTION
PR #95 is experiencing stack overflows in some unrelated tests. It is well known that Rust debug builds have a large stack consumption. It is also reported the M1 macs have tighter restrictions on stack allocation.       

Our CI tests were until now run in debug mode. This PR switches this to `--release`. However, it turned out that the move-cli and related packages cannot operate in release mode:

- The `target/debug` path was hardwired into the test code.
- The Move VM does not generate trace/debug info when compiled in release mode (which is needed for the testing framework)

Both those problems have been fixed, and we are able now  to run the Move CLI, package system, and unit tests in release mode. Notice that the CLI's own tests execute approx. 10x faster in release mode, so even if compilation is slower, overall CI time should be improved, and also turn-around times for CLI users.


### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes
