### PR TITLE
[move-vm] Revisit session extension API.

### DIFF
--- a/language/move-vm/runtime/src/move_vm.rs
+++ b/language/move-vm/runtime/src/move_vm.rs
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    data_cache::TransactionDataCache, native_functions::NativeFunction, runtime::VMRuntime,
+    data_cache::TransactionDataCache,
+    native_functions::{NativeContextExtensions, NativeFunction},
+    runtime::VMRuntime,
     session::Session,
 };
 use move_binary_format::errors::{Location, VMResult};
@@ -41,6 +43,15 @@ impl MoveVM {
     ///     and apply the effects to the storage when the Session ends.
     pub fn new_session<'r, S: MoveResolver>(&self, remote: &'r S) -> Session<'r, '_, S> {
         self.runtime.new_session(remote)
+    }
+
+    /// Create a new session, as in `new_session`, but provide native context extensions.
+    pub fn new_session_with_extensions<'r, S: MoveResolver>(
+        &self,
+        remote: &'r S,
+        extensions: NativeContextExtensions,
+    ) -> Session<'r, '_, S> {
+        self.runtime.new_session_with_extensions(remote, extensions)
     }
 
     /// Load a module into VM's code cache

--- a/language/move-vm/runtime/src/runtime.rs
+++ b/language/move-vm/runtime/src/runtime.rs
@@ -59,6 +59,19 @@ impl VMRuntime {
         Session {
             runtime: self,
             data_cache: TransactionDataCache::new(remote, &self.loader),
+            native_extensions: NativeContextExtensions::default(),
+        }
+    }
+
+    pub fn new_session_with_extensions<'r, S: MoveResolver>(
+        &self,
+        remote: &'r S,
+        native_extensions: NativeContextExtensions,
+    ) -> Session<'r, '_, S> {
+        Session {
+            runtime: self,
+            data_cache: TransactionDataCache::new(remote, &self.loader),
+            native_extensions,
         }
     }
 


### PR DESCRIPTION
This puts the extensions into the Session struct instead of passing them as parameters to exec functions. This design was in some earlier version not possible, as the execute functions had extra type parameters for extensions; however, since we use the new `NativeContextExtensions` object, its natural and cleaner.

One does now

```
let session = vm.new_session_with_extensions(remote, extensions);
<<work with the session>>
let (change_set, events, extension) = session.finish_with_extensions()?;
```

Furthermore the `ExecutionResult::Success` has been extended to have a new field for extensions, which is a breaking change, but a marginal one.

In this design, if one wants to access the extensions on a failed execution, we can just add another function to the Session API to do so. This is currently not there but can be easily added.

## Motivation

Better API.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes


