### PR TITLE
[move-lang] Table extension.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -941,6 +941,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31ad93652f40969dead8d4bf897a41e9462095152eb21c56e5830537e41179dd"
 
 [[package]]
+name = "downcast-rs"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
+
+[[package]]
 name = "dtoa"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2140,6 +2146,7 @@ dependencies = [
  "move-resource-viewer",
  "move-stdlib",
  "move-symbol-pool",
+ "move-table-extension",
  "move-unit-test",
  "move-vm-runtime",
  "move-vm-types",
@@ -2650,6 +2657,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "move-table-extension"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "bcs",
+ "downcast-rs",
+ "itertools 0.10.1",
+ "move-binary-format",
+ "move-cli",
+ "move-command-line-common",
+ "move-compiler",
+ "move-core-types",
+ "move-package",
+ "move-stdlib",
+ "move-unit-test",
+ "move-vm-runtime",
+ "move-vm-types",
+ "once_cell",
+ "sha3 0.9.1",
+ "smallvec",
+ "tempfile",
+ "walkdir",
+ "workspace-hack",
+]
+
+[[package]]
 name = "move-to-yul"
 version = "0.1.0"
 dependencies = [
@@ -2737,6 +2770,7 @@ dependencies = [
  "difference",
  "evm",
  "evm-exec-utils",
+ "itertools 0.10.1",
  "move-binary-format",
  "move-bytecode-utils",
  "move-command-line-common",
@@ -2746,10 +2780,12 @@ dependencies = [
  "move-resource-viewer",
  "move-stackless-bytecode-interpreter",
  "move-stdlib",
+ "move-table-extension",
  "move-to-yul",
  "move-vm-runtime",
  "move-vm-test-utils",
  "move-vm-types",
+ "once_cell",
  "primitive-types",
  "rayon",
  "regex",
@@ -2765,6 +2801,7 @@ dependencies = [
  "move-compiler",
  "move-core-types",
  "move-stdlib",
+ "move-table-extension",
  "move-vm-runtime",
  "move-vm-test-utils",
  "move-vm-types",
@@ -2801,6 +2838,7 @@ dependencies = [
  "anyhow",
  "move-binary-format",
  "move-core-types",
+ "move-table-extension",
  "move-vm-runtime",
  "workspace-hack",
 ]
@@ -4823,7 +4861,7 @@ version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ee73e6e4924fe940354b8d4d98cad5231175d615cd855b758adc658c0aac6a0"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "static_assertions",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "language/evm/exec-utils",
     "language/evm/move-to-yul",
     "language/extensions/async/move-async-vm",
+    "language/extensions/move-table-extension",
     "language/move-analyzer",
     "language/move-binary-format",
     "language/move-binary-format/serializer-tests",

--- a/language/extensions/README.md
+++ b/language/extensions/README.md
@@ -1,0 +1,5 @@
+This tree contains extensions to the Move core language and runtime. Those extensions are not enabled by
+default but can be integrated into a Move-based environment following the instructions found for each individual
+extension.
+
+Some extensions may eventually become part of the core language after some period of stabilization.

--- a/language/extensions/move-table-extension/Cargo.toml
+++ b/language/extensions/move-table-extension/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "move-table-extension"
+version = "0.1.0"
+authors = ["Diem Association <opensource@diem.com>"]
+description = "Wrapper for the Move VM which coordinates multiple extensions"
+repository = "https://github.com/diem/move"
+license = "Apache-2.0"
+edition = "2018"
+publish = false
+
+[dependencies]
+anyhow = "1.0.52"
+downcast-rs = "1.2.0"
+walkdir = "2.3.1"
+itertools = "0.10.0"
+smallvec = "1.6.1"
+bcs = "0.1.2"
+sha3 = "0.9.1"
+once_cell = "1.7.2"
+move-command-line-common = { path = "../../move-command-line-common" }
+move-core-types = { path = "../../move-core/types" }
+move-compiler = { path = "../../move-compiler" }
+move-vm-types = { path = "../../move-vm/types" }
+move-vm-runtime = { path = "../../move-vm/runtime", features = ["debugging"] }
+move-binary-format = { path = "../../move-binary-format" }
+workspace-hack = { version = "0.1", path = "../../../crates/workspace-hack" }
+
+[dev-dependencies]
+move-stdlib = { path = "../../move-stdlib", features = ["testing"] }
+move-unit-test = { path = "../../tools/move-unit-test", features = ["table-extension"] }
+tempfile = "3.2.0"
+#dir-diff = "0.3.2"
+#file_diff = "1.0.0"
+move-cli = { path = "../../tools/move-cli" }
+move-package = { path = "../../tools/move-package" }

--- a/language/extensions/move-table-extension/Move.toml
+++ b/language/extensions/move-table-extension/Move.toml
@@ -1,0 +1,14 @@
+[package]
+name = "MoveTableExtension"
+version = "1.0.0"
+
+[addresses]
+Std = "_"
+Extensions = "_"
+
+[dev-addresses]
+Std = "0x1"
+Extensions = "0x2"
+
+[dependencies]
+MoveStdlib = { local = "../../move-stdlib" }

--- a/language/extensions/move-table-extension/README.md
+++ b/language/extensions/move-table-extension/README.md
@@ -1,0 +1,36 @@
+This crate contains an extension to the Move language with large-scale storage tables.
+
+In order to use this extension with the Move CLI and package system, you need to compile with
+`feature = ["table-extension"]`.
+
+In order to use this extension in your adapter, you do something as follows:
+
+```rust
+use move_core_types::account_address::AccountAddress;
+use move_stdlib::natives;
+use move_table_extension::NativeTableContext;
+use move_vm_runtime::move_vm::MoveVM;
+use move_vm_runtime::native_functions::NativeContextExtensions;
+
+fn run() {
+    let resource_resolver = unimplemented!(); // a resource resolver the adapter provides
+    let txn_hash = unimplemented!(); // a unique hash for table creation for this transaction
+    let table_resolver = unimplemented!(); // a remote table resover the adapter provides
+    let std_addr = unimplemented!(); // address where to deploy the std lib
+    let extension_addr = unimplemented!(); // address where to deploy the table extension
+
+    let mut extensions = NativeContextExtensions::default();
+    extensions.add(NativeTableContext::new(txn_hash, table_resolver));
+    let mut natives = move_stdlib::natives::all_natives(std_addr);
+    natives.append(&mut move_table_extension::table_natives(extension_addr));
+    let vm = MoveVM::new(natives);
+
+    let session = vm.new_session_with_extensions(resource_resolver, extensions);
+    let result = session.execute_function(..)?;
+    let (change_set, events, extensions) = session.finish_with_extensions()?;
+    let table_change_set = extensions.get::<NativeTableContext>().into_change_set();
+
+    // Do something with the table change set
+    // ...
+}
+```

--- a/language/extensions/move-table-extension/sources/Table.move
+++ b/language/extensions/move-table-extension/sources/Table.move
@@ -1,0 +1,94 @@
+/// Type of large-scale storage tables.
+module Extensions::Table {
+    /// Type of tables
+    struct Table<phantom K, phantom V> has store {
+        handle: u128
+    }
+
+    /// Create a new Table.
+    public fun new<K, V: store>(): Table<K, V> {
+        Table{handle: new_table_handle()}
+    }
+
+    /// Destroy a table. The table must be empty to succeed.
+    public fun destroy_empty<K, V>(table: Table<K, V>) {
+        destroy_empty_box<K, V, Box<V>>(&table);
+        drop_unchecked_box<K, V, Box<V>>(table)
+    }
+
+    /// Add a new entry to the table. Aborts if an entry for this
+    /// key already exists. The entry itself is not stored in the
+    /// table, and cannot be discovered from it.
+    public fun add<K, V>(table: &mut Table<K, V>, key: &K, val: V) {
+        add_box<K, V, Box<V>>(table, key, Box{val})
+    }
+
+    /// Acquire an immutable reference to the value which `key` maps to.
+    /// Aborts if there is no entry for `key`.
+    public fun borrow<K, V>(table: &Table<K, V>, key: &K): &V {
+        &borrow_box<K, V, Box<V>>(table, key).val
+    }
+
+    /// Acquire a mutable reference to the value which `key` maps to.
+    /// Aborts if there is no entry for `key`.
+    public fun borrow_mut<K, V>(table: &mut Table<K, V>, key: &K): &mut V {
+        &mut borrow_box_mut<K, V, Box<V>>(table, key).val
+    }
+
+    /// Returns the length of the table, i.e. the number of entries.
+    public fun length<K, V>(table: &Table<K, V>): u64 {
+        length_box<K, V, Box<V>>(table)
+    }
+
+    /// Returns true if this table is empty.
+    public fun empty<K, V>(table: &Table<K, V>): bool {
+        length(table) == 0
+    }
+
+    /// Acquire a mutable reference to the value which `key` maps to.
+    /// Insert the pair (`key`, `default`) first if there is no entry for `key`.
+    public fun borrow_mut_with_default<K, V: drop>(table: &mut Table<K, V>, key: &K, default: V): &mut V {
+        if (!contains(table, key)) {
+            add(table, key, default)
+        };
+        borrow_mut(table, key)
+    }
+
+    /// Remove from `table` and return the value which `key` maps to.
+    /// Aborts if there is no entry for `key`.
+    public fun remove<K, V>(table: &mut Table<K, V>, key: &K): V {
+        let Box{val} = remove_box<K, V, Box<V>>(table, key);
+        val
+    }
+
+    /// Returns true iff `table` contains an entry for `key`.
+    public fun contains<K, V>(table: &Table<K, V>, key: &K): bool {
+        contains_box<K, V, Box<V>>(table, key)
+    }
+
+    #[test_only]
+    /// Testing only: allows to drop a table even if it is not empty.
+    public fun drop_unchecked<K, V>(table: Table<K, V>) {
+        drop_unchecked_box<K, V, Box<V>>(table)
+    }
+
+    // ======================================================================================================
+    // Internal API
+
+    /// Wrapper for values. Required for making values appear as resources in the implementation.
+    struct Box<V> has key, drop, store {
+        val: V
+    }
+
+    // Primitives which take as an additional type parameter `Box<V>`, so the implementation
+    // can use this to determine serialization layout.
+    native fun new_table_handle(): u128;
+    native fun add_box<K, V, B>(table: &mut Table<K, V>, key: &K, val: Box<V>);
+    native fun borrow_box<K, V, B>(table: &Table<K, V>, key: &K): &Box<V>;
+    native fun borrow_box_mut<K, V, B>(table: &mut Table<K, V>, key: &K): &mut Box<V>;
+    native fun length_box<K, V, B>(table: &Table<K, V>): u64;
+    native fun contains_box<K, V, B>(table: &Table<K, V>, key: &K): bool;
+    native fun remove_box<K, V, B>(table: &mut Table<K, V>, key: &K): Box<V>;
+    native fun destroy_empty_box<K, V, B>(table: &Table<K, V>);
+    native fun drop_unchecked_box<K, V, B>(table: Table<K, V>);
+}

--- a/language/extensions/move-table-extension/src/lib.rs
+++ b/language/extensions/move-table-extension/src/lib.rs
@@ -1,0 +1,606 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! A crate which extends Move by tables.
+//!
+//! See [`Table.move`](../sources/Table.move) for language use.
+//! See [`README.md`](../README.md) for integration into an adapter.
+
+use move_binary_format::errors::{PartialVMError, PartialVMResult};
+use move_core_types::{
+    account_address::AccountAddress,
+    gas_schedule::{GasAlgebra, GasCarrier, InternalGasUnits},
+    value::MoveTypeLayout,
+    vm_status::StatusCode,
+};
+use move_vm_runtime::{
+    native_functions,
+    native_functions::{NativeContext, NativeFunctionTable},
+};
+use move_vm_types::{
+    loaded_data::runtime_types::Type,
+    natives::function::NativeResult,
+    pop_arg,
+    values::{GlobalValue, GlobalValueEffect, Reference, StructRef, Value},
+};
+use once_cell::sync::Lazy;
+use sha3::{Digest, Sha3_256};
+use smallvec::smallvec;
+use std::{
+    cell::RefCell,
+    collections::{btree_map::Entry, BTreeMap, BTreeSet, VecDeque},
+    convert::TryInto,
+    fmt::Display,
+};
+
+// ===========================================================================================
+// Public Data Structures and Constants
+
+/// The representation of a table handle. This is created from truncating a sha3-256 based
+/// hash over a transaction hash provided by the environment and a table creation counter
+/// local to the transaction.
+#[derive(Copy, Clone, Debug, PartialOrd, Ord, PartialEq, Eq)]
+pub struct TableHandle(pub u128);
+
+impl Display for TableHandle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "T-{:X}", self.0)
+    }
+}
+
+/// A table change set.
+#[derive(Default)]
+pub struct TableChangeSet {
+    pub new_tables: BTreeSet<TableHandle>,
+    pub removed_tables: BTreeSet<TableHandle>,
+    pub changes: BTreeMap<TableHandle, TableChange>,
+}
+
+/// A change of a single table.
+pub struct TableChange {
+    pub entries: BTreeMap<Vec<u8>, Option<Vec<u8>>>,
+}
+
+/// A table resolver which needs to be provided by the environment. This allows to lookup
+/// data in remote storage, as well as retrieve cost of table operations.
+pub trait TableResolver {
+    fn resolve_table_entry(
+        &self,
+        handle: &TableHandle,
+        key: &[u8],
+    ) -> Result<Option<Vec<u8>>, anyhow::Error>;
+
+    fn table_size(&self, handle: &TableHandle) -> Result<usize, anyhow::Error>;
+
+    fn operation_cost(
+        &self,
+        op: TableOperation,
+        key_size: usize,
+        val_size: usize,
+    ) -> InternalGasUnits<GasCarrier>;
+}
+
+/// A table operation, for supporting cost calculation.
+pub enum TableOperation {
+    NewHandle,
+    Destroy,
+    Insert,
+    Borrow,
+    Length,
+    Remove,
+    Contains,
+}
+
+/// The native table context extension. This needs to be attached to the NativeContextExtensions
+/// value which is passed into session functions, so its accessible from natives of this
+/// extension.
+pub struct NativeTableContext<'a> {
+    resolver: &'a dyn TableResolver,
+    txn_hash: u128,
+    table_data: RefCell<TableData>,
+}
+
+pub static ALREADY_EXISTS: Lazy<u64> = Lazy::new(|| unique_sub_status_code(0));
+pub static NOT_FOUND: Lazy<u64> = Lazy::new(|| unique_sub_status_code(1));
+pub static NOT_EMPTY: Lazy<u64> = Lazy::new(|| unique_sub_status_code(2));
+
+// ===========================================================================================
+// Private Data Structures and Constants
+
+/// A structure representing mutable data of the NativeTableContext. This is in a RefCell
+/// of the overall context so we can mutate while still accessing the overall context.
+#[derive(Default)]
+struct TableData {
+    new_tables: BTreeSet<TableHandle>,
+    removed_tables: BTreeSet<TableHandle>,
+    tables: BTreeMap<TableHandle, Table>,
+}
+
+/// A structure representing a single table.
+struct Table {
+    handle: TableHandle,
+    key_layout: MoveTypeLayout,
+    value_layout: MoveTypeLayout,
+    content: BTreeMap<Vec<u8>, GlobalValue>,
+    size_delta: i64, // The sum of added and removed entries
+}
+
+/// The field index of the `handle` field in the `Table` Move struct.
+const HANDLE_FIELD_INDEX: usize = 0;
+
+// =========================================================================================
+// Implementation of Native Table Context
+
+impl<'a> NativeTableContext<'a> {
+    /// Create a new instance of a native table context. This must be passed in via an
+    /// extension into VM session functions.
+    pub fn new(txn_hash: u128, resolver: &'a dyn TableResolver) -> Self {
+        Self {
+            resolver,
+            txn_hash,
+            table_data: Default::default(),
+        }
+    }
+
+    /// Computes the change set from a NativeTableContext.
+    pub fn into_change_set(self) -> PartialVMResult<TableChangeSet> {
+        let NativeTableContext { table_data, .. } = self;
+        let TableData {
+            new_tables,
+            removed_tables,
+            tables,
+        } = table_data.into_inner();
+        let mut changes = BTreeMap::new();
+        for (handle, table) in tables {
+            let Table {
+                value_layout,
+                content,
+                ..
+            } = table;
+            let mut entries = BTreeMap::new();
+            for (key, gv) in content {
+                match gv.into_effect()? {
+                    GlobalValueEffect::Deleted => {
+                        entries.insert(key, None);
+                    }
+                    GlobalValueEffect::Changed(new_val) => {
+                        let new_bytes = serialize(&value_layout, &new_val)?;
+                        entries.insert(key, Some(new_bytes));
+                    }
+                    _ => {}
+                }
+            }
+            if !entries.is_empty() {
+                changes.insert(handle, TableChange { entries });
+            }
+        }
+        Ok(TableChangeSet {
+            new_tables,
+            removed_tables,
+            changes,
+        })
+    }
+}
+
+impl TableData {
+    /// Gets or creates a new table in the TableData. This initializes information about
+    /// the table, like the type layout for keys and values.
+    fn get_or_create_table(
+        &mut self,
+        context: &NativeContext,
+        handle: TableHandle,
+        key_ty: &Type,
+        value_ty: &Type,
+    ) -> PartialVMResult<&mut Table> {
+        if let Entry::Vacant(e) = self.tables.entry(handle) {
+            let key_layout = get_type_layout(context, key_ty)?;
+            let value_layout = get_type_layout(context, value_ty)?;
+            let table = Table {
+                handle,
+                key_layout,
+                value_layout,
+                size_delta: 0,
+                content: Default::default(),
+            };
+            e.insert(table);
+        }
+        Ok(self.tables.get_mut(&handle).unwrap())
+    }
+}
+
+impl Table {
+    /// Inserts a value into a table.
+    fn insert(
+        &mut self,
+        context: &NativeTableContext,
+        key: &Value,
+        val: Value,
+    ) -> PartialVMResult<(usize, usize)> {
+        let (gv_opt, _, _) = self.global_value(context, key)?;
+        if gv_opt.is_some() {
+            return Err(partial_abort_error(
+                "table entry already occupied",
+                *ALREADY_EXISTS,
+            ));
+        }
+        let key_bytes = serialize(&self.key_layout, key)?;
+        let key_size = key_bytes.len();
+        // Need to serialize for cost computation
+        let val_size = serialize(&self.value_layout, &val)?.len();
+        self.content
+            .entry(key_bytes)
+            .or_insert_with(GlobalValue::none)
+            .move_to(val)?;
+        self.size_delta += 1;
+        Ok((key_size, val_size))
+    }
+
+    /// Borrows a reference to a table (mutable or immutable).
+    fn borrow_global(
+        &mut self,
+        context: &NativeTableContext,
+        key: &Value,
+    ) -> PartialVMResult<(Value, usize, usize)> {
+        let (gv_opt, key_size, val_size) = self.global_value(context, key)?;
+        let gv = gv_opt.ok_or_else(|| partial_abort_error("undefined table entry", *NOT_FOUND))?;
+        let val = gv.borrow_global()?;
+        Ok((val, key_size, val_size))
+    }
+
+    /// Removes an entry from a table.
+    fn remove(
+        &mut self,
+        context: &NativeTableContext,
+        key: &Value,
+    ) -> PartialVMResult<(Value, usize, usize)> {
+        let (gv_opt, key_size, val_size) = self.global_value(context, key)?;
+        let gv = gv_opt.ok_or_else(|| partial_abort_error("undefined table entry", *NOT_FOUND))?;
+        let val = gv.move_from()?;
+        self.size_delta -= 1;
+        Ok((val, key_size, val_size))
+    }
+
+    /// Checks whether a key is in the table.
+    fn contains(
+        &mut self,
+        context: &NativeTableContext,
+        key: &Value,
+    ) -> PartialVMResult<(Value, usize, usize)> {
+        let (gv_opt, key_size, val_size) = self.global_value(context, key)?;
+        let val = Value::bool(gv_opt.and_then(|v| v.exists().ok()).unwrap_or(false));
+        Ok((val, key_size, val_size))
+    }
+
+    /// Compute the size of a table.
+    fn length(&mut self, context: &NativeTableContext) -> PartialVMResult<(u64, usize, usize)> {
+        let remote_size = context
+            .resolver
+            .table_size(&self.handle)
+            .map_err(|err| partial_extension_error(format!("remote table size failed: {}", err)))?;
+        let effective_size = (remote_size as i128) + (self.size_delta as i128);
+        if effective_size < 0 {
+            Err(partial_extension_error("inconsistent table size"))
+        } else {
+            Ok((effective_size as u64, 0, 0))
+        }
+    }
+
+    /// Destroys a table.
+    fn destroy_empty(&mut self, context: &NativeTableContext) -> PartialVMResult<(usize, usize)> {
+        let (len, _, _) = self.length(context)?;
+        if len > 0 {
+            Err(partial_abort_error(
+                "table is not empty and cannot be destroyed",
+                *NOT_EMPTY,
+            ))
+        } else {
+            Ok((0, 0))
+        }
+    }
+
+    /// Gets the global value of an entry in the table. Attempts to retrieve a value from
+    /// the resolver if needed. Aborts if the value does not exists. Also returns the size
+    /// of the key and value (if a value needs to be fetched from remote) for cost computation.
+    fn global_value(
+        &mut self,
+        context: &NativeTableContext,
+        key: &Value,
+    ) -> PartialVMResult<(Option<&mut GlobalValue>, usize, usize)> {
+        let key_bytes = serialize(&self.key_layout, key)?;
+        let key_size = key_bytes.len();
+        let mut val_size = 0;
+        if !self.content.contains_key(&key_bytes) {
+            // Try to retrieve a value from the remote resolver.
+            match context
+                .resolver
+                .resolve_table_entry(&self.handle, &key_bytes)
+                .map_err(|err| {
+                    partial_extension_error(format!("remote table resolver failure: {}", err))
+                })? {
+                Some(val_bytes) => {
+                    val_size = val_bytes.len();
+                    let val = deserialize(&self.value_layout, &val_bytes)?;
+                    self.content
+                        .entry(key_bytes.clone())
+                        .or_insert(GlobalValue::cached(val)?);
+                }
+                None => return Ok((None, key_size, val_size)),
+            }
+        }
+        Ok((
+            Some(self.content.get_mut(&key_bytes).unwrap()),
+            key_size,
+            val_size,
+        ))
+    }
+}
+
+// =========================================================================================
+// Native Function Implementations
+
+/// Returns all natives for tables.
+pub fn table_natives(table_addr: AccountAddress) -> NativeFunctionTable {
+    native_functions::make_table(
+        table_addr,
+        &[
+            ("Table", "new_table_handle", native_new_table_handle),
+            ("Table", "add_box", native_add_box),
+            ("Table", "length_box", native_length_box),
+            ("Table", "borrow_box", native_borrow_box),
+            ("Table", "borrow_box_mut", native_borrow_box),
+            ("Table", "remove_box", native_remove_box),
+            ("Table", "contains_box", native_contains_box),
+            ("Table", "destroy_empty_box", native_destroy_empty_box),
+            ("Table", "drop_unchecked_box", native_drop_unchecked_box),
+        ],
+    )
+}
+
+fn native_new_table_handle(
+    context: &mut NativeContext,
+    mut _ty_args: Vec<Type>,
+    args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    assert!(args.is_empty());
+
+    let table_context = context.extensions().get::<NativeTableContext>();
+    let mut table_data = table_context.table_data.borrow_mut();
+
+    // Take the transaction hash provided by the environment, combine it with the # of tables
+    // produced so far, sha256 this and select 16 bytes from the result. Given the txn hash
+    // is unique, this should create a unique and deterministic global id.
+    let mut digest = Sha3_256::new();
+    Digest::update(&mut digest, table_context.txn_hash.to_be_bytes());
+    Digest::update(&mut digest, table_data.new_tables.len().to_be_bytes());
+    let bytes: [u8; 16] = digest.finalize()[0..16].try_into().unwrap();
+    let id = u128::from_be_bytes(bytes);
+    assert!(table_data.new_tables.insert(TableHandle(id)));
+
+    Ok(NativeResult::ok(
+        table_context
+            .resolver
+            .operation_cost(TableOperation::NewHandle, 0, 0),
+        smallvec![Value::u128(id)],
+    ))
+}
+
+fn native_add_box(
+    context: &mut NativeContext,
+    ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    assert!(ty_args.len() == 3);
+    assert!(args.len() == 3);
+
+    let table_context = context.extensions().get::<NativeTableContext>();
+    let mut table_data = table_context.table_data.borrow_mut();
+
+    let val = args.pop_back().unwrap();
+    let key = args
+        .pop_back()
+        .unwrap()
+        .value_as::<Reference>()?
+        .read_ref()?;
+    let handle = get_table_handle(&pop_arg!(args, StructRef))?;
+
+    let table = table_data.get_or_create_table(context, handle, &ty_args[0], &ty_args[2])?;
+    let status = table.insert(table_context, &key, val);
+    let (key_size, val_size) = status?;
+
+    Ok(NativeResult::ok(
+        table_context
+            .resolver
+            .operation_cost(TableOperation::Insert, key_size, val_size),
+        smallvec![],
+    ))
+}
+
+fn native_length_box(
+    context: &mut NativeContext,
+    ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    assert!(ty_args.len() == 3);
+    assert!(args.len() == 1);
+
+    let table_context = context.extensions().get::<NativeTableContext>();
+    let mut table_data = table_context.table_data.borrow_mut();
+
+    let handle = get_table_handle(&pop_arg!(args, StructRef))?;
+
+    let table = table_data.get_or_create_table(context, handle, &ty_args[0], &ty_args[2])?;
+    let (len, key_size, val_size) = table.length(table_context)?;
+
+    Ok(NativeResult::ok(
+        table_context
+            .resolver
+            .operation_cost(TableOperation::Length, key_size, val_size),
+        smallvec![Value::u64(len)],
+    ))
+}
+
+fn native_borrow_box(
+    context: &mut NativeContext,
+    ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    assert!(ty_args.len() == 3);
+    assert!(args.len() == 2);
+
+    let table_context = context.extensions().get::<NativeTableContext>();
+    let mut table_data = table_context.table_data.borrow_mut();
+
+    let key = args
+        .pop_back()
+        .unwrap()
+        .value_as::<Reference>()?
+        .read_ref()?;
+    let handle = get_table_handle(&pop_arg!(args, StructRef))?;
+
+    let table = table_data.get_or_create_table(context, handle, &ty_args[0], &ty_args[2])?;
+    let (val, key_size, val_size) = table.borrow_global(table_context, &key)?;
+
+    Ok(NativeResult::ok(
+        table_context
+            .resolver
+            .operation_cost(TableOperation::Borrow, key_size, val_size),
+        smallvec![val],
+    ))
+}
+
+fn native_contains_box(
+    context: &mut NativeContext,
+    ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    assert!(ty_args.len() == 3);
+    assert!(args.len() == 2);
+
+    let table_context = context.extensions().get::<NativeTableContext>();
+    let mut table_data = table_context.table_data.borrow_mut();
+
+    let key = args
+        .pop_back()
+        .unwrap()
+        .value_as::<Reference>()?
+        .read_ref()?;
+    let handle = get_table_handle(&pop_arg!(args, StructRef))?;
+
+    let table = table_data.get_or_create_table(context, handle, &ty_args[0], &ty_args[2])?;
+    let (val, key_size, val_size) = table.contains(table_context, &key)?;
+
+    Ok(NativeResult::ok(
+        table_context
+            .resolver
+            .operation_cost(TableOperation::Contains, key_size, val_size),
+        smallvec![val],
+    ))
+}
+
+fn native_remove_box(
+    context: &mut NativeContext,
+    ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    assert!(ty_args.len() == 3);
+    assert!(args.len() == 2);
+
+    let table_context = context.extensions().get::<NativeTableContext>();
+    let mut table_data = table_context.table_data.borrow_mut();
+
+    let key = args
+        .pop_back()
+        .unwrap()
+        .value_as::<Reference>()?
+        .read_ref()?;
+    let handle = get_table_handle(&pop_arg!(args, StructRef))?;
+    let table = table_data.get_or_create_table(context, handle, &ty_args[0], &ty_args[2])?;
+    let (val, key_size, val_size) = table.remove(table_context, &key)?;
+
+    Ok(NativeResult::ok(
+        table_context
+            .resolver
+            .operation_cost(TableOperation::Remove, key_size, val_size),
+        smallvec![val],
+    ))
+}
+
+fn native_destroy_empty_box(
+    context: &mut NativeContext,
+    ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    assert!(ty_args.len() == 3);
+    assert!(args.len() == 1);
+
+    let table_context = context.extensions().get::<NativeTableContext>();
+    let mut table_data = table_context.table_data.borrow_mut();
+
+    let handle = get_table_handle(&pop_arg!(args, StructRef))?;
+    let table = table_data.get_or_create_table(context, handle, &ty_args[0], &ty_args[2])?;
+    let (key_size, val_size) = table.destroy_empty(table_context)?;
+
+    assert!(table_data.removed_tables.insert(handle));
+
+    Ok(NativeResult::ok(
+        table_context
+            .resolver
+            .operation_cost(TableOperation::Destroy, key_size, val_size),
+        smallvec![],
+    ))
+}
+
+fn native_drop_unchecked_box(
+    _context: &mut NativeContext,
+    ty_args: Vec<Type>,
+    args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    assert!(ty_args.len() == 3);
+    assert!(args.len() == 1);
+
+    Ok(NativeResult::ok(InternalGasUnits::new(0_u64), smallvec![]))
+}
+
+// =========================================================================================
+// Helpers
+
+fn get_table_handle(table: &StructRef) -> PartialVMResult<TableHandle> {
+    let field_ref = table
+        .borrow_field(HANDLE_FIELD_INDEX)?
+        .value_as::<Reference>()?;
+    field_ref.read_ref()?.value_as::<u128>().map(TableHandle)
+}
+
+fn serialize(layout: &MoveTypeLayout, val: &Value) -> PartialVMResult<Vec<u8>> {
+    val.simple_serialize(layout)
+        .ok_or_else(|| partial_extension_error("cannot serialize table key or value"))
+}
+
+fn deserialize(layout: &MoveTypeLayout, bytes: &[u8]) -> PartialVMResult<Value> {
+    Value::simple_deserialize(bytes, layout)
+        .ok_or_else(|| partial_extension_error("cannot deserialize table key or value"))
+}
+
+fn partial_extension_error(msg: impl ToString) -> PartialVMError {
+    PartialVMError::new(StatusCode::VM_EXTENSION_ERROR).with_message(msg.to_string())
+}
+
+fn partial_abort_error(msg: impl ToString, code: u64) -> PartialVMError {
+    PartialVMError::new(StatusCode::ABORTED)
+        .with_message(msg.to_string())
+        .with_sub_status(code)
+}
+
+fn get_type_layout(context: &NativeContext, ty: &Type) -> PartialVMResult<MoveTypeLayout> {
+    context
+        .type_to_type_layout(ty)?
+        .ok_or_else(|| partial_extension_error("cannot determine type layout"))
+}
+
+fn unique_sub_status_code(logical_code: u8) -> u64 {
+    let mut digest = Sha3_256::new();
+    Digest::update(&mut digest, "Extensions::Table");
+    Digest::update(&mut digest, logical_code.to_be_bytes());
+    let bytes: [u8; 2] = digest.finalize()[0..2].try_into().unwrap();
+    u16::from_be_bytes(bytes) as u64
+}

--- a/language/extensions/move-table-extension/tests/TableTests.move
+++ b/language/extensions/move-table-extension/tests/TableTests.move
@@ -1,0 +1,217 @@
+#[test_only]
+module Extensions::TableTests {
+    use Std::Vector;
+    use Extensions::Table as T;
+
+    struct S<phantom K, phantom V> has key {
+        t: T::Table<K, V>
+    }
+
+    struct Balance has store {
+        value: u128
+    }
+
+    #[test]
+    fun simple_read_write() {
+        let t = T::new<u64, u64>();
+        T::add(&mut t, &1, 2);
+        T::add(&mut t, &10, 33);
+        assert!(*T::borrow(&t, &1) == 2, 1);
+        assert!(*T::borrow(&t, &10) == 33, 1);
+        T::drop_unchecked(t)
+    }
+
+    #[test]
+    fun simple_update() {
+        let t = T::new<u64, u64>();
+        T::add(&mut t, &1, 2);
+        assert!(*T::borrow(&t, &1) == 2, 1);
+        *T::borrow_mut(&mut t, &1) = 3;
+        assert!(*T::borrow(&t, &1) == 3, 1);
+        T::drop_unchecked(t)
+    }
+
+    #[test]
+    fun test_destroy() {
+        let t = T::new<u64, u64>();
+        T::add(&mut t, &1, 2);
+        assert!(*T::borrow(&t, &1) == 2, 1);
+        T::remove(&mut t, &1);
+        T::destroy_empty(t)
+    }
+
+    #[test]
+    #[expected_failure(abort_code = 51155)]
+    fun test_destroy_fails() {
+        let t = T::new<u64, u64>();
+        T::add(&mut t, &1, 2);
+        assert!(*T::borrow(&t, &1) == 2, 1);
+        T::destroy_empty(t) // expected to fail
+    }
+
+    #[test]
+    fun test_length() {
+        let t = T::new<u64, u64>();
+        T::add(&mut t, &1, 2);
+        T::add(&mut t, &2, 2);
+        assert!(T::length(&t) == 2, 1);
+        T::remove(&mut t, &1);
+        assert!(T::length(&t) == 1, 2);
+        T::drop_unchecked(t)
+    }
+
+    #[test(s = @0x42)]
+    fun test_primitive(s: signer) acquires S {
+        let t = T::new<u64, u128>();
+        assert!(!T::contains(&t, &42), 100);
+
+        T::add(&mut t, &42, 1012);
+        assert!(T::contains(&t, &42), 101);
+        assert!(!T::contains(&t, &0), 102);
+        assert!(*T::borrow(&t, &42) == 1012, 103);
+
+        T::add(&mut t, &43, 1013);
+        assert!(T::contains(&t, &42), 104);
+        assert!(!T::contains(&t, &0), 105);
+        assert!(T::contains(&t, &43), 106);
+        assert!(*T::borrow(&t, &43) == 1013, 107);
+
+        let v = T::remove(&mut t, &42);
+        assert!(v == 1012, 108);
+
+        move_to(&s, S { t });
+
+        let t_ref = &borrow_global<S<u64, u128>>(@0x42).t;
+        let v = *T::borrow(t_ref, &43);
+        assert!(v == 1013, 110);
+
+        let S { t: local_t } = move_from<S<u64, u128>>(@0x42);
+        assert!(*T::borrow(&local_t, &43) == 1013, 111);
+
+        move_to(&s, S { t: local_t });
+    }
+
+    #[test(s = @0x42)]
+    fun test_vector(s: signer) acquires S {
+        let t = T::new<u8, vector<address>>();
+
+        T::add(&mut t, &42, Vector::singleton<address>(@0x1012));
+        assert!(T::contains(&t, &42), 101);
+        assert!(!T::contains(&t, &0), 102);
+        assert!(Vector::length(T::borrow(&t, &42)) == 1, 103);
+        assert!(*Vector::borrow(T::borrow(&t, &42), 0) == @0x1012, 104);
+
+        move_to(&s, S { t });
+
+        let s = borrow_global_mut<S<u8, vector<address>>>(@0x42);
+        let v_mut_ref = T::borrow_mut(&mut s.t, &42);
+        Vector::push_back(v_mut_ref, @0x1013);
+        assert!(Vector::length(T::borrow(&s.t, &42)) == 2, 105);
+        assert!(*Vector::borrow(T::borrow(&s.t, &42), 1) == @0x1013, 106);
+
+        let v = T::remove(&mut s.t, &42);
+        assert!(Vector::length(&v) == 2, 107);
+        assert!(*Vector::borrow(&v, 0) == @0x1012, 108);
+        assert!(*Vector::borrow(&v, 1) == @0x1013, 109);
+        assert!(!T::contains(&s.t, &42), 110);
+    }
+
+    #[test(s = @0x42)]
+    fun test_struct(s: signer) acquires S {
+        let t = T::new<address, Balance>();
+        let val_1 = 11;
+        let val_2 = 45;
+
+        T::add(&mut t, &@0xAB, Balance{ value: val_1 });
+        assert!(T::contains(&t, &@0xAB), 101);
+        assert!(*&T::borrow(&t, &@0xAB).value == val_1, 102);
+
+        move_to(&s, S { t });
+
+        let global_t = &mut borrow_global_mut<S<address, Balance>>(@0x42).t;
+
+        T::add(global_t, &@0xCD, Balance{ value: val_2 });
+        assert!(*&T::borrow(global_t, &@0xAB).value == val_1, 103);
+        assert!(*&T::borrow(global_t, &@0xCD).value == val_2, 104);
+
+
+        let entry_mut_ref = T::borrow_mut(global_t , &@0xCD);
+        *&mut entry_mut_ref.value = entry_mut_ref.value - 1;
+        assert!(*&T::borrow(global_t, &@0xCD).value == val_2 - 1, 105);
+
+        let Balance { value } = T::remove(global_t, &@0xAB);
+        assert!(value == val_1, 106);
+        assert!(!T::contains(global_t, &@0xAB), 107);
+    }
+
+    #[test(s = @0x42)]
+    fun test_table_of_tables(s: signer) {
+        let t = T::new<address, T::Table<address, u128>>();
+        let val_1 = 11;
+        let val_2 = 45;
+        let val_3 = 78;
+
+        // Create two small tables
+        let t1 = T::new<address, u128>();
+        T::add(&mut t1, &@0xAB, val_1);
+
+        let t2 = T::new<address, u128>();
+        T::add(&mut t2, &@0xCD, val_2);
+
+        // Insert two small tables into the big table
+        T::add(&mut t, &@0x12, t1);
+        T::add(&mut t, &@0x34, t2);
+
+
+        assert!(T::contains(T::borrow(&t, &@0x12), &@0xAB), 101);
+        assert!(T::contains(T::borrow(&t, &@0x34), &@0xCD), 102);
+        assert!(*T::borrow(T::borrow(&t, &@0x12), &@0xAB) == val_1, 103);
+        assert!(*T::borrow(T::borrow(&t, &@0x34), &@0xCD) == val_2, 104);
+
+        T::add(T::borrow_mut(&mut t, &@0x12), &@0xEF, val_3);
+        assert!(*T::borrow(T::borrow(&t, &@0x12), &@0xEF) == val_3, 105);
+        assert!(*T::borrow(T::borrow(&t, &@0x12), &@0xAB) == val_1, 106);
+
+        let val = T::remove(T::borrow_mut(&mut t, &@0x34), &@0xCD);
+        assert!(val == val_2, 107);
+        assert!(!T::contains(T::borrow(&t, &@0x34), &@0xCD), 108);
+
+        move_to(&s, S { t });
+    }
+
+    #[test(s = @0x42)]
+    #[expected_failure(abort_code = 64237)]
+    fun test_insert_fail(s: signer) {
+        let t = T::new<u64, u128>();
+        assert!(!T::contains(&t, &42), 100);
+
+        T::add(&mut t, &42, 1012);
+        assert!(T::contains(&t, &42), 101);
+        T::add(&mut t, &42, 1013); // should fail here since key 42 already exists
+
+        move_to(&s, S { t });
+    }
+
+    #[test(s = @0x42)]
+    #[expected_failure(abort_code = 25524)]
+    fun test_borrow_fail(s: signer) {
+        let t = T::new<u64, u128>();
+        assert!(!T::contains(&t, &42), 100);
+
+        let entry_ref = T::borrow_mut(&mut t, &42); // should fail here since key 42 doesn't exist
+        *entry_ref = 1;
+
+        move_to(&s, S { t });
+    }
+
+    #[test(s = @0x42)]
+    #[expected_failure(abort_code = 25524)]
+    fun test_remove_fail(s: signer) {
+        let t = T::new<u64, Balance>();
+        let Balance { value } = T::remove(&mut t, &42); // should fail here since key 42 doesn't exist
+        assert!(value == 0, 101);
+        move_to(&s, S { t });
+    }
+
+
+}

--- a/language/extensions/move-table-extension/tests/move_unit_tests.rs
+++ b/language/extensions/move-table-extension/tests/move_unit_tests.rs
@@ -1,0 +1,44 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use move_cli::package::cli;
+use move_core_types::account_address::AccountAddress;
+use move_table_extension::table_natives;
+use move_unit_test::UnitTestingConfig;
+use std::path::PathBuf;
+use tempfile::tempdir;
+
+fn run_tests_for_pkg(path_to_pkg: impl Into<String>) {
+    let pkg_path = path_in_crate(path_to_pkg);
+    let mut natives =
+        move_stdlib::natives::all_natives(AccountAddress::from_hex_literal("0x1").unwrap());
+    natives.append(&mut table_natives(
+        AccountAddress::from_hex_literal("0x2").unwrap(),
+    ));
+    let res = cli::run_move_unit_tests(
+        &pkg_path,
+        move_package::BuildConfig {
+            test_mode: true,
+            install_dir: Some(tempdir().unwrap().path().to_path_buf()),
+            ..Default::default()
+        },
+        UnitTestingConfig::default_with_bound(Some(100_000)),
+        natives,
+        /* compute_coverage */ false,
+    );
+    res.unwrap();
+}
+
+#[test]
+fn move_unit_tests() {
+    run_tests_for_pkg(".");
+}
+
+pub fn path_in_crate<S>(relative: S) -> PathBuf
+where
+    S: Into<String>,
+{
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.push(relative.into());
+    path
+}

