### PR TITLE
[evm] Added unit tests for ERC20 and ERC1155 contracts

### DIFF
--- a/language/evm/examples/sources/Token.move
+++ b/language/evm/examples/sources/Token.move
@@ -1,6 +1,6 @@
 #[contract]
 /// An implementation of ERC20.
-module Evm::ERC20 {
+module Evm::ERC20Token {
     use Evm::Evm::{sender, self, sign};
     use Std::Errors;
     use Std::Vector;

--- a/language/evm/examples/tests/ERC1155Tests.move
+++ b/language/evm/examples/tests/ERC1155Tests.move
@@ -1,0 +1,81 @@
+module Evm::ERC1155Tests {
+    use Evm::Evm::sender;
+    use Evm::U256::{zero, one, u256_from_u128};
+    use Std::Vector;
+    use Evm::ERC1155;
+    use Std::ASCII::{string};
+
+    const Alice: address = @0x8877;
+    const Bob: address = @0x8888;
+
+    #[test]
+    fun test_create() {
+        ERC1155::create(string(Vector::empty<u8>()));
+    }
+
+    #[test]
+    fun test_balance_of() {
+        ERC1155::create(string(Vector::empty<u8>()));
+        let id1 = one();
+        let id2 = u256_from_u128(22);
+        assert!(ERC1155::balanceOf(sender(), id1) == zero(), 100);
+        assert!(ERC1155::balanceOf(sender(), id2) == zero(), 101);
+        assert!(ERC1155::balanceOf(Alice, id1) == zero(), 102);
+        assert!(ERC1155::balanceOf(Alice, id2) == zero(), 103);
+        assert!(ERC1155::balanceOf(Bob, id1) == zero(), 104);
+        assert!(ERC1155::balanceOf(Bob, id2) == zero(), 105);
+    }
+
+    #[test]
+    fun test_mint() {
+        ERC1155::create(string(Vector::empty<u8>()));
+
+        let id1 = one();
+        let id2 = u256_from_u128(22);
+        let dummy_data = Vector::empty<u8>();
+
+        ERC1155::mint(Alice, id1, u256_from_u128(100), copy dummy_data);
+        ERC1155::mint(Bob, id2, u256_from_u128(1000), copy dummy_data);
+
+        assert!(ERC1155::balanceOf(sender(), id1) == zero(), 106);
+        assert!(ERC1155::balanceOf(sender(), id2) == zero(), 107);
+        assert!(ERC1155::balanceOf(Alice, id1) == u256_from_u128(100), 108);
+        assert!(ERC1155::balanceOf(Alice, id2) == zero(), 109);
+        assert!(ERC1155::balanceOf(Bob, id1) == zero(), 110);
+        assert!(ERC1155::balanceOf(Bob, id2) == u256_from_u128(1000), 111);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = 124)]
+    fun test_transfer() {
+        ERC1155::create(string(Vector::empty<u8>()));
+
+        let id1 = one();
+        let id2 = u256_from_u128(22);
+        let dummy_data = Vector::empty<u8>();
+
+        ERC1155::mint(sender(), id1, u256_from_u128(100), copy dummy_data);
+        ERC1155::mint(sender(), id2, u256_from_u128(1000), copy dummy_data);
+
+        assert!(ERC1155::balanceOf(sender(), id1) == u256_from_u128(100), 112);
+        assert!(ERC1155::balanceOf(sender(), id2) == u256_from_u128(1000), 113);
+        assert!(ERC1155::balanceOf(Alice, id1) == zero(), 114);
+        assert!(ERC1155::balanceOf(Alice, id2) == zero(), 115);
+        assert!(ERC1155::balanceOf(Bob, id1) == zero(), 116);
+        assert!(ERC1155::balanceOf(Bob, id2) == zero(), 117);
+
+        ERC1155::safeTransferFrom(sender(), Alice, id1, u256_from_u128(20), copy dummy_data);
+        ERC1155::safeTransferFrom(sender(), Bob, id1, u256_from_u128(50), copy dummy_data);
+        ERC1155::safeTransferFrom(sender(), Alice, id2, u256_from_u128(300), copy dummy_data);
+        ERC1155::safeTransferFrom(sender(), Bob, id2, u256_from_u128(200), copy dummy_data);
+
+        assert!(ERC1155::balanceOf(sender(), id1) == u256_from_u128(30), 118);
+        assert!(ERC1155::balanceOf(sender(), id2) == u256_from_u128(500), 119);
+        assert!(ERC1155::balanceOf(Alice, id1) == u256_from_u128(20), 120);
+        assert!(ERC1155::balanceOf(Alice, id2) == u256_from_u128(300), 121);
+        assert!(ERC1155::balanceOf(Bob, id1) == u256_from_u128(50), 122);
+        assert!(ERC1155::balanceOf(Bob, id2) == u256_from_u128(200), 123);
+
+        assert!(ERC1155::balanceOf(sender(), id1) == u256_from_u128(100), 124); // expected to fail.
+    }
+}

--- a/language/evm/examples/tests/ERC20Tests.move
+++ b/language/evm/examples/tests/ERC20Tests.move
@@ -1,0 +1,37 @@
+module Evm::ERC20Tests {
+    use Evm::Evm::sender;
+    use Evm::U256::{zero, one, u256_from_u128};
+    use Std::Vector;
+    use Evm::ERC20;
+    use Std::ASCII::{string};
+
+    const Alice: address = @0x8877;
+    const Bob: address = @0x8888;
+
+    #[test]
+    fun test_create() {
+        ERC20::create(string(Vector::empty<u8>()), string(Vector::empty<u8>()), one());
+        assert!(ERC20::balanceOf(sender()) == one(), 100);
+        assert!(ERC20::balanceOf(Alice) == zero(), 101);
+        assert!(ERC20::balanceOf(Bob) == zero(), 102);
+    }
+
+    #[test]
+    fun test_balance_of() {
+        ERC20::create(string(Vector::empty<u8>()), string(Vector::empty<u8>()), one());
+        assert!(ERC20::balanceOf(sender()) == one(), 103);
+        assert!(ERC20::balanceOf(Alice) == zero(), 104);
+        assert!(ERC20::balanceOf(Bob) == zero(), 105);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = 109)]
+    fun test_transfer() {
+        ERC20::create(string(Vector::empty<u8>()), string(Vector::empty<u8>()), u256_from_u128(7));
+        ERC20::transfer(Alice, one());
+        assert!(ERC20::balanceOf(sender()) == u256_from_u128(6), 106);
+        assert!(ERC20::balanceOf(Alice) == one(), 107);
+        assert!(ERC20::balanceOf(Bob) == zero(), 108);
+        assert!(ERC20::balanceOf(sender()) == u256_from_u128(7), 109); // expected to fail
+    }
+}

--- a/language/evm/move-to-yul/src/native_functions.rs
+++ b/language/evm/move-to-yul/src/native_functions.rs
@@ -130,6 +130,16 @@ impl NativeFunctions {
             );
         });
 
+        self.define(ctx, evm, "self", |_, ctx: &Context, _| {
+            emitln!(
+                ctx.writer,
+                "\
+() -> addr {
+  addr := address()
+}"
+            );
+        });
+
         self.define(ctx, evm, "blockhash", |_, ctx: &Context, _| {
             emitln!(
                 ctx.writer,

--- a/language/evm/stdlib/sources/Evm.move
+++ b/language/evm/stdlib/sources/Evm.move
@@ -11,10 +11,14 @@ module Evm::Evm {
     public native fun self(): address;
 
     /// An alias for `msg_sender`.
-    public native fun sender(): address;
+    public fun sender(): address {
+        msg_sender()
+    }
 
     /// An alias for `msg_value`.
-    public native fun value(): U256;
+    public fun value(): U256 {
+        msg_value()
+    }
 
     /// Returns the balance, in Wei, of any account.
     public native fun balance(addr: address): U256;

--- a/language/move-stdlib/docs/ASCII.md
+++ b/language/move-stdlib/docs/ASCII.md
@@ -487,10 +487,10 @@ Unpack the <code>char</code> into its underlying byte.
 
 ## Function `is_valid_char`
 
-Returns <code><b>true</b></code> if <code>byte</code> is a valid ASCII character. Returns <code><b>false</b></code> otherwise.
+Returns <code><b>true</b></code> if <code>b</code> is a valid ASCII character. Returns <code><b>false</b></code> otherwise.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="ASCII.md#0x1_ASCII_is_valid_char">is_valid_char</a>(byte: u8): bool
+<pre><code><b>public</b> <b>fun</b> <a href="ASCII.md#0x1_ASCII_is_valid_char">is_valid_char</a>(b: u8): bool
 </code></pre>
 
 
@@ -499,8 +499,8 @@ Returns <code><b>true</b></code> if <code>byte</code> is a valid ASCII character
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="ASCII.md#0x1_ASCII_is_valid_char">is_valid_char</a>(byte: u8): bool {
-   <a href="ASCII.md#0x1_ASCII_byte">byte</a> &lt;= 0x7F
+<pre><code><b>public</b> <b>fun</b> <a href="ASCII.md#0x1_ASCII_is_valid_char">is_valid_char</a>(b: u8): bool {
+   b &lt;= 0x7F
 }
 </code></pre>
 

--- a/language/move-stdlib/sources/ASCII.move
+++ b/language/move-stdlib/sources/ASCII.move
@@ -136,9 +136,9 @@ module Std::ASCII {
        byte
     }
 
-    /// Returns `true` if `byte` is a valid ASCII character. Returns `false` otherwise.
-    public fun is_valid_char(byte: u8): bool {
-       byte <= 0x7F
+    /// Returns `true` if `b` is a valid ASCII character. Returns `false` otherwise.
+    public fun is_valid_char(b: u8): bool {
+       b <= 0x7F
     }
 
     /// Returns `true` if `byte` is an printable ASCII character. Returns `false` otherwise.


### PR DESCRIPTION
This PR adds some unit tests for ERC20 and ERC1155 contracts, so it
tests out both Emma's Table implementation and Victor's unit testing
support in CLI.

It turns out that the unit testing in move-cli has some issue. See a minimal
example to reproduce the issue in `evm/examples/tests/ERC20Tests.move`.
Instead, this PR adds the unit tests to the `cargo test` testsuite of
the the `move-to-yul` crate.

In addition, this PR:
- implements the "ownable" pattern for ERC1155, and made ERC1155
  mintable
- allows the initial supply for ERC20
- implements the translation of the native function `Evm::self()`

TODO:
- event-related code is commented out because it's not supported in unit testing at the moment.
- `Std::ASCII::is_valid_char` used to use the parameter name `byte` which is incompatible with the `move-to-yul` translation.

## Motivation

To test ERC contracts

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

cargo test
