### PR TITLE
allow EVM-based unit tests to be run through move-cli and fix some issues with the stackless-vm-based ones

### DIFF
--- a/language/evm/move-to-yul/src/generator.rs
+++ b/language/evm/move-to-yul/src/generator.rs
@@ -95,7 +95,12 @@ impl Generator {
     ) -> Result<String, String> {
         let fun = env
             .find_function_by_language_storage_id_name(module_id, fun_name)
-            .expect("Failed to find test function. This should not have happened.");
+            .unwrap_or_else(|| {
+                panic!(
+                    "Failed to find test function {}::{}. This should not have happened.",
+                    module_id, fun_name
+                )
+            });
 
         let ctx = Context::new(options, env, /*for_test*/ true);
         let mut gen = Generator::default();

--- a/language/tools/move-cli/Cargo.toml
+++ b/language/tools/move-cli/Cargo.toml
@@ -59,3 +59,16 @@ path = "src/main.rs"
 [[test]]
 name = "cli_testsuite"
 harness = false
+
+[[test]]
+name = "move_unit_tests_move_vm_and_stackless_vm"
+harness = false
+
+[[test]]
+name = "move_unit_tests_evm"
+harness = false
+required-features = ["evm-backend"]
+
+[features]
+default = ["evm-backend"]
+evm-backend = ["move-unit-test/evm-backend"]

--- a/language/tools/move-cli/tests/move_unit_tests/assign_dev_addr_for_dep/Move.toml
+++ b/language/tools/move-cli/tests/move_unit_tests/assign_dev_addr_for_dep/Move.toml
@@ -1,0 +1,15 @@
+[package]
+name = "Foo"
+version = "1.0.0"
+
+[addresses]
+A = "_"
+
+[dev-addresses]
+Std = "0x1"
+A = "0x2"
+B = "0x2"
+
+[dev-dependencies]
+MoveStdlib = { local = "../../../../../move-stdlib" }
+Bar = { local = "dep" }

--- a/language/tools/move-cli/tests/move_unit_tests/assign_dev_addr_for_dep/args.evm.exp
+++ b/language/tools/move-cli/tests/move_unit_tests/assign_dev_addr_for_dep/args.evm.exp
@@ -1,0 +1,7 @@
+Command `package test --evm`:
+BUILDING MoveStdlib
+BUILDING Bar
+BUILDING Foo
+Running Move unit tests
+[ PASS    ] 0x2::M::nop
+Test result: OK. Total tests: 1; passed: 1; failed: 0

--- a/language/tools/move-cli/tests/move_unit_tests/assign_dev_addr_for_dep/args.evm.txt
+++ b/language/tools/move-cli/tests/move_unit_tests/assign_dev_addr_for_dep/args.evm.txt
@@ -1,0 +1,1 @@
+package test --evm

--- a/language/tools/move-cli/tests/move_unit_tests/assign_dev_addr_for_dep/args.exp
+++ b/language/tools/move-cli/tests/move_unit_tests/assign_dev_addr_for_dep/args.exp
@@ -1,0 +1,7 @@
+Command `package test`:
+BUILDING MoveStdlib
+BUILDING Bar
+BUILDING Foo
+Running Move unit tests
+[ PASS    ] 0x2::M::nop
+Test result: OK. Total tests: 1; passed: 1; failed: 0

--- a/language/tools/move-cli/tests/move_unit_tests/assign_dev_addr_for_dep/args.stackless.exp
+++ b/language/tools/move-cli/tests/move_unit_tests/assign_dev_addr_for_dep/args.stackless.exp
@@ -1,0 +1,7 @@
+Command `package test --stackless`:
+BUILDING MoveStdlib
+BUILDING Bar
+BUILDING Foo
+Running Move unit tests
+[ PASS    ] 0x2::M::nop
+Test result: OK. Total tests: 1; passed: 1; failed: 0

--- a/language/tools/move-cli/tests/move_unit_tests/assign_dev_addr_for_dep/args.stackless.txt
+++ b/language/tools/move-cli/tests/move_unit_tests/assign_dev_addr_for_dep/args.stackless.txt
@@ -1,0 +1,1 @@
+package test --stackless

--- a/language/tools/move-cli/tests/move_unit_tests/assign_dev_addr_for_dep/args.txt
+++ b/language/tools/move-cli/tests/move_unit_tests/assign_dev_addr_for_dep/args.txt
@@ -1,0 +1,1 @@
+package test

--- a/language/tools/move-cli/tests/move_unit_tests/assign_dev_addr_for_dep/dep/Move.toml
+++ b/language/tools/move-cli/tests/move_unit_tests/assign_dev_addr_for_dep/dep/Move.toml
@@ -1,0 +1,9 @@
+[package]
+name = "Bar"
+version = "1.0.0"
+
+[addresses]
+B = "_"
+
+[dev-dependencies]
+MoveStdlib = { local = "../../../../../../move-stdlib" }

--- a/language/tools/move-cli/tests/move_unit_tests/assign_dev_addr_for_dep/dep/sources/M.move
+++ b/language/tools/move-cli/tests/move_unit_tests/assign_dev_addr_for_dep/dep/sources/M.move
@@ -1,0 +1,3 @@
+module B::N {
+    public fun nop() {}
+}

--- a/language/tools/move-cli/tests/move_unit_tests/assign_dev_addr_for_dep/sources/M.move
+++ b/language/tools/move-cli/tests/move_unit_tests/assign_dev_addr_for_dep/sources/M.move
@@ -1,0 +1,8 @@
+module A::M {
+    use B::N;
+
+    #[test]
+    fun nop() {
+        N::nop()
+    }
+}

--- a/language/tools/move-cli/tests/move_unit_tests/standalone_module_with_dev_addr_assignment/Move.toml
+++ b/language/tools/move-cli/tests/move_unit_tests/standalone_module_with_dev_addr_assignment/Move.toml
@@ -1,0 +1,13 @@
+[package]
+name = "StandaloneModule"
+version = "1.0.0"
+
+[addresses]
+A = "_"
+
+[dev-addresses]
+Std = "0x1"
+A = "0x2"
+
+[dev-dependencies]
+MoveStdlib = { local = "../../../../../move-stdlib" }

--- a/language/tools/move-cli/tests/move_unit_tests/standalone_module_with_dev_addr_assignment/args.evm.exp
+++ b/language/tools/move-cli/tests/move_unit_tests/standalone_module_with_dev_addr_assignment/args.evm.exp
@@ -1,0 +1,7 @@
+Command `package test --evm`:
+BUILDING MoveStdlib
+BUILDING StandaloneModule
+Running Move unit tests
+[ PASS    ] 0x2::M::explicit_abort_expect_failure
+[ PASS    ] 0x2::M::nop
+Test result: OK. Total tests: 2; passed: 2; failed: 0

--- a/language/tools/move-cli/tests/move_unit_tests/standalone_module_with_dev_addr_assignment/args.evm.txt
+++ b/language/tools/move-cli/tests/move_unit_tests/standalone_module_with_dev_addr_assignment/args.evm.txt
@@ -1,0 +1,1 @@
+package test --evm

--- a/language/tools/move-cli/tests/move_unit_tests/standalone_module_with_dev_addr_assignment/args.exp
+++ b/language/tools/move-cli/tests/move_unit_tests/standalone_module_with_dev_addr_assignment/args.exp
@@ -1,0 +1,7 @@
+Command `package test`:
+BUILDING MoveStdlib
+BUILDING StandaloneModule
+Running Move unit tests
+[ PASS    ] 0x2::M::explicit_abort_expect_failure
+[ PASS    ] 0x2::M::nop
+Test result: OK. Total tests: 2; passed: 2; failed: 0

--- a/language/tools/move-cli/tests/move_unit_tests/standalone_module_with_dev_addr_assignment/args.stackless.exp
+++ b/language/tools/move-cli/tests/move_unit_tests/standalone_module_with_dev_addr_assignment/args.stackless.exp
@@ -1,0 +1,7 @@
+Command `package test --stackless`:
+BUILDING MoveStdlib
+BUILDING StandaloneModule
+Running Move unit tests
+[ PASS    ] 0x2::M::explicit_abort_expect_failure
+[ PASS    ] 0x2::M::nop
+Test result: OK. Total tests: 2; passed: 2; failed: 0

--- a/language/tools/move-cli/tests/move_unit_tests/standalone_module_with_dev_addr_assignment/args.stackless.txt
+++ b/language/tools/move-cli/tests/move_unit_tests/standalone_module_with_dev_addr_assignment/args.stackless.txt
@@ -1,0 +1,1 @@
+package test --stackless

--- a/language/tools/move-cli/tests/move_unit_tests/standalone_module_with_dev_addr_assignment/args.txt
+++ b/language/tools/move-cli/tests/move_unit_tests/standalone_module_with_dev_addr_assignment/args.txt
@@ -1,0 +1,1 @@
+package test

--- a/language/tools/move-cli/tests/move_unit_tests/standalone_module_with_dev_addr_assignment/sources/M.move
+++ b/language/tools/move-cli/tests/move_unit_tests/standalone_module_with_dev_addr_assignment/sources/M.move
@@ -1,0 +1,10 @@
+module A::M {
+    #[test]
+    fun nop() {}
+
+    #[test]
+    #[expected_failure]
+    fun explicit_abort_expect_failure() {
+        abort 42
+    }
+}

--- a/language/tools/move-cli/tests/move_unit_tests/standalone_module_with_regular_addr_assignment/Move.toml
+++ b/language/tools/move-cli/tests/move_unit_tests/standalone_module_with_regular_addr_assignment/Move.toml
@@ -1,0 +1,12 @@
+[package]
+name = "StandaloneModule"
+version = "1.0.0"
+
+[addresses]
+A = "0x2"
+
+[dev-addresses]
+Std = "0x1"
+
+[dev-dependencies]
+MoveStdlib = { local = "../../../../../move-stdlib" }

--- a/language/tools/move-cli/tests/move_unit_tests/standalone_module_with_regular_addr_assignment/args.evm.exp
+++ b/language/tools/move-cli/tests/move_unit_tests/standalone_module_with_regular_addr_assignment/args.evm.exp
@@ -1,0 +1,7 @@
+Command `package test --evm`:
+BUILDING MoveStdlib
+BUILDING StandaloneModule
+Running Move unit tests
+[ PASS    ] 0x2::M::explicit_abort_expect_failure
+[ PASS    ] 0x2::M::nop
+Test result: OK. Total tests: 2; passed: 2; failed: 0

--- a/language/tools/move-cli/tests/move_unit_tests/standalone_module_with_regular_addr_assignment/args.evm.txt
+++ b/language/tools/move-cli/tests/move_unit_tests/standalone_module_with_regular_addr_assignment/args.evm.txt
@@ -1,0 +1,1 @@
+package test --evm

--- a/language/tools/move-cli/tests/move_unit_tests/standalone_module_with_regular_addr_assignment/args.exp
+++ b/language/tools/move-cli/tests/move_unit_tests/standalone_module_with_regular_addr_assignment/args.exp
@@ -1,0 +1,7 @@
+Command `package test`:
+BUILDING MoveStdlib
+BUILDING StandaloneModule
+Running Move unit tests
+[ PASS    ] 0x2::M::explicit_abort_expect_failure
+[ PASS    ] 0x2::M::nop
+Test result: OK. Total tests: 2; passed: 2; failed: 0

--- a/language/tools/move-cli/tests/move_unit_tests/standalone_module_with_regular_addr_assignment/args.stackless.exp
+++ b/language/tools/move-cli/tests/move_unit_tests/standalone_module_with_regular_addr_assignment/args.stackless.exp
@@ -1,0 +1,7 @@
+Command `package test --stackless`:
+BUILDING MoveStdlib
+BUILDING StandaloneModule
+Running Move unit tests
+[ PASS    ] 0x2::M::explicit_abort_expect_failure
+[ PASS    ] 0x2::M::nop
+Test result: OK. Total tests: 2; passed: 2; failed: 0

--- a/language/tools/move-cli/tests/move_unit_tests/standalone_module_with_regular_addr_assignment/args.stackless.txt
+++ b/language/tools/move-cli/tests/move_unit_tests/standalone_module_with_regular_addr_assignment/args.stackless.txt
@@ -1,0 +1,1 @@
+package test --stackless

--- a/language/tools/move-cli/tests/move_unit_tests/standalone_module_with_regular_addr_assignment/args.txt
+++ b/language/tools/move-cli/tests/move_unit_tests/standalone_module_with_regular_addr_assignment/args.txt
@@ -1,0 +1,1 @@
+package test

--- a/language/tools/move-cli/tests/move_unit_tests/standalone_module_with_regular_addr_assignment/sources/M.move
+++ b/language/tools/move-cli/tests/move_unit_tests/standalone_module_with_regular_addr_assignment/sources/M.move
@@ -1,0 +1,10 @@
+module A::M {
+    #[test]
+    fun nop() {}
+
+    #[test]
+    #[expected_failure]
+    fun explicit_abort_expect_failure() {
+        abort 42
+    }
+}

--- a/language/tools/move-cli/tests/move_unit_tests_evm.rs
+++ b/language/tools/move-cli/tests/move_unit_tests_evm.rs
@@ -22,4 +22,4 @@ fn run_all(args_path: &Path) -> datatest_stable::Result<()> {
 }
 
 // runs all the tests
-datatest_stable::harness!(run_all, "tests/testsuite", r"args\.txt$");
+datatest_stable::harness!(run_all, "tests/move_unit_tests", r"args\.evm\.txt$");

--- a/language/tools/move-cli/tests/move_unit_tests_move_vm_and_stackless_vm.rs
+++ b/language/tools/move-cli/tests/move_unit_tests_move_vm_and_stackless_vm.rs
@@ -22,4 +22,8 @@ fn run_all(args_path: &Path) -> datatest_stable::Result<()> {
 }
 
 // runs all the tests
-datatest_stable::harness!(run_all, "tests/testsuite", r"args\.txt$");
+datatest_stable::harness!(
+    run_all,
+    "tests/move_unit_tests",
+    r"args(\.stackless)?\.txt$"
+);


### PR DESCRIPTION
This allows EVM-based unit tests to be run through the move-cli and fixes some issues with the stackless-vm-based ones.

I've added some move-cli tests and manually checked that it can correctly launch the MoveStdlib unit tests. (Some MoveStdlib tests are failing due to `move-to-yul` issues, but that's a separate thing to fix...)

There are still some additional issues we need to sort out, but they are mostly about internal implementations/automated testing and shouldn't prevent you from running the tool manually (via `move-cli package test --evm`).

List of known issues:
1. Paths of some (removed) mv interface files are being passed into the move model builder. Currently I'm working around this by filtering out the paths that contain "mv_interfaces". This is a dirty hack only meant for the short term while I try to figure out the root cause.
2. `move-cli` is producing weird error messages in its own unit tests, preventing me from adding negative test cases. This doesn't seem to be an issue when you run the executable manually, which is actually concerning to me since this seem to imply we have different code paths for tests and manual invocations.
3. ~~The EVM or stackless-vm -based move cli unit tests should be gated behind the "evm-backend" feature flag~~ Done