--- a/language/move-vm/integration-tests/Cargo.toml
+++ b/language/move-vm/integration-tests/Cargo.toml
@@ -22,4 +22,12 @@ move-vm-runtime = { path = "../runtime" }
 move-vm-types = { path = "../types" }
 move-vm-test-utils = { path = "../test-utils" }
 move-stdlib = { path = "../../move-stdlib" }
+move-table-extension = { path = "../../extensions/move-table-extension", optional = true }
 workspace-hack = { version = "0.1", path = "../../../crates/workspace-hack" }
+
+[features]
+default = []
+table-extension = [
+    "move-table-extension",
+    "move-vm-test-utils/table-extension"
+]

--- a/language/move-vm/test-utils/Cargo.toml
+++ b/language/move-vm/test-utils/Cargo.toml
@@ -17,4 +17,9 @@ anyhow = "1.0.52"
 move-vm-runtime = { path = "../runtime" }
 move-core-types = {path = "../../move-core/types" }
 move-binary-format = { path = "../../move-binary-format" }
+move-table-extension = { path = "../../extensions/move-table-extension", optional = true }
 workspace-hack = { version = "0.1", path = "../../../crates/workspace-hack" }
+
+[features]
+default = [ ]
+table-extension = [ "move-table-extension" ]

--- a/language/tools/move-cli/Cargo.toml
+++ b/language/tools/move-cli/Cargo.toml
@@ -34,6 +34,7 @@ move-core-types = { path = "../../move-core/types" }
 move-ir-types = { path = "../../move-ir/types" }
 move-compiler = { path = "../../move-compiler" }
 move-stdlib = { path = "../../move-stdlib", features = ["testing"] }
