### PR TITLE
[evm] Added more hardhat examples

### DIFF
--- a/language/evm/hardhat-examples/contracts/Event.abi.json
+++ b/language/evm/hardhat-examples/contracts/Event.abi.json
@@ -1,0 +1,99 @@
+[
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "x",
+        "type": "uint64"
+      }
+    ],
+    "name": "SimpleEvent",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "x",
+        "type": "uint64"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "message",
+        "type": "string"
+      }
+    ],
+    "name": "MyEvent",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "x",
+        "type": "uint64"
+      }
+    ],
+    "name": "emitSimpleEvent",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "x",
+        "type": "uint64"
+      }
+    ],
+    "name": "emitSimpleEventTwice",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "x",
+        "type": "uint64"
+      }
+    ],
+    "name": "emitNothing",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "x",
+        "type": "uint64"
+      }
+    ],
+    "name": "emitMyEvent",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "x",
+        "type": "uint64"
+      }
+    ],
+    "name": "emitMyEventTwice",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/language/evm/hardhat-examples/contracts/Event.move
+++ b/language/evm/hardhat-examples/contracts/Event.move
@@ -1,0 +1,41 @@
+module 0x1::FortyTwo {
+    use Evm::Evm::{emit};
+
+    #[event]
+    struct SimpleEvent {
+        x: u64,
+    }
+
+    #[callable(sig=b"emitNothing(uint64)")]
+    public fun emitNothing(_x: u64) {
+    }
+
+    #[callable(sig=b"emitEvent(uint64)")]
+    public fun emitSimpleEvent(x: u64) {
+        emit(SimpleEvent{x});
+    }
+
+    #[callable(sig=b"emitEventTwice(uint64)")]
+    public fun emitSimpleEventTwice(x: u64) {
+        emit(SimpleEvent{x});
+        emit(SimpleEvent{x: x+x});
+    }
+
+    // TODO: move-to-yul does not support events with string args.
+    // #[event]
+    // struct MyEvent {
+    //     x: u64,
+    //     message: vector<u8>,
+    // }
+
+    // #[callable(sig=b"emitMyEvent(uint64)")]
+    // public fun emitMyEvent(x: u64) {
+    //     emit(MyEvent{x, message: b"hello_event"});
+    // }
+
+    // #[callable(sig=b"emitMyEventTwice(uint64)")]
+    // public fun emitMyEventTwice(x: u64) {
+    //     emit(MyEvent{x, message: b"hello_event_#1"});
+    //     emit(MyEvent{x+x, message: b"hello_event_#2"});
+    // }
+}

--- a/language/evm/hardhat-examples/contracts/Event.sol
+++ b/language/evm/hardhat-examples/contracts/Event.sol
@@ -1,0 +1,28 @@
+//SPDX-License-Identifier: Unlicense
+pragma solidity ^0.8.0;
+
+contract Event {
+    event SimpleEvent(uint64 x);
+    event MyEvent(uint64 x, string message);
+
+    function emitNothing(uint64 x) public {
+    }
+
+    function emitSimpleEvent(uint64 x) public {
+        emit SimpleEvent(x);
+    }
+
+    function emitSimpleEventTwice(uint64 x) public {
+        emit SimpleEvent(x);
+        emit SimpleEvent(x+x);
+    }
+
+    function emitMyEvent(uint64 x) public {
+        emit MyEvent(x, "hello_event");
+    }
+
+    function emitMyEventTwice(uint64 x) public {
+        emit MyEvent(x, "hello_event_#1");
+        emit MyEvent(x+x, "hello_event_#2");
+    }
+}

--- a/language/evm/hardhat-examples/contracts/FortyTwo.sol
+++ b/language/evm/hardhat-examples/contracts/FortyTwo.sol
@@ -1,8 +1,6 @@
 //SPDX-License-Identifier: Unlicense
 pragma solidity ^0.8.0;
 
