### PR TITLE
[tools/docs] Add README for tools and packages

### DIFF
--- a/language/tools/README.md
+++ b/language/tools/README.md
@@ -1,0 +1,53 @@
+---
+id: tools
+title: Move Tools
+custom_edit_url: https://github.com/diem/move/edit/main/language/tools
+---
+
+# Summary
+
+Move has a number of tools associated with it. This directory contains all,
+or almost all of them. The following crates in this directory are libraries
+that are used by the [`move-cli`](./move-cli) `package` subcommand:
+
+* `move-bytecode-viewer`
+* `move-disassembler`
+* `move-explain`
+* `move-unit-test`
+* `move-package`
+* `move-coverage`
+
+In this sense each of these crates defines the core logic for a specific
+package command, e.g., how to run and report unit tests, or collect and
+display test coverage information. However, the Move CLI is responsible for
+stitching these commands together, e.g., when running a move unit test the
+Move CLI is responsible for first making sure the package was built in
+`test` mode ( using the `move-package` library), collecting the test plan
+to feed to the `move-unit-test` library, and returning a non-zero error
+code if a test fails.
+
+Generally, if you want to see how various tools interact with each other,
+or how a normal Move user would interact with these tools, you should first
+look at the Move CLI (specifically the `package` subdirectory/command) as
+that is responsible for stitching everything together. If you are looking
+for where the logic for a specific tool is defined, this is most likely in
+the specific crate for that tool (e.g., if you want to see how TUIs are
+handled for the `move-bytecode-viewer` that's defined in the
+`move-bytecode-viewer` crate, and not the `move-cli` crate).
+
+Some of the crates mentioned above are also binaries at the moment, however
+they should all be able to be made libaries only, with the possible
+exception of the `move-coverage` crate. The primary reason for this, is
+that this tool can collect and report test coverage statistics across
+multiple packages, and multiple runs over a package. This functionality is
+important if you have a large functional test suite such as Diem's and want
+to gather coverage information across all of them.
+
+The `move-resource-viewer`, and `read-write-set` similarly are library
+crates that are used by and exposed by the Move CLI, but not through the
+`package` subcommand.
+
+The `mirai-dataflow-analysis` and `move-bytecode-utils` crates are separate
+crates that are either experimental in nature, or libraries holding general
+utilities for working with Move bytecode, e.g., computing the dependency
+order for modules.

--- a/language/tools/move-package/README.md
+++ b/language/tools/move-package/README.md
@@ -1,0 +1,96 @@
+---
+id: move-package
+title: Move Package
+custom_edit_url: https://github.com/diem/move/edit/main/language/tools/move-package
+---
+
+# Summary
+
+The Move package crate contains the logic for parsing, resolving, and
+building Move packages. It is meant to be used as a library, both for
+building packages (e.g., by the Move CLI), or by other applications that
+may be working with Move packages. The package system is split into three
+main phases: parsing, resolution, and compilation.
+
+## Parsing and Manifest Layout
+
+The parsing and manifest layout logic is defined in the
+[`./src/source_package`](./src/source_package) directory. This defines the
+layout and the set of required and optional directories for a Move package
+in [`./src/source_package/layout.rs`](./src/source_package/layout.rs), it
+defines the format of the parsed Move package manifest ("`Move.toml`") in
+[`./src/source_package/parsed_manifest.rs`](./src/source_package/parsed_manifest.rs),
+and it defines the parser for the Move package manifest in
+[`./src/source_package/manifest_parser.rs`](./src/source_package/manifest_parser.rs).
+Note that we don't have a tokenizer/lexer as we use the TOML lexer. This
+also resolves git dependencies to where they will live on the local file
+system (but does not clone them).
+
+## Resolution
+
+The resolution phase is responsible for resolving all packages and building
+the package graph which represents the dependency relations between
+packages. It is also responsible for ensuring that all named addresses have
+a value assigned to them, and that there are no conflicting assignments.
+The package graph is rooted at the package being built and is a DAG.
+
+When building the package graph we do the following conceptual operations:
+verify that dependencies exist at the declared locations, that their
+package names and source digests match (if applicable), clone git
+dependencies if they don't already exist locally, build a dependency graph
+of Move packages and ensure this forms a DAG, compute an
+assignment for each named address in each Move package in the package
+graph, and ensure that the resulting named address assignment is valid.
+
+All of the above steps are fairly straightforward, with the possible
+exception of named addresses: each package will have a set of in-scope
+named addresses. The set of in-scope named addresses for a package `P` is
+defined as the transitive closure of all named addresses in the
+dependencies of `P`. Additionally, a package can rename named addresses
+that are in-scope as long as the final assignment of a value to the set of
+named addresses can be unified. To ensure that named addresses are
+unifiable across renamings, resolution performs unification across named
+addresses using a `Rc<RefCell<Opton<Address>>>`: when a named address first
+enters scope in the package graph a `Rc<RefCell<..>>` is created for it.
+This refcell is then shared to all uses of the named address _even across
+renamings_ and when a value is assigned to it, the value must (1) match the
+current value contained within the `Option`, or (2) the `Option` is `None`,
+and the value is placed into the refcell.
+
+## Compilation
+
+The final stage of the package system is compilation. All logic relating to
+the final build artifacts, or global environment creation, is contained in
+the [`./src/compilation`](./src/compilation) directory. The package layout
+for compiled Move packages is defined in
+[`./src/compilation/package_layout.rs`](./src/compilation/package_layout.rs).
+
+The [`./src/compilation/build_plan.rs`](./src/compilation/build_plan.rs)
+contains the logic for driving the compilation of a package and the
+compilation of all of the package's dependencies given a valid resolution
+graph. The logic in
+[`./src/compilation/compiled_package.rs`](./src/compilation/compiled_package.rs)
+contains the definition of the in-memory representation of compiled Move
+packages and other data structures and APIs relating to compiled Move
+packages, along with the logic for compiling a _single_ Move package
+assuming all of its dependencies are already compiled and saved to disk.
+This is driven by the logic in
+[`./src/compilation/build_plan.rs`](./src/compilation/build_plan.rs). The
+compilation process is also responsible for generating documentation, ABIs
+and the like, along with determining if a cached version of the
+to-be-built package already exists and if so, if the cached version
+can be used or if the cached copy is invalid and needs to be recompiled.
+
+One important thing to note here is that depending on the compilation
+flags, the caching policy may need to be updated and the `compiler_driver`
+function that is passed into the compilation process may change. However,
+what this function should be is determined by the client of the Move
+package library. In particular, when testing even if we are recompiling
+with the same flags we cannot cache the root package as we need to compile
+it to generate the test plan that will be used by the unit test runner
+later on. This gathering of the test plan is inserted into the compilation
+process via the `compiler_driver` function that is passed in by the client.
+In this case, the [`../move-cli/src/package`](../move-cli/src/package) is
+the client and it is responsible for supplying the correct function as the
+compiler driver to collect the test plan and to later pass that to the unit
+test runner.

--- a/language/tools/move-unit-test/README.md
+++ b/language/tools/move-unit-test/README.md
@@ -1,0 +1,64 @@
+---
+id: move-unit-test
+title: Move Unit Testing Framework
+custom_edit_url: https://github.com/diem/move/edit/main/language/tools/move-unit-test
+---
+
+# Summary
+
+This crate defines the core logic for running and reporting Move unit
+tests. Move unit testing is made up of two main components; a test runner,
+and a test reporter.
+
+It's important to also note here that unit tests can be run using the
+[stackless bytecode interpreter](../../move-prover/interpreter). If the
+unit tests are run with the stackless bytecode interpreter and the test
+returns a value, then the result of executing the unit test with the Move
+VM and the result of the interpreter will be compared and an error will
+be raised if they are not equal.
+
+Detailed information on how to use unit tests as a user of Move can be
+found [here](https://diem.github.io/move/unit-testing.html).
+
+## Test Runner
+
+The test runner consumes a
+[`TestPlan`](../../move-compiler/src/unit_test/mod.rs): this is a
+datastructure that is built by the Move compiler, based on source `#[test]`
+attributes. At a high level, this test plan consists of:
+1. A list of `ModuleTestPlan`s for each non-dependency module. A
+   `ModuleTestPlan` consists of a list of unit tests declared in a module,
+   along with its arguments and whether the unit test is an expected
+   failure or not.
+2. Compiled modules for each source module, along with compiled modules for
+   all transitive dependencies.
+3. The source text and source maps for every source and transitive dependency.
+
+The test runner takes this `TestPlan` along with various configuration
+options (e.g., number of threads). From this information the test runner
+creates an initial test state consisting solely of the modules in bullet
+(2) above. This will be the same initial state for all unit tests.
+
+After constructing this initial state, a work queue of `ModuleTestPlan`s is
+passed to a [`rayon`](https://docs.rs/rayon/latest/rayon/) threadpool to
+execute.  After the execution of each test a `PASS`, `FAIL` or `TIMEOUT` is
+reported to the writer (usually `std::io::stdout`) as soon as the test's
+result is known. The result of running tests in a `ModuleTestPlan` is a
+mapping of failing and passing tests (where failing means that the tests
+failed when it was expected to fail, or vis versa) along with profiling
+information and failure information if applicable. These test statistics
+for each module are combined in parallel and produce a `TestResults` data
+structure.
+
+## Test Reporter
+
+After all of the unit tests have been run and a `TestResults` data
+structure has been created, the test reporter will iterate through the test
+results, and will use the data in the `TestFailure` info along with the
+source maps and source text in the test plan to display source-level error
+messages for any failing tests.
+
+Depending on the options passed to the unit testing framework, additional
+info, such as the global storage state at the point of error for each
+failing test, or the execution time and number of instructions for each
+test may be display at the end of a test run.


### PR DESCRIPTION
This PR adds a README for the `tools` directory explaining technical details on how the various tools relate with one another and the Move CLI. It also adds READMEs to the `move-package` and `move-unit-test` crates which are primarily focused on providing a high-level technical overview of the crate.

This PR also adds a number of comments to the Move CLI package subcommand handler.