+move-table-extension = { path = "../../extensions/move-table-extension", optional = true }
 move-symbol-pool = { path = "../../move-symbol-pool" }
 move-vm-types = { path = "../../move-vm/types" }
 move-vm-runtime = { path = "../../move-vm/runtime", features = ["debugging"] }
@@ -72,3 +73,8 @@ required-features = ["evm-backend"]
 [features]
 default = ["evm-backend"]
 evm-backend = ["move-unit-test/evm-backend"]
+
+table-extension = [
+    "move-table-extension",
+    "move-unit-test/table-extension"
+]

--- a/language/tools/move-unit-test/Cargo.toml
+++ b/language/tools/move-unit-test/Cargo.toml
@@ -15,9 +15,12 @@ clap = { version = "3", features = ["derive"] }
 colored = "2.0.0"
 rayon = "1.5.0"
 regex = "1.1.9"
+once_cell = "1.7.2"
+itertools = "0.10.1"
 
 move-command-line-common = { path = "../../move-command-line-common" }
 move-stdlib = { path = "../../move-stdlib", features = ["testing"] }
+move-table-extension = { path = "../../extensions/move-table-extension" }
 move-core-types = { path = "../../move-core/types" }
 move-compiler = { path = "../../move-compiler" }
 move-vm-types = { path = "../../move-vm/types" }