-import "hardhat/console.sol";
-
 contract FortyTwo {
     function forty_two() public pure returns (uint64) {
         return 42;

--- a/language/evm/hardhat-examples/contracts/Greeter.sol
+++ b/language/evm/hardhat-examples/contracts/Greeter.sol
@@ -1,8 +1,6 @@
 //SPDX-License-Identifier: Unlicense
 pragma solidity ^0.8.0;
 
-import "hardhat/console.sol";
-
 contract Greeter {
     string private greeting;
 

--- a/language/evm/hardhat-examples/contracts/Native.abi.json
+++ b/language/evm/hardhat-examples/contracts/Native.abi.json
@@ -1,0 +1,28 @@
+[
+    {
+      "inputs": [],
+      "name": "getContractAddr",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "getSenderAddr",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    }
+  ]

--- a/language/evm/hardhat-examples/contracts/Native.move
+++ b/language/evm/hardhat-examples/contracts/Native.move
@@ -1,0 +1,13 @@
+module 0x1::Native {
+    use Evm::Evm::{self, sender};
+
+    #[callable, view]
+    public fun getContractAddr(): address {
+        self()
+    }
+
+    #[callable, view]
+    public fun getSenderAddr(): address {
+        sender()
+    }
+}

--- a/language/evm/hardhat-examples/contracts/Native.sol
+++ b/language/evm/hardhat-examples/contracts/Native.sol
@@ -1,0 +1,12 @@
+//SPDX-License-Identifier: Unlicense
+pragma solidity ^0.8.0;
+
+contract Native {
+    function getContractAddr() public view returns (address) {
+        return address(this);
+    }
+
+    function getSenderAddr() public view returns (address) {
+        return msg.sender;
+    }
+}

--- a/language/evm/hardhat-examples/contracts/Revert.abi.json
+++ b/language/evm/hardhat-examples/contracts/Revert.abi.json
@@ -1,0 +1,34 @@
+[
+    {
+        "inputs": [
+        {
+            "internalType": "uint64",
+            "name": "x",
+            "type": "uint64"
+        }
+        ],
+        "name": "revertIf0",
+        "outputs": [
+        {
+            "internalType": "uint64",
+            "name": "",
+            "type": "uint64"
+        }
+        ],
+        "stateMutability": "pure",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "revertWithMessage",
+        "outputs": [
+        {
+            "internalType": "uint64",
+            "name": "",
+            "type": "uint64"
+        }
+        ],
+        "stateMutability": "pure",
+        "type": "function"
+    }
+]

--- a/language/evm/hardhat-examples/contracts/Revert.move
+++ b/language/evm/hardhat-examples/contracts/Revert.move
@@ -1,0 +1,16 @@
+module 0x1::Revert {
+    use Evm::U256::{u256_from_u128, U256};
+
+    #[callable, pure]
+    public fun revertIf0(x: u64) {
+        if (x == 0) {
+            abort(0);
+        }
+    }
+
+    #[callable, pure]
+    public fun revertWithMessage() {
+        // TODO: The native function `Evm::abortWith` is not implemented.
+        abort(0);
+    }
+}

--- a/language/evm/hardhat-examples/contracts/Revert.sol
+++ b/language/evm/hardhat-examples/contracts/Revert.sol
@@ -1,0 +1,15 @@
+//SPDX-License-Identifier: Unlicense
+pragma solidity ^0.8.0;
+
+contract Revert {
+    function revertIf0(uint64 x) public pure returns (uint64) {
+        if (x == 0) {
+            revert();
+        }
+        return x;
+    }
+
+    function revertWithMessage() public pure returns (uint64) {
+        revert('error message');
+    }
+}

--- a/language/evm/hardhat-examples/package-lock.json
+++ b/language/evm/hardhat-examples/package-lock.json
@@ -856,6 +856,15 @@
         "@types/web3": "1.0.19"
       }
     },
+    "@nomiclabs/hardhat-web3": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@nomiclabs/hardhat-web3/-/hardhat-web3-2.0.0.tgz",
+      "integrity": "sha512-zt4xN+D+fKl3wW2YlTX3k9APR3XZgPkxJYf36AcliJn3oujnKEVRZaHu0PhgLjO+gR+F/kiYayo9fgd2L8970Q==",
+      "dev": true,
+      "requires": {
+        "@types/bignumber.js": "^5.0.0"
+      }
+    },
     "@openzeppelin/contract-loader": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/@openzeppelin/contract-loader/-/contract-loader-0.6.3.tgz",
@@ -2109,6 +2118,15 @@
       "resolved": "https://registry.npmjs.org/@types/abstract-leveldown/-/abstract-leveldown-7.2.0.tgz",
       "integrity": "sha512-q5veSX6zjUy/DlDhR4Y4cU0k2Ar+DT2LUraP00T19WLmTO6Se1djepCCaqU6nQrwcJ5Hyo/CWqxTzrrFg8eqbQ==",
       "dev": true
+    },
+    "@types/bignumber.js": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/bignumber.js/-/bignumber.js-5.0.0.tgz",
+      "integrity": "sha512-0DH7aPGCClywOFaxxjE6UwpN2kQYe9LwuDQMv+zYA97j5GkOMo8e66LYT+a8JYU7jfmUFRZLa9KycxHDsKXJCA==",
+      "dev": true,
+      "requires": {
+        "bignumber.js": "*"
+      }
     },
     "@types/bn.js": {
       "version": "5.1.0",

--- a/language/evm/hardhat-examples/package.json
+++ b/language/evm/hardhat-examples/package.json
@@ -12,10 +12,12 @@
   "devDependencies": {
     "@nomiclabs/hardhat-ethers": "^2.0.5",
     "@nomiclabs/hardhat-waffle": "^2.0.3",
+    "@nomiclabs/hardhat-web3": "^2.0.0",
     "@openzeppelin/test-helpers": "^0.5.15",
     "chai": "^4.3.6",
     "ethereum-waffle": "^3.4.4",
     "ethers": "^5.6.2",
-    "hardhat": "^2.9.2"
+    "hardhat": "^2.9.2",
+    "web3": "^1.7.1"
   }
 }

