### PR TITLE
Fix the typetag serde error

### DIFF
--- a/language/move-core/types/src/language_storage.rs
+++ b/language/move-core/types/src/language_storage.rs
@@ -18,21 +18,21 @@ pub const CORE_CODE_ADDRESS: AccountAddress = AccountAddress::ONE;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Hash, Eq, Clone, PartialOrd, Ord)]
 pub enum TypeTag {
-    #[serde(rename(serialize = "bool", deserialize = "Bool"))]
+    #[serde(rename(serialize = "bool", deserialize = "bool"))]
     Bool,
-    #[serde(rename(serialize = "u8", deserialize = "U8"))]
+    #[serde(rename(serialize = "u8", deserialize = "u8"))]
     U8,
-    #[serde(rename(serialize = "u64", deserialize = "U64"))]
+    #[serde(rename(serialize = "u64", deserialize = "u64"))]
     U64,
-    #[serde(rename(serialize = "u128", deserialize = "U128"))]
+    #[serde(rename(serialize = "u128", deserialize = "u128"))]
     U128,
-    #[serde(rename(serialize = "address", deserialize = "Address"))]
+    #[serde(rename(serialize = "address", deserialize = "address"))]
     Address,
-    #[serde(rename(serialize = "signer", deserialize = "Signer"))]
+    #[serde(rename(serialize = "signer", deserialize = "signer"))]
     Signer,
-    #[serde(rename(serialize = "vector", deserialize = "Vector"))]
+    #[serde(rename(serialize = "vector", deserialize = "vector"))]
     Vector(Box<TypeTag>),
-    #[serde(rename(serialize = "struct", deserialize = "Struct"))]
+    #[serde(rename(serialize = "struct", deserialize = "struct"))]
     Struct(StructTag),
 }
 
@@ -42,7 +42,7 @@ pub struct StructTag {
     pub module: Identifier,
     pub name: Identifier,
     // TODO: rename to "type_args" (or better "ty_args"?)
-    #[serde(rename(serialize = "type_args", deserialize = "type_params"))]
+    #[serde(rename(serialize = "type_args", deserialize = "type_args"))]
     pub type_params: Vec<TypeTag>,
 }
 
@@ -169,5 +169,26 @@ impl Display for ResourceKey {
 impl From<StructTag> for TypeTag {
     fn from(t: StructTag) -> TypeTag {
         TypeTag::Struct(t)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::TypeTag;
+    use crate::{
+        account_address::AccountAddress, identifier::Identifier, language_storage::StructTag,
+    };
+
+    #[test]
+    fn test_type_tag_serde() {
+        let a = TypeTag::Struct(StructTag {
+            address: AccountAddress::ONE,
+            module: Identifier::from_utf8(("abc".as_bytes()).to_vec()).unwrap(),
+            name: Identifier::from_utf8(("abc".as_bytes()).to_vec()).unwrap(),
+            type_params: vec![TypeTag::U8],
+        });
+        let b = serde_json::to_string(&a).unwrap();
+        let c: TypeTag = serde_json::from_str(&b).unwrap();
+        assert!(a.eq(&c), "Typetag serde error")
     }
 }

--- a/language/move-core/types/src/value.rs
+++ b/language/move-core/types/src/value.rs
@@ -79,21 +79,21 @@ pub enum MoveStructLayout {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum MoveTypeLayout {
-    #[serde(rename(serialize = "bool", deserialize = "Bool"))]
+    #[serde(rename(serialize = "bool", deserialize = "bool"))]
     Bool,
-    #[serde(rename(serialize = "u8", deserialize = "U8"))]
+    #[serde(rename(serialize = "u8", deserialize = "u8"))]
     U8,
-    #[serde(rename(serialize = "u64", deserialize = "U64"))]
+    #[serde(rename(serialize = "u64", deserialize = "u64"))]
     U64,
-    #[serde(rename(serialize = "u128", deserialize = "U128"))]
+    #[serde(rename(serialize = "u128", deserialize = "u128"))]
     U128,
-    #[serde(rename(serialize = "address", deserialize = "Address"))]
+    #[serde(rename(serialize = "address", deserialize = "address"))]
     Address,
-    #[serde(rename(serialize = "vector", deserialize = "Vector"))]
+    #[serde(rename(serialize = "vector", deserialize = "vector"))]
     Vector(Box<MoveTypeLayout>),
-    #[serde(rename(serialize = "struct", deserialize = "Struct"))]
+    #[serde(rename(serialize = "struct", deserialize = "struct"))]
     Struct(MoveStructLayout),
-    #[serde(rename(serialize = "signer", deserialize = "Signer"))]
+    #[serde(rename(serialize = "signer", deserialize = "signer"))]
     Signer,
 }
 


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

TypeTag Serde error.  Serialize to lowcase and deserialize back causes error

```
#[derive(Serialize, Deserialize)]
enum TypeTag {
    #[serde(rename(serialize = "bool", deserialize = "Bool"))]
    Bool,
    #[serde(rename(serialize = "u8", deserialize = "U8"))]
    U8,
    #[serde(rename(serialize = "u64", deserialize = "U64"))]
    U64,
    #[serde(rename(serialize = "u128", deserialize = "U128"))]
    U128,
    #[serde(rename(serialize = "address", deserialize = "Address"))]
    Address,
    #[serde(rename(serialize = "signer", deserialize = "Signer"))]
    Signer,
    #[serde(rename(serialize = "vector", deserialize = "Vector"))]
    Vector(Box<TypeTag>),
    #[serde(rename(serialize = "struct", deserialize = "Struct"))]
    Struct(u64),
}
fn main() {
    let a = TypeTag::Bool;
    let b = serde_json::to_vec(&a).unwrap();
    let c: TypeTag = serde_json::from_slice(&b).unwrap();
}
```

```
`thread ‘main’ panicked at ‘called `Result::unwrap()` on an `Err` value: Error(“unknown variant `bool`, expected one of `Bool`, `U8`, `U64`, `U128`, `Address`, `Signer`, `Vector`, `Struct`“, line: 1, column: 6)’, src/main.rs:29:49
```

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

 cargo test -p move-core-types passed

## Related PR
https://github.com/diem/move/pull/127