### PR TITLE
Change type of `args` inputs to `execute_function_for_effects` to make it more flexible

### DIFF
--- a/language/move-vm/runtime/src/session.rs
+++ b/language/move-vm/runtime/src/session.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use std::borrow::Borrow;
+
 use crate::{data_cache::TransactionDataCache, runtime::VMRuntime};
 use move_binary_format::errors::*;
 use move_core_types::{
@@ -90,14 +92,17 @@ impl<'r, 'l, S: MoveResolver> Session<'r, 'l, S> {
     /// NOTE: The ability to deserialize `args` into arbitrary types is very powerful--e.g., it can
     /// used to manufacture `signer`'s or `Coin`'s from raw bytes. It is the respmsibility of the
     /// caller (e.g. adapter) to ensure that this power is useed responsibility/securely for its use-case.
-    pub fn execute_function_for_effects(
+    pub fn execute_function_for_effects<V>(
         mut self,
         module: &ModuleId,
         function_name: &IdentStr,
         ty_args: Vec<TypeTag>,
-        args: Vec<Vec<u8>>,
+        args: Vec<V>,
         gas_status: &mut GasStatus,
-    ) -> ExecutionResult {
+    ) -> ExecutionResult
+    where
+        V: Borrow<[u8]>,
+    {
         let gas_budget = gas_status.remaining_gas().get();
         let execution_res = self.runtime.execute_function_for_effects(
             module,


### PR DESCRIPTION
## Motivation

Currently function to enter VM execution take fully owned vectors of `[u8]` only to promptly deserialize them and drop the vectors. This requires VM users to continuously clone, and live with endless allocations / deallocations. 

The solution is to make the `args` input to `execute_function_for_effects` into an `args: Vec<V>`, with `V` being a generic type with `V: Borrow<[u8]>`. And fix called functions to do the same. This is purely a change of type and an addition of `.borrow()` to get a reference when needed, no other functionality changes. 

As a result, those who enjoy passing `Vec<u8>`s around can continue to do so, while others can pass in types that provide a &[u8] without allocations.

### Have you read the [Contributing Guidelines on pull requests]

Yes.

## Test Plan

All tests pass.