--- a/language/evm/hardhat-examples/test/Event.test.js
+++ b/language/evm/hardhat-examples/test/Event.test.js
@@ -1,0 +1,28 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("Event", function () {
+  before(async function () {
+    this.Event = await ethers.getContractFactory("Event");
+    this.event = await this.Event.deploy();
+    await this.event.deployed();
+  });
+  it("emitSimpleEvent(42) should return an event", async function () {
+    const tx = this.event.emitSimpleEvent(42);
+    await expect(tx).to.emit(this.event, 'SimpleEvent').withArgs(42);
+  });
+  it("emitSimpleEventTwice(42) should return two events", async function () {
+      const tx = this.event.emitSimpleEventTwice(42);
+      await expect(tx).to.emit(this.event, 'SimpleEvent').withArgs(42);
+      await expect(tx).to.emit(this.event, 'SimpleEvent').withArgs(84);
+  });
+  it("emitMyEvent(42) should return an event", async function () {
+    const tx = this.event.emitMyEvent(42);
+    await expect(tx).to.emit(this.event, 'MyEvent').withArgs(42, 'hello_event');
+  });
+  it("emitMyEventTwice(42) should return two events", async function () {
+      const tx = this.event.emitMyEventTwice(42);
+      await expect(tx).to.emit(this.event, 'MyEvent').withArgs(42, 'hello_event_#1');
+      await expect(tx).to.emit(this.event, 'MyEvent').withArgs(84, 'hello_event_#2');
+  });
+});

--- a/language/evm/hardhat-examples/test/Native.test.js
+++ b/language/evm/hardhat-examples/test/Native.test.js
@@ -1,0 +1,18 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("Native", function () {
+  before(async function () {
+    this.Native = await ethers.getContractFactory("Native");
+    this.native = await this.Native.deploy();
+    await this.native.deployed();
+  });
+  it("getContractAddr() should return the contract address", async function () {
+    const tx = this.native.getContractAddr();
+    expect(await tx).to.equal(this.native.address);
+  });
+  it("getSenderAddr() should return the sender address", async function () {
+    const tx = this.native.getSenderAddr();
+    expect(await tx).to.equal(this.native.signer.address);
+  });
+});

--- a/language/evm/hardhat-examples/test/Revert.test.js
+++ b/language/evm/hardhat-examples/test/Revert.test.js
@@ -1,0 +1,18 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("Revert", function () {
+  before(async function () {
+    this.Revert = await ethers.getContractFactory("Revert");
+    this.revert = await this.Revert.deploy();
+    await this.revert.deployed();
+  });
+  it("revertIf0(0) should revert", async function () {
+    const tx = this.revert.revertIf0(0);
+    await expect(tx).to.be.reverted;
+  });
+  it("revertWithMessage() should revert with a message", async function () {
+    const tx = this.revert.revertWithMessage();
+    await expect(tx).to.be.revertedWith('error message');
+  });
+});

--- a/language/evm/stdlib/sources/Evm.move
+++ b/language/evm/stdlib/sources/Evm.move
@@ -32,7 +32,7 @@ module Evm::Evm {
     /// Creates a signer for the contract's address space.
     public native fun sign(addr: address): signer;
 
-        /// Returns the keccak256 hash for the input `data`.
+    /// Returns the keccak256 hash for the input `data`.
     /// The length of the resulting vector should be 32.
     public native fun keccak256(data: vector<u8>): vector<u8>;
 
@@ -70,6 +70,9 @@ module Evm::Evm {
     // This is implemented in Solidity as follows:
     //   bytes(baseURI).length > 0 ? string(abi.encodePacked(baseURI, tokenId.toString())) : "";
     public native fun tokenURI_with_baseURI(baseURI: String, tokenId: U256): String;
+
+    /// Abort with an error message.
+    public native fun abortWith(message: vector<u8>);
 
     // --------------------------------
     // Block and Transaction Properties


### PR DESCRIPTION
Added the following contracts and their tests:
- Event: to test the event emission
- Revert: to test reverting with/without a custom message
- Native: to test the native functions such as `self()` and `sender()`

TODO:
- move-to-yul does not support events with string arguments. the Move contracts fail on the tests of Event and Revert. https://github.com/diem/move/issues/170
- Move-on-EVM should be able to revert (or abort) with a custom error message. https://github.com/diem/move/issues/171

## Motivation

To add more hardhat examples for testing Move-on-Evm

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

hardhat test

