### PR TITLE
[bug] fix tests broken for non-16 byte address

### DIFF
--- a/language/testing-infra/transactional-test-runner/src/tasks.rs
+++ b/language/testing-infra/transactional-test-runner/src/tasks.rs
@@ -24,10 +24,15 @@ pub enum RawAddress {
 }
 
 fn parse_address_literal(s: &str) -> Result<AccountAddress> {
-    let (number, _number_format) = move_compiler::shared::parse_u128(s)
-        .map_err(|e| anyhow!("Failed to parse address. Got error: {}", e))?;
+    let (array, _) = move_compiler::shared::parse_address(s).ok_or_else(|| {
+        anyhow!(
+            "Failed to parse address {} to AccountAddress with Length {}",
+            s,
+            AccountAddress::LENGTH
+        )
+    })?;
 
-    Ok(AccountAddress::new(number.to_be_bytes()))
+    Ok(AccountAddress::new(array))
 }
 
 impl RawAddress {

--- a/language/testing-infra/transactional-test-runner/src/vm_test_harness.rs
+++ b/language/testing-infra/transactional-test-runner/src/vm_test_harness.rs
@@ -33,8 +33,7 @@ use move_vm_test_utils::InMemoryStorage;
 use move_vm_types::gas_schedule::GasStatus;
 use once_cell::sync::Lazy;
 
-const STD_ADDR: AccountAddress =
-    AccountAddress::new([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]);
+const STD_ADDR: AccountAddress = AccountAddress::ONE;
 
 struct SimpleVMTestAdapter<'a> {
     compiled_state: CompiledState<'a>,


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

This is to solve the bugs identified in https://github.com/diem/move/issues/118. The current test has the assumption that the AccountAddress is 16-bytes and hard code this assumption in the code. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

 cargo test -p move-transactional-test-runner passed
cargo x lint && cargo xfmt && cargo xclippy --all-targets

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/diem/diem/tree/main/developers.diem.com, and link to your PR here.)

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