@@ -52,3 +55,6 @@ harness = false
 [features]
 default = ["evm-backend"]
 evm-backend = ["move-to-yul", "evm-exec-utils", "evm", "primitive-types"]
+table-extension = [
+ "move-vm-test-utils/table-extension"
+]

--- a/language/tools/move-unit-test/src/extensions.rs
+++ b/language/tools/move-unit-test/src/extensions.rs
@@ -1,0 +1,74 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! This module manages native extensions supported by the unit testing framework.
+//! Such extensions are enabled by cfg features and must be compiled into the test
+//! to be usable.
+
+use move_vm_runtime::native_functions::NativeContextExtensions;
+use std::fmt::Write;
+
+#[cfg(feature = "table-extension")]
+use itertools::Itertools;
+#[cfg(feature = "table-extension")]
+use move_table_extension::NativeTableContext;
+#[cfg(feature = "table-extension")]
+use move_vm_test_utils::BlankStorage;
+#[cfg(feature = "table-extension")]
+use once_cell::sync::Lazy;
+
+/// Create all available native context extensions.
+#[allow(unused_mut)]
+pub(crate) fn new_extensions() -> NativeContextExtensions {
+    let mut e = NativeContextExtensions::default();
+    #[cfg(feature = "table-extension")]
+    create_table_extension(&mut e);
+    e
+}
+
+/// Print the change sets for available native context extensions.
+#[allow(unused)]
+pub(crate) fn print_change_sets<W: Write>(_w: &mut W, mut extensions: NativeContextExtensions) {
+    #[cfg(feature = "table-extension")]
+    print_table_extension(_w, &mut extensions);
+}
+
+// =============================================================================================
+// Table Extensions
+
+#[cfg(feature = "table-extension")]
+fn create_table_extension(extensions: &mut NativeContextExtensions) {
+    extensions.add(NativeTableContext::new(0, &*DUMMY_RESOLVER));
+}
+
+#[cfg(feature = "table-extension")]
+fn print_table_extension<W: Write>(w: &mut W, extensions: &mut NativeContextExtensions) {
+    let cs = extensions.remove::<NativeTableContext>().into_change_set();
+    if let Ok(cs) = cs {
+        if !cs.new_tables.is_empty() {
+            writeln!(
+                w,
+                "new tables {}",
+                cs.new_tables.iter().map(|h| h.to_string()).join(", ")
+            )
+            .unwrap();
+        }
+        if !cs.removed_tables.is_empty() {
+            writeln!(
+                w,
+                "removed tables {}",
+                cs.removed_tables.iter().map(|h| h.to_string()).join(", ")
+            )
+            .unwrap();
+        }
+        for (h, c) in cs.changes {
+            writeln!(w, "for {}", h).unwrap();
+            for (k, v) in c.entries {
+                writeln!(w, "  {:X?} := {:X?}", k, v).unwrap();
+            }
+        }
+    }
+}
+
+#[cfg(feature = "table-extension")]
+static DUMMY_RESOLVER: Lazy<BlankStorage> = Lazy::new(|| BlankStorage);

--- a/language/tools/move-unit-test/src/lib.rs
+++ b/language/tools/move-unit-test/src/lib.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod cargo_runner;
+mod extensions;
 pub mod test_reporter;
 pub mod test_runner;
 


### PR DESCRIPTION
This adds tables as an extension to Move, using the new VM extension mechanism.

Tables (and other future extensions) are suggested to live in the `language/extensions` tree. They come with a Move library and a Rust implementation of the table extension data, including changeset representation, and a native function table.

The CLI and unit testing framework has been extended to support extensions. This is controlled by a compile-time feature flag `table-extension`. The mechanism is generic enough to also support future extensions.

A fairly complete test suite has been copied over from the EVM project.  However, while functionality should be covered, Move unit tests do not support testing of change set generation and remote table resolver access, so this aspect stays untested. For this integration tests are needed.



## Motivation

Tables

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

