### PR TITLE
[move-package] Ensure dev-addresses are unique

### DIFF
--- a/language/tools/move-cli/tests/move_unit_tests/assign_dev_addr_for_dep/Move.toml
+++ b/language/tools/move-cli/tests/move_unit_tests/assign_dev_addr_for_dep/Move.toml
@@ -8,7 +8,7 @@ A = "_"
 [dev-addresses]
 Std = "0x1"
 A = "0x2"
-B = "0x2"
+B = "0x3"
 
 [dev-dependencies]
 MoveStdlib = { local = "../../../../../move-stdlib" }

--- a/language/tools/move-package/tests/test_sources/resolution/conflicting_dev_address_with_dep/Move.exp
+++ b/language/tools/move-package/tests/test_sources/resolution/conflicting_dev_address_with_dep/Move.exp
@@ -1,0 +1,1 @@
+Unable to resolve packages for package 'Root': Found non-unique dev address assignment 'B = 0x1' in root package 'Root'. Dev address assignments must not conflict with any other assignments in order to ensure that the package will compile with any possible address assignment. Assignment conflicts with previous assignments: A = 0x1

--- a/language/tools/move-package/tests/test_sources/resolution/conflicting_dev_address_with_dep/Move.toml
+++ b/language/tools/move-package/tests/test_sources/resolution/conflicting_dev_address_with_dep/Move.toml
@@ -1,0 +1,12 @@
+[package]
+name = "Root"
+version = "0.0.0"
+
+[addresses]
+B = "_"
+
+[dev-addresses]
+B = "0x1"
+
+[dependencies]
+A = { local = "./deps_only/A" }

--- a/language/tools/move-package/tests/test_sources/resolution/conflicting_dev_address_with_dep/deps_only/A/Move.toml
+++ b/language/tools/move-package/tests/test_sources/resolution/conflicting_dev_address_with_dep/deps_only/A/Move.toml
@@ -1,0 +1,6 @@
+[package]
+name = "A"
+version = "0.0.0"
+
+[addresses]
+A = "0x1"

--- a/language/tools/move-package/tests/test_sources/resolution/conflicting_dev_address_with_dev_dep/Move.exp
+++ b/language/tools/move-package/tests/test_sources/resolution/conflicting_dev_address_with_dev_dep/Move.exp
@@ -1,0 +1,1 @@
+Unable to resolve packages for package 'Root': Found non-unique dev address assignment 'B = 0x1' in root package 'Root'. Dev address assignments must not conflict with any other assignments in order to ensure that the package will compile with any possible address assignment. Assignment conflicts with previous assignments: A = 0x1

--- a/language/tools/move-package/tests/test_sources/resolution/conflicting_dev_address_with_dev_dep/Move.toml
+++ b/language/tools/move-package/tests/test_sources/resolution/conflicting_dev_address_with_dev_dep/Move.toml
@@ -1,0 +1,13 @@
+[package]
+name = "Root"
+version = "0.0.0"
+
+[addresses]
+B = "_"
+A = "0x1"
+
+[dev-addresses]
+B = "0x1"
+
+[dev-dependencies]
+A = { local = "./deps_only/A" }

--- a/language/tools/move-package/tests/test_sources/resolution/conflicting_dev_address_with_dev_dep/deps_only/A/Move.toml
+++ b/language/tools/move-package/tests/test_sources/resolution/conflicting_dev_address_with_dev_dep/deps_only/A/Move.toml
@@ -1,0 +1,9 @@
+[package]
+name = "A"
+version = "0.0.0"
+
+[addresses]
+A = "_"
+
+[dev-addresses]
+A = "0x1"

--- a/language/tools/move-package/tests/test_sources/resolution/conflicting_dev_addresses/Move.exp
+++ b/language/tools/move-package/tests/test_sources/resolution/conflicting_dev_addresses/Move.exp
@@ -1,0 +1,1 @@
+Unable to resolve packages for package 'Root': Found non-unique dev address assignment 'B = 0x1' in root package 'Root'. Dev address assignments must not conflict with any other assignments in order to ensure that the package will compile with any possible address assignment. Assignment conflicts with previous assignments: A = 0x1

--- a/language/tools/move-package/tests/test_sources/resolution/conflicting_dev_addresses/Move.toml
+++ b/language/tools/move-package/tests/test_sources/resolution/conflicting_dev_addresses/Move.toml
@@ -1,0 +1,11 @@
+[package]
+name = "Root"
+version = "0.0.0"
+
+[addresses]
+A = "_"
+B = "_"
+
+[dev-addresses]
+A = "0x1"
+B = "0x1"

--- a/language/tools/move-package/tests/test_sources/resolution/sources/B.move
+++ b/language/tools/move-package/tests/test_sources/resolution/sources/B.move
@@ -1,0 +1,7 @@
+module B::M {
+    struct S has drop {}
+    fun foo(_: S) {}
+    fun bar() {
+        foo(A::M::S {})
+    }
+}


### PR DESCRIPTION
## Motivation

- With the recent change (#145) to named addresses being transparent, it is now possible for code to not work for every possible instantiation of addresses
- This fixes that by ensuring unassigned addresses, set in dev addresses, are assigned to a unique address
- We still need to ban/warn against non-named address qualification of module members to fully ensure packages compile properly with any mapping of named addresses 

## Test Plan

new tests 

## Related PRs

- Followup to #145 