### PR TITLE
[move-book] Added block doc comment option

### DIFF
--- a/language/documentation/book/src/coding-conventions.md
+++ b/language/documentation/book/src/coding-conventions.md
@@ -65,7 +65,7 @@ module 0x1::Importer {
 ## Comments
 
 - Each module, struct, and public function declaration should be commented
-- Move has both doc comments `///`, regular single-line comments `//`, and block comments `/* */`
+- Move has doc comments `///`, regular single-line comments `//`, block comments `/* */`, and block doc comments `/** */`
 
 ## Formatting
 


### PR DESCRIPTION
Move seems to support block doc comments /** */.

It seems that the document does not make style recommendations on the
comment style, therefore listing all the possible comment options here.

**This PR was originally opened against `diem` repository: https://github.com/diem/diem/pull/9660**

(The Stale bot reminded me that the PR was still open)

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes (the whole file, the anchor "pull-requests" doesn't exist anymore).

## Test Plan
Documentation-only change (book).

## Related PRs
Original PR (now closed): https://github.com/diem/diem/pull/9660