### PR TITLE
Provide an option for using 32 byte address

### DIFF
--- a/language/move-core/types/Cargo.toml
+++ b/language/move-core/types/Cargo.toml
@@ -31,5 +31,6 @@ serde_json = "1.0.64"
 
 [features]
 address20 = []
+address32 = []
 default = []
 fuzzing = ["proptest", "proptest-derive"]

--- a/language/move-core/types/src/account_address.rs
+++ b/language/move-core/types/src/account_address.rs
@@ -18,7 +18,13 @@ impl AccountAddress {
 
     /// The number of bytes in an address.
     /// Default to 16 bytes, can be set to 20 bytes with address20 feature.
-    pub const LENGTH: usize = if cfg!(feature = "address20") { 20 } else { 16 };
+    pub const LENGTH: usize = if cfg!(feature = "address20") {
+        20
+    } else if cfg!(feature = "address32") {
+        32
+    } else {
+        16
+    };
 
     /// Hex address: 0x0
     pub const ZERO: Self = Self([0u8; Self::LENGTH]);


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

This PR is to provide an option for enabling 32 byte address as there could be more addresses needed for future aptos application scenarios.

The initial account authenticator, roughly the hash of the pubic keys for an account, represent the account address at the time of creation. At which point, a user can change their account authenticator to whatever they like. Right now, this is represented by 16 bytes, as a result, the only way to securely create these accounts without some sort of land grabbing is to require proof of key ownership. This is very unnatural in web3 space, where accounts can often be created as a by-product of another operation. In order to support that behavior, we must expand our account addresses to be back at 32-bytes.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

cargo test -p move-core-types passed
