### PR TITLE
[type] Add alias to StructTag for compatibility with old serialized json

### DIFF
--- a/language/move-core/types/src/language_storage.rs
+++ b/language/move-core/types/src/language_storage.rs
@@ -18,21 +18,21 @@ pub const CORE_CODE_ADDRESS: AccountAddress = AccountAddress::ONE;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Hash, Eq, Clone, PartialOrd, Ord)]
 pub enum TypeTag {
-    #[serde(rename = "bool")]
+    #[serde(rename = "bool", alias = "Bool")]
     Bool,
-    #[serde(rename = "u8")]
+    #[serde(rename = "u8", alias = "U8")]
     U8,
-    #[serde(rename = "u64")]
+    #[serde(rename = "u64", alias = "U64")]
     U64,
-    #[serde(rename = "u128")]
+    #[serde(rename = "u128", alias = "U128")]
     U128,
-    #[serde(rename = "address")]
+    #[serde(rename = "address", alias = "Address")]
     Address,
-    #[serde(rename = "signer")]
+    #[serde(rename = "signer", alias = "Signer")]
     Signer,
-    #[serde(rename = "vector")]
+    #[serde(rename = "vector", alias = "Vector")]
     Vector(Box<TypeTag>),
-    #[serde(rename = "struct")]
+    #[serde(rename = "struct", alias = "Struct")]
     Struct(StructTag),
 }
 
@@ -42,7 +42,7 @@ pub struct StructTag {
     pub module: Identifier,
     pub name: Identifier,
     // TODO: rename to "type_args" (or better "ty_args"?)
-    #[serde(rename = "type_args")]
+    #[serde(rename = "type_args", alias = "type_params")]
     pub type_params: Vec<TypeTag>,
 }
 

--- a/language/move-core/types/src/unit_tests/language_storage_test.rs
+++ b/language/move-core/types/src/unit_tests/language_storage_test.rs
@@ -1,13 +1,37 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::language_storage::ModuleId;
+use crate::language_storage::{ModuleId, StructTag, TypeTag};
 use bcs::test_helpers::assert_canonical_encode_decode;
 use proptest::prelude::*;
+use crate::account_address::AccountAddress;
+use crate::identifier::{Identifier, IdentStr};
 
 proptest! {
     #[test]
     fn test_module_id_canonical_roundtrip(module_id in any::<ModuleId>()) {
         assert_canonical_encode_decode(module_id);
     }
+}
+
+#[test]
+fn test_type_tag_deserialize_case_insensitive() {
+    let org_struct_tag = StructTag{
+        address: AccountAddress::ONE,
+        module: Identifier::from(IdentStr::new("TestModule").unwrap()),
+        name: Identifier::from(IdentStr::new("TestStruct").unwrap()),
+        type_params: vec![TypeTag::U8, TypeTag::U64, TypeTag::U128, TypeTag::Bool, TypeTag::Address,  TypeTag::Signer]
+    };
+
+    let upper_case_json = r#"
+    {"address":"0x00000000000000000000000000000001","module":"TestModule","name":"TestStruct","type_params":["U8","U64","U128","Bool","Address","Signer"]}
+    "#;
+    let upper_case_decoded = serde_json::from_str(&upper_case_json).unwrap();
+    assert_eq!(org_struct_tag, upper_case_decoded);
+
+    let lower_case_json = r#"
+    {"address":"0x00000000000000000000000000000001","module":"TestModule","name":"TestStruct","type_args":["u8","u64","u128","bool","address","signer"]}
+    "#;
+    let lower_case_decoded = serde_json::from_str(&lower_case_json).unwrap();
+    assert_eq!(org_struct_tag, lower_case_decoded);
 }

--- a/language/move-core/types/src/unit_tests/language_storage_test.rs
+++ b/language/move-core/types/src/unit_tests/language_storage_test.rs
@@ -26,12 +26,12 @@ fn test_type_tag_deserialize_case_insensitive() {
     let upper_case_json = r#"
     {"address":"0x00000000000000000000000000000001","module":"TestModule","name":"TestStruct","type_params":["U8","U64","U128","Bool","Address","Signer"]}
     "#;
-    let upper_case_decoded = serde_json::from_str(&upper_case_json).unwrap();
+    let upper_case_decoded = serde_json::from_str(upper_case_json).unwrap();
     assert_eq!(org_struct_tag, upper_case_decoded);
 
     let lower_case_json = r#"
     {"address":"0x00000000000000000000000000000001","module":"TestModule","name":"TestStruct","type_args":["u8","u64","u128","bool","address","signer"]}
     "#;
-    let lower_case_decoded = serde_json::from_str(&lower_case_json).unwrap();
+    let lower_case_decoded = serde_json::from_str(lower_case_json).unwrap();
     assert_eq!(org_struct_tag, lower_case_decoded);
 }


### PR DESCRIPTION

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

When the TypeTag add `serde(rename = "u8")`, this break the compatibility with old version, so add a `alias = "U8"` for compatibility.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)
Add a new unit test.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/diem/diem/tree/main/developers.diem.com, and link to your PR here.)

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
