### PR TITLE
fix transactional-test-runner::tasks::TaskCommand

### DIFF
--- a/language/testing-infra/transactional-test-runner/src/tasks.rs
+++ b/language/testing-infra/transactional-test-runner/src/tasks.rs
@@ -369,11 +369,12 @@ impl<
     > CommandFactory for TaskCommand<ExtraInitArgs, ExtraPublishArgs, ExtraRunArgs, SubCommands>
 {
     fn into_app<'help>() -> Command<'help> {
-        clap::Command::new("Task Command")
-            .subcommand(InitCommand::command().name("init"))
+        SubCommands::command()
+            .name("Task Command")
+            .subcommand(InitCommand::augment_args(ExtraInitArgs::command()).name("init"))
             .subcommand(PrintBytecodeCommand::command().name("print-bytecode"))
-            .subcommand(PublishCommand::command().name("publish"))
-            .subcommand(RunCommand::command().name("run"))
+            .subcommand(PublishCommand::augment_args(ExtraPublishArgs::command()).name("publish"))
+            .subcommand(RunCommand::augment_args(ExtraRunArgs::command()).name("run"))
             .subcommand(ViewCommand::command().name("view"))
     }
 


### PR DESCRIPTION
## Motivation

https://github.com/diem/move/pull/130 made it ignore extra arguments passed in by the test adapter, which broke Diem/Aptos tests



### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

Aptos side tests work with this.
