### PR TITLE
Fix move-unit-test option collision

### DIFF
--- a/language/tools/move-unit-test/src/lib.rs
+++ b/language/tools/move-unit-test/src/lib.rs
@@ -67,7 +67,7 @@ pub struct UnitTestingConfig {
 
     #[structopt(
         name = "report_stacktrace_on_abort",
-        short = "t",
+        short = "r",
         long = "stacktrace_on_abort"
     )]
     pub report_stacktrace_on_abort: bool,


### PR DESCRIPTION
`-t` is already taken for `num_threads`. Use `-r` instead.