### PR TITLE
[move-prover] Fixed bugs in shift

### DIFF
--- a/language/move-prover/boogie-backend/src/bytecode_translator.rs
+++ b/language/move-prover/boogie-backend/src/bytecode_translator.rs
@@ -1306,10 +1306,17 @@ impl<'env> FunctionTranslator<'env> {
                         let dest = dests[0];
                         let op1 = srcs[0];
                         let op2 = srcs[1];
+                        let sh_type = match &self.get_local_type(dest) {
+                            Type::Primitive(PrimitiveType::U8) => "U8",
+                            Type::Primitive(PrimitiveType::U64) => "U64",
+                            Type::Primitive(PrimitiveType::U128) => "U128",
+                            _ => unreachable!(),
+                        };
                         emitln!(
                             writer,
-                            "call {} := $Shl({}, {});",
+                            "call {} := $Shl{}({}, {});",
                             str_local(dest),
+                            sh_type,
                             str_local(op1),
                             str_local(op2)
                         );

--- a/language/move-prover/tests/sources/functional/arithm.move
+++ b/language/move-prover/tests/sources/functional/arithm.move
@@ -239,4 +239,5 @@ module 0x42::TestArithmetic {
     spec overflow_u128_mul {
         aborts_if x * y > max_u128(); // U128_MAX
     }
+
 }

--- a/language/move-prover/tests/sources/functional/fixed_point_arithm.exp
+++ b/language/move-prover/tests/sources/functional/fixed_point_arithm.exp
@@ -1,139 +1,139 @@
 Move prover returns: exiting with verification errors
 error: post-condition does not hold
-    ┌─ tests/sources/functional/fixed_point_arithm.move:141:9
+    ┌─ tests/sources/functional/fixed_point_arithm.move:144:9
     │
-141 │         ensures result != 10;
+144 │         ensures result != 10;
     │         ^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/fixed_point_arithm.move:136: mul_2_times_incorrect
+    =     at tests/sources/functional/fixed_point_arithm.move:139: mul_2_times_incorrect
     =         a = <redacted>
     =         b = <redacted>
     =         c = <redacted>
-    =     at tests/sources/functional/fixed_point_arithm.move:137: mul_2_times_incorrect
+    =     at tests/sources/functional/fixed_point_arithm.move:140: mul_2_times_incorrect
     =         result = <redacted>
-    =     at tests/sources/functional/fixed_point_arithm.move:138: mul_2_times_incorrect
-    =     at tests/sources/functional/fixed_point_arithm.move:141: mul_2_times_incorrect (spec)
+    =     at tests/sources/functional/fixed_point_arithm.move:141: mul_2_times_incorrect
+    =     at tests/sources/functional/fixed_point_arithm.move:144: mul_2_times_incorrect (spec)
 
 error: post-condition does not hold
-    ┌─ tests/sources/functional/fixed_point_arithm.move:149:9
+    ┌─ tests/sources/functional/fixed_point_arithm.move:152:9
     │
-149 │         ensures result != 10;
+152 │         ensures result != 10;
     │         ^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/fixed_point_arithm.move:144: mul_3_times_incorrect
+    =     at tests/sources/functional/fixed_point_arithm.move:147: mul_3_times_incorrect
     =         a = <redacted>
     =         b = <redacted>
     =         c = <redacted>
     =         d = <redacted>
-    =     at tests/sources/functional/fixed_point_arithm.move:145: mul_3_times_incorrect
+    =     at tests/sources/functional/fixed_point_arithm.move:148: mul_3_times_incorrect
     =         result = <redacted>
-    =     at tests/sources/functional/fixed_point_arithm.move:146: mul_3_times_incorrect
-    =     at tests/sources/functional/fixed_point_arithm.move:149: mul_3_times_incorrect (spec)
+    =     at tests/sources/functional/fixed_point_arithm.move:149: mul_3_times_incorrect
+    =     at tests/sources/functional/fixed_point_arithm.move:152: mul_3_times_incorrect (spec)
 
 error: post-condition does not hold
-    ┌─ tests/sources/functional/fixed_point_arithm.move:107:9
+    ┌─ tests/sources/functional/fixed_point_arithm.move:110:9
     │
-107 │         ensures result >= x; // disproved
+110 │         ensures result >= x; // disproved
     │         ^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/fixed_point_arithm.move:101: mul_div_incorrect
+    =     at tests/sources/functional/fixed_point_arithm.move:104: mul_div_incorrect
     =         x = <redacted>
     =         y = <redacted>
-    =     at tests/sources/functional/fixed_point_arithm.move:102: mul_div_incorrect
+    =     at tests/sources/functional/fixed_point_arithm.move:105: mul_div_incorrect
     =     at ../move-stdlib/sources/FixedPoint32.move:150: get_raw_value
     =         num = <redacted>
     =     at ../move-stdlib/sources/FixedPoint32.move:151: get_raw_value
     =         result = <redacted>
     =     at ../move-stdlib/sources/FixedPoint32.move:152: get_raw_value
     =         y_raw_val = <redacted>
-    =     at tests/sources/functional/fixed_point_arithm.move:103: mul_div_incorrect
+    =     at tests/sources/functional/fixed_point_arithm.move:106: mul_div_incorrect
     =         z = <redacted>
-    =     at tests/sources/functional/fixed_point_arithm.move:104: mul_div_incorrect
+    =     at tests/sources/functional/fixed_point_arithm.move:107: mul_div_incorrect
     =         result = <redacted>
-    =     at tests/sources/functional/fixed_point_arithm.move:105: mul_div_incorrect
-    =     at tests/sources/functional/fixed_point_arithm.move:107: mul_div_incorrect (spec)
+    =     at tests/sources/functional/fixed_point_arithm.move:108: mul_div_incorrect
+    =     at tests/sources/functional/fixed_point_arithm.move:110: mul_div_incorrect (spec)
 
 error: post-condition does not hold
-    ┌─ tests/sources/functional/fixed_point_arithm.move:109:9
+    ┌─ tests/sources/functional/fixed_point_arithm.move:112:9
     │
-109 │         ensures result < x; // disproved
+112 │         ensures result < x; // disproved
     │         ^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/fixed_point_arithm.move:101: mul_div_incorrect
+    =     at tests/sources/functional/fixed_point_arithm.move:104: mul_div_incorrect
     =         x = <redacted>
     =         y = <redacted>
-    =     at tests/sources/functional/fixed_point_arithm.move:102: mul_div_incorrect
+    =     at tests/sources/functional/fixed_point_arithm.move:105: mul_div_incorrect
     =     at ../move-stdlib/sources/FixedPoint32.move:150: get_raw_value
     =         num = <redacted>
     =     at ../move-stdlib/sources/FixedPoint32.move:151: get_raw_value
     =         result = <redacted>
     =     at ../move-stdlib/sources/FixedPoint32.move:152: get_raw_value
     =         y_raw_val = <redacted>
-    =     at tests/sources/functional/fixed_point_arithm.move:103: mul_div_incorrect
+    =     at tests/sources/functional/fixed_point_arithm.move:106: mul_div_incorrect
     =         z = <redacted>
-    =     at tests/sources/functional/fixed_point_arithm.move:104: mul_div_incorrect
+    =     at tests/sources/functional/fixed_point_arithm.move:107: mul_div_incorrect
     =         result = <redacted>
-    =     at tests/sources/functional/fixed_point_arithm.move:105: mul_div_incorrect
-    =     at tests/sources/functional/fixed_point_arithm.move:107: mul_div_incorrect (spec)
-    =     at tests/sources/functional/fixed_point_arithm.move:108: mul_div_incorrect (spec)
-    =     at tests/sources/functional/fixed_point_arithm.move:109: mul_div_incorrect (spec)
+    =     at tests/sources/functional/fixed_point_arithm.move:108: mul_div_incorrect
+    =     at tests/sources/functional/fixed_point_arithm.move:110: mul_div_incorrect (spec)
+    =     at tests/sources/functional/fixed_point_arithm.move:111: mul_div_incorrect (spec)
+    =     at tests/sources/functional/fixed_point_arithm.move:112: mul_div_incorrect (spec)
 
 error: post-condition does not hold
-   ┌─ tests/sources/functional/fixed_point_arithm.move:28:9
+   ┌─ tests/sources/functional/fixed_point_arithm.move:31:9
    │
-28 │         ensures result == 1; // disproved
+31 │         ensures result == 1; // disproved
    │         ^^^^^^^^^^^^^^^^^^^^
    │
-   =     at tests/sources/functional/fixed_point_arithm.move:23: multiply_0_x_incorrect
+   =     at tests/sources/functional/fixed_point_arithm.move:26: multiply_0_x_incorrect
    =         x = <redacted>
-   =     at tests/sources/functional/fixed_point_arithm.move:24: multiply_0_x_incorrect
+   =     at tests/sources/functional/fixed_point_arithm.move:27: multiply_0_x_incorrect
    =         result = <redacted>
-   =     at tests/sources/functional/fixed_point_arithm.move:25: multiply_0_x_incorrect
-   =     at tests/sources/functional/fixed_point_arithm.move:27: multiply_0_x_incorrect (spec)
-   =     at tests/sources/functional/fixed_point_arithm.move:28: multiply_0_x_incorrect (spec)
+   =     at tests/sources/functional/fixed_point_arithm.move:28: multiply_0_x_incorrect
+   =     at tests/sources/functional/fixed_point_arithm.move:30: multiply_0_x_incorrect (spec)
+   =     at tests/sources/functional/fixed_point_arithm.move:31: multiply_0_x_incorrect (spec)
 
 error: post-condition does not hold
-   ┌─ tests/sources/functional/fixed_point_arithm.move:67:9
+   ┌─ tests/sources/functional/fixed_point_arithm.move:70:9
    │
-67 │         ensures result != (x.value >> 32); // disproved
+70 │         ensures result != (x.value >> 32); // disproved
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │
-   =     at tests/sources/functional/fixed_point_arithm.move:61: multiply_1_x_incorrect
+   =     at tests/sources/functional/fixed_point_arithm.move:64: multiply_1_x_incorrect
    =         x = <redacted>
-   =     at tests/sources/functional/fixed_point_arithm.move:62: multiply_1_x_incorrect
+   =     at tests/sources/functional/fixed_point_arithm.move:65: multiply_1_x_incorrect
    =         result = <redacted>
-   =     at tests/sources/functional/fixed_point_arithm.move:63: multiply_1_x_incorrect
-   =     at tests/sources/functional/fixed_point_arithm.move:65: multiply_1_x_incorrect (spec)
-   =     at tests/sources/functional/fixed_point_arithm.move:67: multiply_1_x_incorrect (spec)
+   =     at tests/sources/functional/fixed_point_arithm.move:66: multiply_1_x_incorrect
+   =     at tests/sources/functional/fixed_point_arithm.move:68: multiply_1_x_incorrect (spec)
+   =     at tests/sources/functional/fixed_point_arithm.move:70: multiply_1_x_incorrect (spec)
 
 error: post-condition does not hold
-   ┌─ tests/sources/functional/fixed_point_arithm.move:44:9
+   ┌─ tests/sources/functional/fixed_point_arithm.move:47:9
    │
-44 │         ensures result == 1; // disproved
+47 │         ensures result == 1; // disproved
    │         ^^^^^^^^^^^^^^^^^^^^
    │
-   =     at tests/sources/functional/fixed_point_arithm.move:39: multiply_x_0_incorrect
+   =     at tests/sources/functional/fixed_point_arithm.move:42: multiply_x_0_incorrect
    =         x = <redacted>
-   =     at tests/sources/functional/fixed_point_arithm.move:40: multiply_x_0_incorrect
+   =     at tests/sources/functional/fixed_point_arithm.move:43: multiply_x_0_incorrect
    =         result = <redacted>
-   =     at tests/sources/functional/fixed_point_arithm.move:41: multiply_x_0_incorrect
-   =     at tests/sources/functional/fixed_point_arithm.move:43: multiply_x_0_incorrect (spec)
-   =     at tests/sources/functional/fixed_point_arithm.move:44: multiply_x_0_incorrect (spec)
+   =     at tests/sources/functional/fixed_point_arithm.move:44: multiply_x_0_incorrect
+   =     at tests/sources/functional/fixed_point_arithm.move:46: multiply_x_0_incorrect (spec)
+   =     at tests/sources/functional/fixed_point_arithm.move:47: multiply_x_0_incorrect (spec)
 
 error: post-condition does not hold
-   ┌─ tests/sources/functional/fixed_point_arithm.move:83:9
+   ┌─ tests/sources/functional/fixed_point_arithm.move:86:9
    │
-83 │         ensures result != x; // disproved
+86 │         ensures result != x; // disproved
    │         ^^^^^^^^^^^^^^^^^^^^
    │
-   =     at tests/sources/functional/fixed_point_arithm.move:78: multiply_x_1_incorrect
+   =     at tests/sources/functional/fixed_point_arithm.move:81: multiply_x_1_incorrect
    =         x = <redacted>
-   =     at tests/sources/functional/fixed_point_arithm.move:79: multiply_x_1_incorrect
+   =     at tests/sources/functional/fixed_point_arithm.move:82: multiply_x_1_incorrect
    =     at ../move-stdlib/sources/FixedPoint32.move:126
    =     at ../move-stdlib/sources/FixedPoint32.move:127
    =     at ../move-stdlib/sources/FixedPoint32.move:128
-   =     at tests/sources/functional/fixed_point_arithm.move:79: multiply_x_1_incorrect
+   =     at tests/sources/functional/fixed_point_arithm.move:82: multiply_x_1_incorrect
    =         result = <redacted>
-   =     at tests/sources/functional/fixed_point_arithm.move:80: multiply_x_1_incorrect
-   =     at tests/sources/functional/fixed_point_arithm.move:82: multiply_x_1_incorrect (spec)
-   =     at tests/sources/functional/fixed_point_arithm.move:83: multiply_x_1_incorrect (spec)
+   =     at tests/sources/functional/fixed_point_arithm.move:83: multiply_x_1_incorrect
+   =     at tests/sources/functional/fixed_point_arithm.move:85: multiply_x_1_incorrect (spec)
+   =     at tests/sources/functional/fixed_point_arithm.move:86: multiply_x_1_incorrect (spec)

--- a/language/move-prover/tests/sources/functional/fixed_point_arithm.move
+++ b/language/move-prover/tests/sources/functional/fixed_point_arithm.move
@@ -1,6 +1,9 @@
-// separate_baseline: cvc4
-// TODO(cvc4): cvc4 currently produces false positives.
+// exclude_for: cvc5
 // separate_baseline: simplify
+// (There used to be a separate baseline: cvc5, but now it's excluded)
+// TODO(cvc5): cvc5 goes into infinite loop because of recursive function
+// $pow (used in shifts) in prelude.bpl.
+// TODO(cvc4): cvc4 currently produces false positives.
 module 0x42::FixedPointArithmetic {
 
     use Std::FixedPoint32::{Self, FixedPoint32};

--- a/language/move-prover/tests/sources/functional/fixed_point_arithm.simplify_exp
+++ b/language/move-prover/tests/sources/functional/fixed_point_arithm.simplify_exp
@@ -1,135 +1,135 @@
 Move prover returns: exiting with verification errors
 error: post-condition does not hold
-    ┌─ tests/sources/functional/fixed_point_arithm.move:141:9
+    ┌─ tests/sources/functional/fixed_point_arithm.move:144:9
     │
-141 │         ensures result != 10;
+144 │         ensures result != 10;
     │         ^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/fixed_point_arithm.move:136: mul_2_times_incorrect
+    =     at tests/sources/functional/fixed_point_arithm.move:139: mul_2_times_incorrect
     =         a = <redacted>
     =         b = <redacted>
     =         c = <redacted>
-    =     at tests/sources/functional/fixed_point_arithm.move:137: mul_2_times_incorrect
+    =     at tests/sources/functional/fixed_point_arithm.move:140: mul_2_times_incorrect
     =         result = <redacted>
-    =     at tests/sources/functional/fixed_point_arithm.move:138: mul_2_times_incorrect
-    =     at tests/sources/functional/fixed_point_arithm.move:141: mul_2_times_incorrect (spec)
+    =     at tests/sources/functional/fixed_point_arithm.move:141: mul_2_times_incorrect
+    =     at tests/sources/functional/fixed_point_arithm.move:144: mul_2_times_incorrect (spec)
 
 error: post-condition does not hold
-    ┌─ tests/sources/functional/fixed_point_arithm.move:149:9
+    ┌─ tests/sources/functional/fixed_point_arithm.move:152:9
     │
-149 │         ensures result != 10;
+152 │         ensures result != 10;
     │         ^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/fixed_point_arithm.move:144: mul_3_times_incorrect
+    =     at tests/sources/functional/fixed_point_arithm.move:147: mul_3_times_incorrect
     =         a = <redacted>
     =         b = <redacted>
     =         c = <redacted>
     =         d = <redacted>
-    =     at tests/sources/functional/fixed_point_arithm.move:145: mul_3_times_incorrect
+    =     at tests/sources/functional/fixed_point_arithm.move:148: mul_3_times_incorrect
     =         result = <redacted>
-    =     at tests/sources/functional/fixed_point_arithm.move:146: mul_3_times_incorrect
-    =     at tests/sources/functional/fixed_point_arithm.move:149: mul_3_times_incorrect (spec)
+    =     at tests/sources/functional/fixed_point_arithm.move:149: mul_3_times_incorrect
+    =     at tests/sources/functional/fixed_point_arithm.move:152: mul_3_times_incorrect (spec)
 
 error: post-condition does not hold
-    ┌─ tests/sources/functional/fixed_point_arithm.move:107:9
+    ┌─ tests/sources/functional/fixed_point_arithm.move:110:9
     │
-107 │         ensures result >= x; // disproved
+110 │         ensures result >= x; // disproved
     │         ^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/fixed_point_arithm.move:101: mul_div_incorrect
+    =     at tests/sources/functional/fixed_point_arithm.move:104: mul_div_incorrect
     =         x = <redacted>
     =         y = <redacted>
-    =     at tests/sources/functional/fixed_point_arithm.move:102: mul_div_incorrect
+    =     at tests/sources/functional/fixed_point_arithm.move:105: mul_div_incorrect
     =     at ../move-stdlib/sources/FixedPoint32.move:150: get_raw_value
     =         num = <redacted>
     =     at ../move-stdlib/sources/FixedPoint32.move:151: get_raw_value
     =         result = <redacted>
     =     at ../move-stdlib/sources/FixedPoint32.move:152: get_raw_value
     =         y_raw_val = <redacted>
-    =     at tests/sources/functional/fixed_point_arithm.move:103: mul_div_incorrect
+    =     at tests/sources/functional/fixed_point_arithm.move:106: mul_div_incorrect
     =         z = <redacted>
-    =     at tests/sources/functional/fixed_point_arithm.move:104: mul_div_incorrect
+    =     at tests/sources/functional/fixed_point_arithm.move:107: mul_div_incorrect
     =         result = <redacted>
-    =     at tests/sources/functional/fixed_point_arithm.move:105: mul_div_incorrect
-    =     at tests/sources/functional/fixed_point_arithm.move:107: mul_div_incorrect (spec)
+    =     at tests/sources/functional/fixed_point_arithm.move:108: mul_div_incorrect
+    =     at tests/sources/functional/fixed_point_arithm.move:110: mul_div_incorrect (spec)
 
 error: post-condition does not hold
-    ┌─ tests/sources/functional/fixed_point_arithm.move:109:9
+    ┌─ tests/sources/functional/fixed_point_arithm.move:112:9
     │
-109 │         ensures result < x; // disproved
+112 │         ensures result < x; // disproved
     │         ^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/fixed_point_arithm.move:101: mul_div_incorrect
+    =     at tests/sources/functional/fixed_point_arithm.move:104: mul_div_incorrect
     =         x = <redacted>
     =         y = <redacted>
-    =     at tests/sources/functional/fixed_point_arithm.move:102: mul_div_incorrect
+    =     at tests/sources/functional/fixed_point_arithm.move:105: mul_div_incorrect
     =     at ../move-stdlib/sources/FixedPoint32.move:150: get_raw_value
     =         num = <redacted>
     =     at ../move-stdlib/sources/FixedPoint32.move:151: get_raw_value
     =         result = <redacted>
     =     at ../move-stdlib/sources/FixedPoint32.move:152: get_raw_value
     =         y_raw_val = <redacted>
-    =     at tests/sources/functional/fixed_point_arithm.move:103: mul_div_incorrect
+    =     at tests/sources/functional/fixed_point_arithm.move:106: mul_div_incorrect
     =         z = <redacted>
-    =     at tests/sources/functional/fixed_point_arithm.move:104: mul_div_incorrect
+    =     at tests/sources/functional/fixed_point_arithm.move:107: mul_div_incorrect
     =         result = <redacted>
-    =     at tests/sources/functional/fixed_point_arithm.move:105: mul_div_incorrect
-    =     at tests/sources/functional/fixed_point_arithm.move:107: mul_div_incorrect (spec)
-    =     at tests/sources/functional/fixed_point_arithm.move:108: mul_div_incorrect (spec)
-    =     at tests/sources/functional/fixed_point_arithm.move:109: mul_div_incorrect (spec)
+    =     at tests/sources/functional/fixed_point_arithm.move:108: mul_div_incorrect
+    =     at tests/sources/functional/fixed_point_arithm.move:110: mul_div_incorrect (spec)
+    =     at tests/sources/functional/fixed_point_arithm.move:111: mul_div_incorrect (spec)
+    =     at tests/sources/functional/fixed_point_arithm.move:112: mul_div_incorrect (spec)
 
 error: post-condition does not hold
-   ┌─ tests/sources/functional/fixed_point_arithm.move:28:9
+   ┌─ tests/sources/functional/fixed_point_arithm.move:31:9
    │
-28 │         ensures result == 1; // disproved
+31 │         ensures result == 1; // disproved
    │         ^^^^^^^^^^^^^^^^^^^^
    │
-   =     at tests/sources/functional/fixed_point_arithm.move:23: multiply_0_x_incorrect
+   =     at tests/sources/functional/fixed_point_arithm.move:26: multiply_0_x_incorrect
    =         x = <redacted>
-   =     at tests/sources/functional/fixed_point_arithm.move:24: multiply_0_x_incorrect
+   =     at tests/sources/functional/fixed_point_arithm.move:27: multiply_0_x_incorrect
    =         result = <redacted>
-   =     at tests/sources/functional/fixed_point_arithm.move:25: multiply_0_x_incorrect
-   =     at tests/sources/functional/fixed_point_arithm.move:27: multiply_0_x_incorrect (spec)
-   =     at tests/sources/functional/fixed_point_arithm.move:28: multiply_0_x_incorrect (spec)
+   =     at tests/sources/functional/fixed_point_arithm.move:28: multiply_0_x_incorrect
+   =     at tests/sources/functional/fixed_point_arithm.move:30: multiply_0_x_incorrect (spec)
+   =     at tests/sources/functional/fixed_point_arithm.move:31: multiply_0_x_incorrect (spec)
 
 error: post-condition does not hold
-   ┌─ tests/sources/functional/fixed_point_arithm.move:67:9
+   ┌─ tests/sources/functional/fixed_point_arithm.move:70:9
    │
-67 │         ensures result != (x.value >> 32); // disproved
+70 │         ensures result != (x.value >> 32); // disproved
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │
-   =     at tests/sources/functional/fixed_point_arithm.move:61: multiply_1_x_incorrect
+   =     at tests/sources/functional/fixed_point_arithm.move:64: multiply_1_x_incorrect
    =         x = <redacted>
-   =     at tests/sources/functional/fixed_point_arithm.move:62: multiply_1_x_incorrect
+   =     at tests/sources/functional/fixed_point_arithm.move:65: multiply_1_x_incorrect
    =         result = <redacted>
-   =     at tests/sources/functional/fixed_point_arithm.move:63: multiply_1_x_incorrect
-   =     at tests/sources/functional/fixed_point_arithm.move:65: multiply_1_x_incorrect (spec)
-   =     at tests/sources/functional/fixed_point_arithm.move:67: multiply_1_x_incorrect (spec)
+   =     at tests/sources/functional/fixed_point_arithm.move:66: multiply_1_x_incorrect
+   =     at tests/sources/functional/fixed_point_arithm.move:68: multiply_1_x_incorrect (spec)
+   =     at tests/sources/functional/fixed_point_arithm.move:70: multiply_1_x_incorrect (spec)
 
 error: post-condition does not hold
-   ┌─ tests/sources/functional/fixed_point_arithm.move:44:9
+   ┌─ tests/sources/functional/fixed_point_arithm.move:47:9
    │
-44 │         ensures result == 1; // disproved
+47 │         ensures result == 1; // disproved
    │         ^^^^^^^^^^^^^^^^^^^^
    │
-   =     at tests/sources/functional/fixed_point_arithm.move:39: multiply_x_0_incorrect
+   =     at tests/sources/functional/fixed_point_arithm.move:42: multiply_x_0_incorrect
    =         x = <redacted>
-   =     at tests/sources/functional/fixed_point_arithm.move:40: multiply_x_0_incorrect
+   =     at tests/sources/functional/fixed_point_arithm.move:43: multiply_x_0_incorrect
    =         result = <redacted>
-   =     at tests/sources/functional/fixed_point_arithm.move:41: multiply_x_0_incorrect
-   =     at tests/sources/functional/fixed_point_arithm.move:43: multiply_x_0_incorrect (spec)
-   =     at tests/sources/functional/fixed_point_arithm.move:44: multiply_x_0_incorrect (spec)
+   =     at tests/sources/functional/fixed_point_arithm.move:44: multiply_x_0_incorrect
+   =     at tests/sources/functional/fixed_point_arithm.move:46: multiply_x_0_incorrect (spec)
+   =     at tests/sources/functional/fixed_point_arithm.move:47: multiply_x_0_incorrect (spec)
 
 error: post-condition does not hold
-   ┌─ tests/sources/functional/fixed_point_arithm.move:83:9
+   ┌─ tests/sources/functional/fixed_point_arithm.move:86:9
    │
-83 │         ensures result != x; // disproved
+86 │         ensures result != x; // disproved
    │         ^^^^^^^^^^^^^^^^^^^^
    │
-   =     at tests/sources/functional/fixed_point_arithm.move:78: multiply_x_1_incorrect
+   =     at tests/sources/functional/fixed_point_arithm.move:81: multiply_x_1_incorrect
    =         x = <redacted>
-   =     at tests/sources/functional/fixed_point_arithm.move:79: multiply_x_1_incorrect
+   =     at tests/sources/functional/fixed_point_arithm.move:82: multiply_x_1_incorrect
    =         result = <redacted>
-   =     at tests/sources/functional/fixed_point_arithm.move:80: multiply_x_1_incorrect
-   =     at tests/sources/functional/fixed_point_arithm.move:82: multiply_x_1_incorrect (spec)
-   =     at tests/sources/functional/fixed_point_arithm.move:83: multiply_x_1_incorrect (spec)
+   =     at tests/sources/functional/fixed_point_arithm.move:83: multiply_x_1_incorrect
+   =     at tests/sources/functional/fixed_point_arithm.move:85: multiply_x_1_incorrect (spec)
+   =     at tests/sources/functional/fixed_point_arithm.move:86: multiply_x_1_incorrect (spec)

--- a/language/move-prover/tests/sources/functional/shift.exp
+++ b/language/move-prover/tests/sources/functional/shift.exp
@@ -1,0 +1,79 @@
+Move prover returns: exiting with verification errors
+error: post-condition does not hold
+   ┌─ tests/sources/functional/shift.move:79:9
+   │
+79 │         ensures result == x << 10u8;
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   =     at tests/sources/functional/shift.move:65: shift_l_11_incorrect
+   =         x = <redacted>
+   =     at tests/sources/functional/shift.move:66: shift_l_11_incorrect
+   =         result = <redacted>
+   =     at tests/sources/functional/shift.move:67: shift_l_11_incorrect
+   =     at tests/sources/functional/shift.move:79: shift_l_11_incorrect (spec)
+
+error: post-condition does not hold
+   ┌─ tests/sources/functional/shift.move:30:9
+   │
+30 │         ensures result == x * 64 + 1;
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   =     at tests/sources/functional/shift.move:25: shiftl_64_incorrect
+   =         x = <redacted>
+   =     at tests/sources/functional/shift.move:26: shiftl_64_incorrect
+   =         result = <redacted>
+   =     at tests/sources/functional/shift.move:27: shiftl_64_incorrect
+   =     at tests/sources/functional/shift.move:30: shiftl_64_incorrect (spec)
+
+error: post-condition does not hold
+   ┌─ tests/sources/functional/shift.move:38:9
+   │
+38 │         ensures result == x * 128 + 1;
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   =     at tests/sources/functional/shift.move:33: shiftl_7_incorrect
+   =         x = <redacted>
+   =     at tests/sources/functional/shift.move:34: shiftl_7_incorrect
+   =         result = <redacted>
+   =     at tests/sources/functional/shift.move:35: shiftl_7_incorrect
+   =     at tests/sources/functional/shift.move:38: shiftl_7_incorrect (spec)
+
+error: post-condition does not hold
+   ┌─ tests/sources/functional/shift.move:46:9
+   │
+46 │         ensures result == x / 64 + 1;
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   =     at tests/sources/functional/shift.move:41: shiftr_64_incorrect
+   =         x = <redacted>
+   =     at tests/sources/functional/shift.move:42: shiftr_64_incorrect
+   =         result = <redacted>
+   =     at tests/sources/functional/shift.move:43: shiftr_64_incorrect
+   =     at tests/sources/functional/shift.move:46: shiftr_64_incorrect (spec)
+
+error: post-condition does not hold
+   ┌─ tests/sources/functional/shift.move:54:9
+   │
+54 │         ensures result == x / 128 + 1;
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   =     at tests/sources/functional/shift.move:49: shiftr_7_incorrect
+   =         x = <redacted>
+   =     at tests/sources/functional/shift.move:50: shiftr_7_incorrect
+   =         result = <redacted>
+   =     at tests/sources/functional/shift.move:51: shiftr_7_incorrect
+   =     at tests/sources/functional/shift.move:54: shiftr_7_incorrect (spec)
+
+error: post-condition does not hold
+   ┌─ tests/sources/functional/shift.move:89:9
+   │
+89 │         ensures result == x << a;
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   =     at tests/sources/functional/shift.move:82: var_shift_l_incorrect
+   =         x = <redacted>
+   =         a = <redacted>
+   =     at tests/sources/functional/shift.move:83: var_shift_l_incorrect
+   =         result = <redacted>
+   =     at tests/sources/functional/shift.move:84: var_shift_l_incorrect
+   =     at tests/sources/functional/shift.move:89: var_shift_l_incorrect (spec)

--- a/language/move-prover/tests/sources/functional/shift.move
+++ b/language/move-prover/tests/sources/functional/shift.move
@@ -1,0 +1,112 @@
+// exclude_for: cvc5
+
+// cvc5 seems to go into an infinite loop because of the recursive $pow function.
+// For some reason, it does not time out in a reasonable time.
+module 0x42::TestShift {
+
+    fun shiftl_1_correct(x: u64): u64 {
+        x << 1
+    }
+
+    spec shiftl_1_correct {
+        ensures result == 2*x % (1 << 64);
+        ensures x < (1 << 63) ==> result == 2*x;
+    }
+
+    fun shiftr_1_correct(x: u64): u64 {
+        x >> 1
+    }
+
+    spec shiftr_1_correct {
+        ensures result == x / 2;
+    }
+
+
+    fun shiftl_64_incorrect(x: u64): u64 {
+        x << 64u8
+    }
+
+    spec shiftl_64_incorrect {
+        ensures result == x * 64 + 1;
+    }
+
+    fun shiftl_7_incorrect(x: u64): u64 {
+        x << 7u8
+    }
+
+    spec shiftl_7_incorrect {
+        ensures result == x * 128 + 1;
+    }
+
+    fun shiftr_64_incorrect(x: u64): u64 {
+        x >> 64u8
+    }
+
+    spec shiftr_64_incorrect {
+        ensures result == x / 64 + 1;
+    }
+
+    fun shiftr_7_incorrect(x: u64): u64 {
+        x >> 7u8
+    }
+
+    spec shiftr_7_incorrect {
+        ensures result == x / 128 + 1;
+    }
+
+    fun shift_l_11_correct(x: u64): u64 {
+        x << 11u8
+    }
+
+    spec shift_l_11_correct {
+        ensures result == (x << 11u8) % (1 << 64);
+    }
+
+    fun shift_l_11_incorrect(x: u64): u64 {
+        x << 11u8
+    }
+
+    fun shift_r_11_correct(x: u64): u64 {
+        x >> 11u8
+    }
+
+    spec shift_r_11_correct {
+        ensures result == x / (1 << 11);
+    }
+
+
+    spec shift_l_11_incorrect {
+        ensures result == x << 10u8;
+    }
+
+    fun var_shift_l_incorrect(x: u64, a: u8): u64 {
+        x << a
+    }
+
+    spec var_shift_l_incorrect {
+        // The spec allows bits to be shifted beyond destination.
+        // E.g., x = 2, a = 99
+        ensures result == x << a;
+    }
+
+    fun var_shift_l_correct(x: u64, a: u8): u64 {
+        x << a
+    }
+
+    spec var_shift_l_correct {
+        // The spec allows bits to be shifted beyond destination.
+        // E.g., x = 2, a = 99
+        ensures result == (x << a) % (1 << 64);
+    }
+
+    fun var_shift_r_correct(x: u64, a: u8): u64 {
+        x >> a
+    }
+
+    spec var_shift_r_correct {
+        // The spec allows bits to be shifted beyond destination.
+        // E.g., x = 2, a = 99
+        ensures result == (x >> a);
+    }
+
+}

--- a/language/move-prover/tests/sources/functional/trace.exp
+++ b/language/move-prover/tests/sources/functional/trace.exp
@@ -27,7 +27,7 @@ error: global memory invariant does not hold
    │
    = Related Global Memory:
    =         Resource name: TestTracing_R
-   =         Values:  {Address(0): <redacted>, Default: empty}
+   =         Values:  {Address(24801): <redacted>, Default: empty}
    =     at tests/sources/functional/trace.move:29: publish_invalid
    =     at tests/sources/functional/trace.move:33: publish_invalid (spec)
    =         `let addr = Signer::address_of(s);` = <redacted>
@@ -45,7 +45,7 @@ error: post-condition does not hold
    │
    = Related Global Memory:
    =         Resource name: TestTracing_R
-   =         Values:  {Address(6334): <redacted>, Default: empty}
+   =         Values:  {Address(24801): <redacted>, Default: empty}
    = Related Bindings:
    =         addr = <redacted>
    =         exists<R>(addr) = <redacted>

--- a/language/move-stdlib/docs/Errors.md
+++ b/language/move-stdlib/docs/Errors.md
@@ -178,7 +178,7 @@ A function to create an error from from a category and a reason.
 
 
 <pre><code><b>pragma</b> opaque = <b>true</b>;
-<b>ensures</b> [concrete] result == category + (reason &lt;&lt; 8);
+<b>ensures</b> [concrete] result == category + (reason &lt;&lt; 8) % (1 &lt;&lt; 64);
 <b>aborts_if</b> [abstract] <b>false</b>;
 <b>ensures</b> [abstract] result == category;
 </code></pre>

--- a/language/move-stdlib/sources/Errors.move
+++ b/language/move-stdlib/sources/Errors.move
@@ -19,7 +19,11 @@ module Std::Errors {
     }
     spec make {
         pragma opaque = true;
-        ensures [concrete] result == category + (reason << 8);
+        // The % below is to account for bits that could be shifted off the left end.
+        // For correctness, we would like that never to happen, but I'm cautious about
+        // using assert! in this module (no other uses), and require is just going to
+        // cause verification errors in public calling functions below.
+        ensures [concrete] result == category + (reason << 8) % (1 << 64);
         aborts_if [abstract] false;
         ensures [abstract] result == category;
     }


### PR DESCRIPTION
Issue #147 reported a bug in the left shift operation where the prover
failed to report an obviously violated postcondition.  The report also
observed that the shift operators were only for a few shift amounts.
It is unfortunate that the unimplemented shift amounts did not result
in a false error report.  Upon inspection of the code, I also found a
"TODO" that shift left doesn't delete bits that are shifted left of
the end of the destination.  In the prover, this would result in cases
where the unbounded integer value would exceed the upper bound imposed
by the bit width of the destination.

The use of a recursive function raises a risk of non-termination, but
it seems to work fine in test cases, including a variable shift
(somewhat to my surprise).

I made the following changes and improvements
1. In prelude.bpl, implemented a recursive function $pow
   to raise an integer value an integer exponent. It explicitly
   returns an undefined result when the exponent is negative,
   to eliminate an obvious possibility for non-termination.
2. Change $shl and $shr to call this function to raise 2 to
   the shift amount, the multiply or divide the shifted value by
   that amount.
3. Added sized shift-left instructions $ShlU8/64/128 which call
   $shl and then mod the result by the appropriate amount to delete
   bits that would be shifted beyond the limits of the destination.
   No such change was required for $Shr, so there is only one $Shr
   operator.
4. Modified bytecode_translator to generation $ShlU8/64/128 instead of
   $Shl.
5. Added function tests for shift operators in shift.move

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/diem/diem/tree/main/developers.diem.com, and link to your PR here.)

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
