### PR TITLE
[evm] support arguments in evm-based unit tests

### DIFF
--- a/language/evm/move-to-yul/src/attributes.rs
+++ b/language/evm/move-to-yul/src/attributes.rs
@@ -131,5 +131,5 @@ pub fn is_evm_test_fun(fun: &FunctionEnv<'_>) -> bool {
 
 /// Check whether the function has a `#[test]` attribute.
 pub fn is_test_fun(fun: &FunctionEnv<'_>) -> bool {
-    has_attr(fun.module_env.env, fun.get_attributes(), TEST_ATTR, true)
+    has_attr(fun.module_env.env, fun.get_attributes(), TEST_ATTR, false)
 }

--- a/language/evm/move-to-yul/src/native_functions.rs
+++ b/language/evm/move-to-yul/src/native_functions.rs
@@ -43,7 +43,7 @@ impl NativeFunctions {
             ctx.env.error(
                 &gen.parent.contract_loc,
                 &format!(
-                    "native function `{}` not implemented for type `{:?}`",
+                    "native function {} not implemented (w/ signature `{:?}`)",
                     ctx.env
                         .get_function(fun_id.to_qualified_id())
                         .get_full_name_str(),

--- a/language/tools/move-unit-test/src/test_reporter.rs
+++ b/language/tools/move-unit-test/src/test_reporter.rs
@@ -37,6 +37,10 @@ pub enum FailureReason {
     Property(String),
     // The test failed for some unknown reason. This shouldn't be encountered
     Unknown(String),
+
+    // Failed to compile Move code into EVM bytecode.
+    #[cfg(feature = "evm-backend")]
+    MoveToEVMError(String),
 }
 
 #[derive(Debug, Clone, Ord, PartialOrd, PartialEq, Eq)]
@@ -115,6 +119,10 @@ impl FailureReason {
         FailureReason::Property(details)
     }
 
+    pub fn move_to_evm_error(diagnostics: String) -> Self {
+        FailureReason::MoveToEVMError(diagnostics)
+    }
+
     pub fn unknown() -> Self {
         FailureReason::Unknown("ITE: An unknown error was reported.".to_string())
     }
@@ -183,6 +191,14 @@ impl TestFailure {
                         .as_ref()
                         .map(|err| format!("{:#?}", err))
                         .unwrap_or_else(|| "".to_string()),
+                )
+            }
+
+            #[cfg(feature = "evm-backend")]
+            FailureReason::MoveToEVMError(diagnostics) => {
+                format!(
+                    "Failed to compile Move code into EVM bytecode.\n\n{}",
+                    diagnostics
                 )
             }
         };

--- a/language/tools/move-unit-test/tests/test_sources/address_args.evm.exp
+++ b/language/tools/move-unit-test/tests/test_sources/address_args.evm.exp
@@ -1,0 +1,5 @@
+Running Move unit tests
+[ PASS    ] 0x1::M::correct_address
+[ PASS    ] 0x1::M::correct_addresses
+[ PASS    ] 0x1::M::wrong_address
+Test result: OK. Total tests: 3; passed: 3; failed: 0

--- a/language/tools/move-unit-test/tests/test_sources/address_args.exp
+++ b/language/tools/move-unit-test/tests/test_sources/address_args.exp
@@ -1,0 +1,5 @@
+Running Move unit tests
+[ PASS    ] 0x1::M::correct_address
+[ PASS    ] 0x1::M::correct_addresses
+[ PASS    ] 0x1::M::wrong_address
+Test result: OK. Total tests: 3; passed: 3; failed: 0

--- a/language/tools/move-unit-test/tests/test_sources/address_args.move
+++ b/language/tools/move-unit-test/tests/test_sources/address_args.move
@@ -1,0 +1,20 @@
+address 0x1 {
+module M {
+    #[test(a = @0x42)]
+    fun correct_address(a: address) {
+        assert!(a == @0x42, 100);
+    }
+
+    #[test(a = @0x42, b = @0x43)]
+    fun correct_addresses(a: address, b: address) {
+        assert!(a == @0x42, 100);
+        assert!(b == @0x43, 101);
+    }
+
+    #[test(a = @0x42)]
+    #[expected_failure(abort_code = 100)]
+    fun wrong_address(a: address) {
+        assert!(a == @0x43, 100);
+    }
+}
+}

--- a/language/tools/move-unit-test/tests/test_sources/non_exsistent_native.evm.exp
+++ b/language/tools/move-unit-test/tests/test_sources/non_exsistent_native.evm.exp
@@ -1,0 +1,20 @@
+Running Move unit tests
+[ FAIL    ] 0x1::M::non_existent_native
+
+Test failures:
+
+Failures in 0x1::M:
+
+┌── non_existent_native ──────
+│ Failed to compile Move code into EVM bytecode.
+│ 
+│ error: native function M::foo not implemented (w/ signature `[]`)
+│   ┌─ <unknown>:1:1
+│   │
+│ 1 │ <unknown>
+│   │ ^
+│ 
+│ 
+└──────────────────
+
+Test result: FAILED. Total tests: 1; passed: 0; failed: 1

--- a/language/tools/move-unit-test/tests/test_sources/non_exsistent_native.exp
+++ b/language/tools/move-unit-test/tests/test_sources/non_exsistent_native.exp
@@ -1,0 +1,35 @@
+Running Move unit tests
+[ FAIL    ] 0x1::M::non_existent_native
+
+Test failures:
+
+Failures in 0x1::M:
+
+┌── non_existent_native ──────
+│ ITE: An unknown error was reported. Location: 
+│ VMError (if there is one): VMError {
+│     major_status: UNEXPECTED_VERIFIER_ERROR,
+│     sub_status: None,
+│     message: Some(
+│         "Unexpected verifier/deserialization error! This likely means there is code stored on chain that is unverifiable!\nError: VMError { major_status: MISSING_DEPENDENCY, sub_status: None, message: None, stacktrace: None, location: Module(ModuleId { address: 00000000000000000000000000000001, name: Identifier(\"M\") }), indices: [(FunctionHandle, 0)], offsets: [] }",
+│     ),
+│     stacktrace: None,
+│     location: Module(
+│         ModuleId {
+│             address: 00000000000000000000000000000001,
+│             name: Identifier(
+│                 "M",
+│             ),
+│         },
+│     ),
+│     indices: [
+│         (
+│             FunctionHandle,
+│             0,
+│         ),
+│     ],
+│     offsets: [],
+│ }
+└──────────────────
+
+Test result: FAILED. Total tests: 1; passed: 0; failed: 1

--- a/language/tools/move-unit-test/tests/test_sources/non_exsistent_native.move
+++ b/language/tools/move-unit-test/tests/test_sources/non_exsistent_native.move
@@ -1,0 +1,10 @@
+address 0x1 {
+module M {
+    native fun foo();
+
+    #[test]
+    fun non_existent_native() {
+        foo()
+    }
+}
+}

--- a/language/tools/move-unit-test/tests/test_sources/proposal_test.evm.exp
+++ b/language/tools/move-unit-test/tests/test_sources/proposal_test.evm.exp
@@ -1,0 +1,17 @@
+Running Move unit tests
+[ PASS    ] 0x1::Module::other_module_aborts
+[ PASS    ] 0x1::Module::tests_a
+[ PASS    ] 0x1::Module::tests_aborts
+[ PASS    ] 0x1::Module::tests_b
+[ PASS    ] 0x1::Module::tests_c
+[ FAIL    ] 0x1::Module::tests_d
+
+Test failures:
+
+Failures in 0x1::Module:
+
+┌── tests_d ──────
+│ Test was not expected to abort but it aborted with 3 here
+└──────────────────
+
+Test result: FAILED. Total tests: 6; passed: 5; failed: 1

--- a/language/tools/move-unit-test/tests/test_sources/signer_args.evm.exp
+++ b/language/tools/move-unit-test/tests/test_sources/signer_args.evm.exp
@@ -1,0 +1,22 @@
+Running Move unit tests
+[ FAIL    ] 0x1::M::multi_signer_fail
+[ PASS    ] 0x1::M::multi_signer_pass
+[ PASS    ] 0x1::M::multi_signer_pass_expected_failure
+[ FAIL    ] 0x1::M::single_signer_fail
+[ PASS    ] 0x1::M::single_signer_pass
+[ PASS    ] 0x1::M::test_correct_signer_arg_addrs
+
+Test failures:
+
+Failures in 0x1::M:
+
+┌── multi_signer_fail ──────
+│ Test did not abort as expected
+└──────────────────
+
+
+┌── single_signer_fail ──────
+│ Test was not expected to abort but it aborted with 0 here
+└──────────────────
+
+Test result: FAILED. Total tests: 6; passed: 4; failed: 2


### PR DESCRIPTION
This allows arguments (`#[test(a = ...)]`) to be used in EVM-based unit tests. 

It should be noted that right now, the unit test framework itself only supports address arguments (passed to parameters of `signer` or `address` types), so this is all we get for EVM-based unit tests.