### PR TITLE
[move-vm] Extension mechanism for VM state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4800,7 +4800,7 @@ version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ee73e6e4924fe940354b8d4d98cad5231175d615cd855b758adc658c0aac6a0"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "static_assertions",
 ]
 

--- a/language/move-binary-format/src/errors.rs
+++ b/language/move-binary-format/src/errors.rs
@@ -171,6 +171,8 @@ impl VMError {
     }
 }
 
+impl std::error::Error for VMError {}
+
 #[derive(Debug, Clone)]
 pub struct PartialVMError {
     major_status: StatusCode,

--- a/language/move-core/types/src/vm_status.rs
+++ b/language/move-core/types/src/vm_status.rs
@@ -660,6 +660,8 @@ pub enum StatusCode {
     CALL_STACK_OVERFLOW = 4021,
     VM_MAX_TYPE_DEPTH_REACHED = 4024,
     VM_MAX_VALUE_DEPTH_REACHED = 4025,
+    VM_EXTENSION_ERROR = 4026,
+
 
     // A reserved status to represent an unknown vm status.
     // this is std::u64::MAX, but we can't pattern match on that, so put the hardcoded value in

--- a/language/move-stdlib/src/natives/mod.rs
+++ b/language/move-stdlib/src/natives/mod.rs
@@ -13,8 +13,11 @@ pub mod unit_test;
 #[cfg(feature = "testing")]
 pub mod debug;
 
-use move_core_types::{account_address::AccountAddress, identifier::Identifier};
-use move_vm_runtime::native_functions::{NativeFunction, NativeFunctionTable};
+use move_core_types::account_address::AccountAddress;
+use move_vm_runtime::{
+    native_functions,
+    native_functions::{NativeFunction, NativeFunctionTable},
+};
 
 pub fn all_natives(move_std_addr: AccountAddress) -> NativeFunctionTable {
     const NATIVES: &[(&str, &str, NativeFunction)] = &[
@@ -46,16 +49,5 @@ pub fn all_natives(move_std_addr: AccountAddress) -> NativeFunctionTable {
             unit_test::native_create_signers_for_testing,
         ),
     ];
-    NATIVES
-        .iter()
-        .cloned()
-        .map(|(module_name, func_name, func)| {
-            (
-                move_std_addr,
-                Identifier::new(module_name).unwrap(),
-                Identifier::new(func_name).unwrap(),
-                func,
-            )
-        })
-        .collect()
+    native_functions::make_table(move_std_addr, NATIVES)
 }

--- a/language/move-vm/runtime/src/loader.rs
+++ b/language/move-vm/runtime/src/loader.rs
@@ -769,7 +769,11 @@ impl Loader {
     // Helpers for loading and verification
     //
 
-    fn load_type(&self, type_tag: &TypeTag, data_store: &impl DataStore) -> VMResult<Type> {
+    pub(crate) fn load_type(
+        &self,
+        type_tag: &TypeTag,
+        data_store: &impl DataStore,
+    ) -> VMResult<Type> {
         Ok(match type_tag {
             TypeTag::Bool => Type::Bool,
             TypeTag::U8 => Type::U8,

--- a/language/move-vm/types/src/gas_schedule.rs
+++ b/language/move-vm/types/src/gas_schedule.rs
@@ -457,6 +457,8 @@ pub fn calculate_intrinsic_gas(
     }
 }
 
+// TODO: need to refactor native gas calculation so it is extensible. Currently we
+// have hardcoded here the stdlib natives.
 #[allow(non_camel_case_types)]
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 #[repr(u8)]

--- a/language/move-vm/types/src/values/values_impl.rs
+++ b/language/move-vm/types/src/values/values_impl.rs
@@ -1,6 +1,7 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::loaded_data::runtime_types::Type;
 use move_binary_format::{
     errors::*,
     file_format::{Constant, SignatureToken},
@@ -2323,7 +2324,6 @@ pub mod debug {
  *   is to involve an explicit representation of the type layout.
  *
  **************************************************************************************/
-use crate::loaded_data::runtime_types::Type;
 use serde::{
     de::Error as DeError,
     ser::{Error as SerError, SerializeSeq, SerializeTuple},


### PR DESCRIPTION
[This PR has been split from #142 for better transparency of this new mechanism. There are a few more functions added to the VM which are useful helpers for #142 but have no obvious need in this PR; I left them here to not complicate the split too much.]

This adds an extension mechanism to the Move VM which allows native functions to access some state defined by the execution environment. The mechanism is based on the Rust `Any` type. New variantes of the execute functions in the session (`execute_XXX_with_env_ext`) which allow to pass in the extension which can then be consumed by natives.



No tests are in this PR as the VM doesn't have its own test suite but is tested indirectly via other crates; #142 contains a number of tests for this.


## Motivation

Extensible VM

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes
