### PR TITLE
[move-vm] Reduce VALUE_DEPTH_MAX to 128 + enable release build for CLI

### DIFF
--- a/language/move-stdlib/tests/BCSTests.move
+++ b/language/move-stdlib/tests/BCSTests.move
@@ -9,7 +9,6 @@ module Std::BCSTests {
     struct Box31<T> has copy, drop, store { x: Box15<Box15<T>> }
     struct Box63<T> has copy, drop, store { x: Box31<Box31<T>> }
     struct Box127<T> has copy, drop, store { x: Box63<Box63<T>> }
-    struct Box255<T> has copy, drop, store { x: Box127<Box127<T>> }
 
     #[test]
     fun bcs_address() {
@@ -73,23 +72,14 @@ module Std::BCSTests {
         Box127 { x: box63(box63(x)) }
     }
 
-    fun box255<T>(x: T): Box255<T> {
-        Box255 { x: box127(box127(x)) }
-    }
-
     #[test]
     fun encode_128() {
         BCS::to_bytes(&box127(true));
     }
 
     #[test]
-    fun encode_256() {
-        BCS::to_bytes(&box255(true));
-    }
-
-    #[test]
     #[expected_failure(abort_code = 453)]
-    fun encode_257() {
-        BCS::to_bytes(&Box { x: box255(true) });
+    fun encode_129() {
+        BCS::to_bytes(&Box { x: box127(true) });
     }
 }

--- a/language/move-stdlib/tests/EventTests.move
+++ b/language/move-stdlib/tests/EventTests.move
@@ -16,7 +16,6 @@ module Std::EventTests {
     struct Box31<T> has copy, drop, store { x: Box15<Box15<T>> }
     struct Box63<T> has copy, drop, store { x: Box31<Box31<T>> }
     struct Box127<T> has copy, drop, store { x: Box63<Box63<T>> }
-    struct Box255<T> has copy, drop, store { x: Box127<Box127<T>> }
 
     struct MyEvent<phantom T: copy + drop + store> has key {
         e: EventHandle<T>
@@ -46,10 +45,6 @@ module Std::EventTests {
         Box127 { x: box63(box63(x)) }
     }
 
-    fun box255<T>(x: T): Box255<T> {
-        Box255 { x: box127(box127(x)) }
-    }
-
     fun maybe_init_event<T: copy + drop + store>(s: &signer) {
         if (exists<MyEvent<T>>(address_of(s))) return;
 
@@ -62,19 +57,13 @@ module Std::EventTests {
         emit_event(&mut borrow_global_mut<MyEvent<Box127<bool>>>(address_of(s)).e, box127(true))
     }
 
-    public fun event_256(s: &signer) acquires MyEvent {
-        maybe_init_event<Box255<bool>>(s);
-
-        emit_event(&mut borrow_global_mut<MyEvent<Box255<bool>>>(address_of(s)).e, box255(true))
-    }
-
-    public fun event_257(s: &signer) acquires MyEvent {
-        maybe_init_event<Box<Box255<bool>>>(s);
+    public fun event_129(s: &signer) acquires MyEvent {
+        maybe_init_event<Box<Box127<bool>>>(s);
 
         // will abort
         emit_event(
-            &mut borrow_global_mut<MyEvent<Box<Box255<bool>>>>(address_of(s)).e,
-            Box { x: box255(true) }
+            &mut borrow_global_mut<MyEvent<Box<Box127<bool>>>>(address_of(s)).e,
+            Box { x: box127(true) }
         )
     }
 
@@ -84,14 +73,9 @@ module Std::EventTests {
     }
 
     #[test(s = @0x42)]
-    fun test_event_256(s: signer) acquires MyEvent {
-        event_256(&s);
-    }
-
-    #[test(s = @0x42)]
     #[expected_failure(abort_code = 0)]
-    fun test_event_257(s: signer) acquires MyEvent {
-        event_257(&s);
+    fun test_event_129(s: signer) acquires MyEvent {
+        event_129(&s);
     }
 
     // More detailed version of the above--test BCS compatibility between the old event

--- a/language/move-vm/runtime/Cargo.toml
+++ b/language/move-vm/runtime/Cargo.toml
@@ -29,8 +29,6 @@ workspace-hack = { version = "0.1", path = "../../../crates/workspace-hack" }
 anyhow = "1.0.52"
 hex = "0.4.3"
 proptest = "1.0.0"
-
-
 move-ir-compiler = { path = "../../move-ir-compiler" }
 move-compiler = { path = "../../move-compiler" }
 
@@ -38,3 +36,5 @@ move-compiler = { path = "../../move-compiler" }
 default = []
 fuzzing = ["move-vm-types/fuzzing"]
 failpoints = ["fail/failpoints"]
+# Enable tracing and debugging also for release builds. By default, it is only enabled for debug builds.
+debugging = []

--- a/language/move-vm/runtime/src/lib.rs
+++ b/language/move-vm/runtime/src/lib.rs
@@ -24,7 +24,7 @@ pub mod session;
 mod tracing;
 
 // Only include debugging functionality in debug builds
-#[cfg(debug_assertions)]
+#[cfg(any(debug_assertions, feature = "debugging"))]
 mod debug;
 
 #[cfg(test)]

--- a/language/move-vm/runtime/src/loader.rs
+++ b/language/move-vm/runtime/src/loader.rs
@@ -2010,7 +2010,7 @@ impl TypeCache {
     }
 }
 
-const VALUE_DEPTH_MAX: usize = 256;
+const VALUE_DEPTH_MAX: usize = 128;
 
 impl Loader {
     fn struct_gidx_to_type_tag(&self, gidx: usize, ty_args: &[Type]) -> PartialVMResult<StructTag> {

--- a/language/move-vm/runtime/src/tracing.rs
+++ b/language/move-vm/runtime/src/tracing.rs
@@ -1,10 +1,10 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#[cfg(debug_assertions)]
+#[cfg(any(debug_assertions, feature = "debugging"))]
 use crate::debug::DebugContext;
 
-#[cfg(debug_assertions)]
+#[cfg(any(debug_assertions, feature = "debugging"))]
 use ::{
     move_binary_format::file_format::Bytecode,
     move_vm_types::values::Locals,
@@ -19,31 +19,31 @@ use ::{
     },
 };
 
-#[cfg(debug_assertions)]
+#[cfg(any(debug_assertions, feature = "debugging"))]
 use crate::{
     interpreter::Interpreter,
     loader::{Function, Loader},
 };
 
-#[cfg(debug_assertions)]
+#[cfg(any(debug_assertions, feature = "debugging"))]
 const MOVE_VM_TRACING_ENV_VAR_NAME: &str = "MOVE_VM_TRACE";
 
-#[cfg(debug_assertions)]
+#[cfg(any(debug_assertions, feature = "debugging"))]
 const MOVE_VM_STEPPING_ENV_VAR_NAME: &str = "MOVE_VM_STEP";
 
-#[cfg(debug_assertions)]
+#[cfg(any(debug_assertions, feature = "debugging"))]
 static FILE_PATH: Lazy<String> = Lazy::new(|| {
     env::var(MOVE_VM_TRACING_ENV_VAR_NAME).unwrap_or_else(|_| "move_vm_trace.trace".to_string())
 });
 
-#[cfg(debug_assertions)]
+#[cfg(any(debug_assertions, feature = "debugging"))]
 static TRACING_ENABLED: Lazy<bool> = Lazy::new(|| env::var(MOVE_VM_TRACING_ENV_VAR_NAME).is_ok());
 
-#[cfg(debug_assertions)]
+#[cfg(any(debug_assertions, feature = "debugging"))]
 static DEBUGGING_ENABLED: Lazy<bool> =
     Lazy::new(|| env::var(MOVE_VM_STEPPING_ENV_VAR_NAME).is_ok());
 
-#[cfg(debug_assertions)]
+#[cfg(any(debug_assertions, feature = "debugging"))]
 static LOGGING_FILE: Lazy<Mutex<File>> = Lazy::new(|| {
     Mutex::new(
         OpenOptions::new()
@@ -55,11 +55,11 @@ static LOGGING_FILE: Lazy<Mutex<File>> = Lazy::new(|| {
     )
 });
 
-#[cfg(debug_assertions)]
+#[cfg(any(debug_assertions, feature = "debugging"))]
 static DEBUG_CONTEXT: Lazy<Mutex<DebugContext>> = Lazy::new(|| Mutex::new(DebugContext::new()));
 
 // Only include in debug builds
-#[cfg(debug_assertions)]
+#[cfg(any(debug_assertions, feature = "debugging"))]
 pub(crate) fn trace(
     function_desc: &Function,
     locals: &Locals,
@@ -93,7 +93,7 @@ pub(crate) fn trace(
 macro_rules! trace {
     ($function_desc:expr, $locals:expr, $pc:expr, $instr:tt, $resolver:expr, $interp:expr) => {
         // Only include this code in debug releases
-        #[cfg(debug_assertions)]
+        #[cfg(any(debug_assertions, feature = "debugging"))]
         crate::tracing::trace(
             &$function_desc,
             $locals,

--- a/language/tools/move-cli/Cargo.toml
+++ b/language/tools/move-cli/Cargo.toml
@@ -36,7 +36,7 @@ move-compiler = { path = "../../move-compiler" }
 move-stdlib = { path = "../../move-stdlib", features = ["testing"] }
 move-symbol-pool = { path = "../../move-symbol-pool" }
 move-vm-types = { path = "../../move-vm/types" }
-move-vm-runtime = { path = "../../move-vm/runtime" }
+move-vm-runtime = { path = "../../move-vm/runtime", features = ["debugging"] }
 read-write-set = { path = "../read-write-set" }
 read-write-set-dynamic = { path = "../read-write-set/dynamic" }
 move-resource-viewer = { path = "../move-resource-viewer" }

--- a/language/tools/move-cli/tests/cli_tests.rs
+++ b/language/tools/move-cli/tests/cli_tests.rs
@@ -5,8 +5,12 @@ use move_cli::sandbox::commands::test;
 
 use std::path::PathBuf;
 
-pub const CLI_BINARY_PATH: [&str; 6] = ["..", "..", "..", "target", "debug", "move"];
 pub const CLI_METATEST_PATH: [&str; 3] = ["tests", "metatests", "args.txt"];
+
+#[cfg(debug_assertions)]
+pub const CLI_BINARY_PATH: [&str; 6] = ["..", "..", "..", "target", "debug", "move"];
+#[cfg(not(debug_assertions))]
+pub const CLI_BINARY_PATH: [&str; 6] = ["..", "..", "..", "target", "release", "move"];
 
 fn get_cli_binary_path() -> PathBuf {
     CLI_BINARY_PATH.iter().collect()
@@ -36,14 +40,18 @@ fn run_metatest() {
 
 #[test]
 fn cross_process_locking_git_deps() {
+    #[cfg(debug_assertions)]
+    const CLI_EXE: &str = "../../../../../../target/debug/move";
+    #[cfg(not(debug_assertions))]
+    const CLI_EXE: &str = "../../../../../../target/release/move";
     let handle = std::thread::spawn(|| {
-        std::process::Command::new("../../../../../../target/debug/move")
+        std::process::Command::new(CLI_EXE)
             .current_dir("./tests/cross_process_tests/Package1")
             .args(["package", "build"])
             .output()
             .expect("Package1 failed");
     });
-    std::process::Command::new("../../../../../../target/debug/move")
+    std::process::Command::new(CLI_EXE)
         .current_dir("./tests/cross_process_tests/Package2")
         .args(["package", "build"])
         .output()

--- a/language/tools/move-cli/tests/cli_testsuite.rs
+++ b/language/tools/move-cli/tests/cli_testsuite.rs
@@ -5,11 +5,16 @@ use move_cli::sandbox::commands::test;
 
 use std::path::{Path, PathBuf};
 
+#[cfg(debug_assertions)]
+const CLI_EXE: &str = "../../../target/debug/move";
+#[cfg(not(debug_assertions))]
+const CLI_EXE: &str = "../../../target/release/move";
+
 fn run_all(args_path: &Path) -> datatest_stable::Result<()> {
     let use_temp_dir = !args_path.parent().unwrap().join("NO_TEMPDIR").exists();
     test::run_one(
         args_path,
-        &PathBuf::from("../../../target/debug/move"),
+        &PathBuf::from(CLI_EXE),
         /* use_temp_dir */ use_temp_dir,
         /* track_cov */ false,
     )?;


### PR DESCRIPTION
PR #95 is experiencing stack overflows in some unrelated tests. After some analysis, it appears that is caused by some stress tests in `BCSTests` and `EventTests` which construct (via generics) types which have a nesting depth of 256 and are excercising the VALUE_DEPTH_MAX constant in the VM. In debug builds this constants value is simply to high, as it triggers the recursive computation of a TypeLayout.

This PR reduces the size of VALUE_DEPTH_MAX to 128 and adopts the existing tests accordingly. A max depth of 128 seems more than sufficient. (It means, in practice, that a user cannot nest more than 128 struct types.)

The PR also enables release builds of the Move CLI and therefore unit tests. This will allow in the future to analyze such failures, as it is well known that Rust in debug mode has huge stack consumption. However, it does not enable (yet) CI testing in release mode, because unfortunately, this would disable all kind of `debug_assert!` in our code. (We should eventually make all such assertions available also in release builds.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes


