### PR TITLE
Added a Move example to interact with the existing UniswapV2

### DIFF
--- a/language/evm/examples/sources/IERC20.move
+++ b/language/evm/examples/sources/IERC20.move
@@ -1,0 +1,23 @@
+#[interface]
+/// The interface for ERC-20.
+/// This module defines the API for the interface of ERC-20 and
+/// the utility functions such as selectors and `interfaceId`.
+module Evm::IERC20 {
+    use Evm::U256::{U256};
+
+    #[external(sig=b"transferFrom(address,address,uint) returns (bool)")]
+    public native fun call_transferFrom(contract: address, from: address, to: address, amount: U256): bool;
+
+    #[external(sig=b"approve(address,uint) returns (bool)")]
+    public native fun call_approve(contract: address, spender: address, amount: U256): bool;
+
+    #[external(sig=b"balanceOf(address) returns (uint)")]
+    public native fun call_balanceOf(contract: address, account: address): U256;
+
+    #[interface_id]
+    /// Return the interface identifier.
+    // TODO: complete this function.
+   public native fun interfaceId(): vector<u8>;
+
+    // TODO: complete this module.
+}

--- a/language/evm/examples/sources/IUniswapV2Factory.move
+++ b/language/evm/examples/sources/IUniswapV2Factory.move
@@ -1,0 +1,16 @@
+#[interface]
+/// The interface for UniswapV2Factory.
+/// This module defines the API for the interface of UniswapV2Factory and
+/// the utility functions such as selectors and `interfaceId`.
+module Evm::IUniswapV2Factory {
+
+    #[external(sig=b"getPair(address,address) returns (address)")]
+    public native fun call_getPair(contract: address, tokenA: address, tokenB: address): address;
+
+    #[interface_id]
+    /// Return the interface identifier.
+    // TODO: complete this function.
+   public native fun interfaceId(): vector<u8>;
+
+    // TODO: complete this module.
+}

--- a/language/evm/examples/sources/IUniswapV2Router.move
+++ b/language/evm/examples/sources/IUniswapV2Router.move
@@ -1,0 +1,23 @@
+#[interface]
+/// The interface for UniswapV2Router.
+/// This module defines the API for the interface of UniswapV2Router and
+/// the utility functions such as selectors and `interfaceId`.
+module Evm::IUniswapV2Router {
+    use Evm::U256::{U256};
+
+    #[external(sig=b"swapExactTokensForTokens(uint,uint,address[],address,uint) returns (uint[])")]
+    public native fun call_swapExactTokensForTokens(contract: address, amountIn: U256, amountOutMin: U256, path: vector<address>, to: address, deadline: U256): vector<U256>;
+
+    #[external(sig=b"addLiquidity(address,address,uint,uint,uint,uint,address) returns (uint,uint,uint)")]
+    public native fun call_addLiquidity(contract: address, tokenA: address, tokenB: address, amountADesired: U256, amountBDesired: U256, amountAMin: U256, amountBMin: U256, to: address, deadline: U256): (U256, U256, U256);
+
+    #[external(sig=b"removeLiquidity(address,address,uint,uint,uint,address,uint) returns (uint,uint)")]
+    public native fun call_removeLiquidity(contract: address, tokenA: address, tokenB: address, liquidity: U256, amountAMin: U256, amountBMin: U256, to: address, deadline: U256): (U256, U256);
+
+    #[interface_id]
+    /// Return the interface identifier.
+    // TODO: complete this function.
+   public native fun interfaceId(): vector<u8>;
+
+    // TODO: complete this module.
+}

--- a/language/evm/examples/sources/TestUniswap.move
+++ b/language/evm/examples/sources/TestUniswap.move
@@ -1,0 +1,48 @@
+// This module is to test the interaction with the existing dapp called UniswapV2.
+module Evm::TestUniswap {
+    use Evm::IERC20;
+    use Evm::IUniswapV2Router;
+    use Evm::U256::{Self, U256, u256_from_words};
+    use Evm::Evm::{sender, self, block_timestamp};
+    use Std::Vector;
+
+    // Swap tokenIn for tokenOut.
+    public fun swap(
+        tokenIn: address,
+        tokenOut: address,
+        amountIn: U256,
+        amountOutMin: U256,
+        to: address
+    ) {
+        // TODO: Replace these local constants with module-level constants once Move supports 20-bytes addresses and literals.
+        let const_UNISWAP_V2_ROUTER = U256::to_address(u256_from_words(0x7a250d56, 0x30B4cF539739dF2C5dAcb4c659F2488D));
+        let const_WETH = U256::to_address(u256_from_words(0xC02aaA39, 0xb223FE8D0A0e5C4F27eAD9083C756Cc2));
+
+        IERC20::call_transferFrom(tokenIn, sender(), self(), copy amountIn);
+        IERC20::call_approve(tokenIn, const_UNISWAP_V2_ROUTER, copy amountIn);
+
+        let path = Vector::empty<address>();
+
+        if(tokenIn == const_WETH || tokenOut == const_WETH) {
+            // Directly swapping tokenIn for tokenOut.
+            Vector::push_back(&mut path, tokenIn);
+            Vector::push_back(&mut path, tokenOut);
+        }
+        else {
+            // Swapping tokenIn for WETH, and then WETH for tokenOut.
+            // Bridging is needed because UniswapV2 cannot directly swap two ERC20 token types.
+            Vector::push_back(&mut path, tokenIn);
+            Vector::push_back(&mut path, const_WETH);
+            Vector::push_back(&mut path, tokenOut);
+        };
+
+        IUniswapV2Router::call_swapExactTokensForTokens(
+            const_UNISWAP_V2_ROUTER,
+            amountIn,
+            amountOutMin,
+            path,
+            to,
+            block_timestamp()
+        );
+    }
+}

--- a/language/evm/examples/sources/TestUniswapLiquidity.move
+++ b/language/evm/examples/sources/TestUniswapLiquidity.move
@@ -1,0 +1,61 @@
+// This module is to test the interaction with the existing dapp called UniswapV2.
+module Evm::TestUniswapLiquidity {
+    use Evm::IERC20;
+    use Evm::IUniswapV2Router;
+    use Evm::IUniswapV2Factory;
+    use Evm::U256::{Self, U256, u256_from_words};
+    use Evm::Evm::{sender, self, block_timestamp};
+
+    public fun addLiquidity(
+        tokenA: address,
+        tokenB: address,
+        amountA: U256,
+        amountB: U256,
+    ) {
+        // TODO: Replace these local constants with module-level constants once Move supports 20-bytes addresses and literals.
+        let const_ROUTER = U256::to_address(u256_from_words(0x7a250d56, 0x30B4cF539739dF2C5dAcb4c659F2488D));
+
+        IERC20::call_transferFrom(tokenA, sender(), self(), copy amountA);
+        IERC20::call_transferFrom(tokenB, sender(), self(), copy amountB);
+
+        IERC20::call_approve(tokenA, const_ROUTER, copy amountA);
+        IERC20::call_approve(tokenB, const_ROUTER, copy amountB);
+
+        let (_amountA, _amountB, _liquidity) = IUniswapV2Router::call_addLiquidity(
+            const_ROUTER,
+            tokenA,
+            tokenB,
+            amountA,
+            amountB,
+            U256::one(),
+            U256::one(),
+            self(),
+            block_timestamp()
+        );
+    }
+
+    public fun removeLiquidity(
+        tokenA: address,
+        tokenB: address,
+    ) {
+        // TODO: Replace these local constants with module-level constants once Move supports 20-bytes addresses and literals.
+        let const_FACTORY = U256::to_address(u256_from_words(0x5C69bEe7, 0x01ef814a2B6a3EDD4B1652CB9cc5aA6f));
+        let const_ROUTER = U256::to_address(u256_from_words(0x7a250d56, 0x30B4cF539739dF2C5dAcb4c659F2488D));
+
+        let pair = IUniswapV2Factory::call_getPair(const_FACTORY, tokenA, tokenB);
+
+        let liquidity = IERC20::call_balanceOf(pair, self());
+        IERC20::call_approve(pair, const_ROUTER, copy liquidity);
+
+        let (_amountA, _amountB) = IUniswapV2Router::call_removeLiquidity(
+            const_ROUTER,
+            tokenA,
+            tokenB,
+            liquidity,
+            U256::one(),
+            U256::one(),
+            self(),
+            block_timestamp()
+        );
+    }
+}

--- a/language/evm/stdlib/sources/U256.move
+++ b/language/evm/stdlib/sources/U256.move
@@ -28,4 +28,6 @@ module Evm::U256 {
     public fun one(): U256 {
         u256_from_words(0, 1)
     }
+
+    native public fun to_address(x: U256): address;
 }


### PR DESCRIPTION
This PR adds a user (client) contract of UniswapV2. The Move modules
interact with the existing UniswapV2 contract via the external functions
which are defined in the "interface" modules (e.g., `IERC20.move`). The
external functions define their signatures as attributes. For example,
`#[external(sig=b"transferFrom(address,address,uint) returns (bool)")]`

This PR also adds a couple of new native functions such as
`Evm::block_timestamp` and `U256::to_address`.

TODO: In this PR, Ethereum addresses (20 bytes long) are defined as
local variables (using `u256_from_words`) rather than module constants.
This can be fixed once Move supports 20 byte long addresses and
literals.

## Motivation

To add an example which interacts with some existing contract via external calls

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

cargo test

