### PR TITLE
[evm] run hardhat tests in CI

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -162,6 +162,38 @@ jobs:
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
 
+  hardhat-tests:
+    runs-on: ubuntu-20.04-xl
+    timeout-minutes: 20
+    needs: prepare
+    if: ${{ needs.prepare.outputs.test-rust == 'true' }}
+    container:
+      image: ghcr.io/diem/diem_build_environment:${{ needs.prepare.outputs.changes-target-branch }}
+      volumes:
+        - "${{github.workspace}}:/opt/git/diem"
+    steps:
+      - uses: actions/checkout@v2.4.0
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - uses: ./.github/actions/build-setup
+      - uses: Swatinem/rust-cache@c5ed9ba6b7e1bb8aff90d43acd2f0af4990fa57c
+      - name: setup hardhat
+        working-directory: language/evm/hardhat-examples
+        run: "./setup.sh"
+      - name: compile and install move-to-yul
+        working-directory: language/evm/move-to-yul
+        run: "cargo install --path ."
+      - name: run hardhat tests (Move contracts)
+        working-directory: language/evm/hardhat-examples
+        run: "./compile_all_and_run_tests.sh"
+      # TODO: reenable this once we figure a way to keep package-lock.json stable.
+      # - uses: ./.github/actions/build-teardown
+      - name: Early terminate workflow
+        if: ${{ failure() }}
+        uses: ./.github/actions/early-terminator
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+
   # Compile (but don't run) the benchmarks, to insulate against bit rot
   build-benchmarks:
     runs-on: ubuntu-20.04-xl

--- a/language/evm/hardhat-examples/compile_all_and_run_tests.sh
+++ b/language/evm/hardhat-examples/compile_all_and_run_tests.sh
@@ -2,6 +2,8 @@
 # Copyright (c) The Diem Core Contributors
 # SPDX-License-Identifier: Apache-2.0
 
+# Script to compile Move contracts and run unit tests.
+
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 npx hardhat compile && python3 "$SCRIPT_DIR/compile_move.py" && npx hardhat test --no-compile

--- a/language/evm/hardhat-examples/contracts/Event.move
+++ b/language/evm/hardhat-examples/contracts/Event.move
@@ -30,13 +30,13 @@ module 0x1::FortyTwo {
 
     #[callable(sig=b"emitMyEvent(uint64)")]
     public fun emitMyEvent(x: u64) {
-         emit(MyEvent{x, message: b"hello_event"});
+        emit(MyEvent{x, message: b"hello_event"});
     }
 
     #[callable(sig=b"emitMyEventTwice(uint64)")]
     public fun emitMyEventTwice(x: u64) {
-         emit(MyEvent{x, message: b"hello_event_#1"});
-         emit(MyEvent{x: x+x, message: b"hello_event_#2"});
+        emit(MyEvent{x, message: b"hello_event_#1"});
+        emit(MyEvent{x: x+x, message: b"hello_event_#2"});
     }
 
     #[callable(sig=b"emitMyEventWith(uint64,string)")]

--- a/language/evm/hardhat-examples/contracts/FortyTwo.move
+++ b/language/evm/hardhat-examples/contracts/FortyTwo.move
@@ -14,7 +14,7 @@ module 0x1::FortyTwo {
     // TODO: move-to-yul does not support literal string.
     #[callable(sig=b"forty_two_as_string() returns (string)"), pure]
     public fun forty_two_as_string(): vector<u8> {
-         b"forty two"
+        b"forty two"
     }
 
     #[callable, pure]

--- a/language/evm/hardhat-examples/setup.sh
+++ b/language/evm/hardhat-examples/setup.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Copyright (c) The Diem Core Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+# Hardhat packages, along with their dependencies, are not checked into the Move repo.
+# Use this script to get them downloaded and configured.
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+cd $SCRIPT_DIR
+
+npm install --save-dev hardhat

--- a/language/evm/hardhat-examples/test/Event.test.js
+++ b/language/evm/hardhat-examples/test/Event.test.js
@@ -1,8 +1,8 @@
 const { expect } = require("chai");
 const { ethers } = require("hardhat");
 
-const make_test = function(contract_name) {
-  return function() {
+const make_test = function (contract_name) {
+  return function () {
     before(async function () {
       this.Event = await ethers.getContractFactory(contract_name);
       this.event = await this.Event.deploy();
@@ -13,27 +13,27 @@ const make_test = function(contract_name) {
       await expect(tx).to.emit(this.event, 'SimpleEvent').withArgs(42);
     });
     it("emitSimpleEventTwice(42) should emit two events", async function () {
-        const tx = this.event.emitSimpleEventTwice(42);
-        await expect(tx).to.emit(this.event, 'SimpleEvent').withArgs(42);
-        await expect(tx).to.emit(this.event, 'SimpleEvent').withArgs(84);
+      const tx = this.event.emitSimpleEventTwice(42);
+      await expect(tx).to.emit(this.event, 'SimpleEvent').withArgs(42);
+      await expect(tx).to.emit(this.event, 'SimpleEvent').withArgs(84);
     });
     it("emitMyEvent(42) should emit an event", async function () {
       const tx = this.event.emitMyEvent(42);
       await expect(tx).to.emit(this.event, 'MyEvent').withArgs(42, 'hello_event');
     });
     it("emitMyEventTwice(42) should emit two events", async function () {
-        const tx = this.event.emitMyEventTwice(42);
-        await expect(tx).to.emit(this.event, 'MyEvent').withArgs(42, 'hello_event_#1');
-        await expect(tx).to.emit(this.event, 'MyEvent').withArgs(84, 'hello_event_#2');
+      const tx = this.event.emitMyEventTwice(42);
+      await expect(tx).to.emit(this.event, 'MyEvent').withArgs(42, 'hello_event_#1');
+      await expect(tx).to.emit(this.event, 'MyEvent').withArgs(84, 'hello_event_#2');
     });
     it("emitMyEventWith(42, 'hello_event') should emit an event", async function () {
       const tx = this.event.emitMyEventWith(42, "hello_event");
       await expect(tx).to.emit(this.event, 'MyEvent').withArgs(42, 'hello_event');
     });
     it("emitMyEventWithTwice(42, 'hello_event') should emit two events", async function () {
-        const tx = this.event.emitMyEventWithTwice(42, "hello_event");
-        await expect(tx).to.emit(this.event, 'MyEvent').withArgs(42, 'hello_event');
-        await expect(tx).to.emit(this.event, 'MyEvent').withArgs(84, 'hello_event');
+      const tx = this.event.emitMyEventWithTwice(42, "hello_event");
+      await expect(tx).to.emit(this.event, 'MyEvent').withArgs(42, 'hello_event');
+      await expect(tx).to.emit(this.event, 'MyEvent').withArgs(84, 'hello_event');
     });
     it("emitU256Event should emit a U256Event event", async function () {
       const tx = this.event.emitU256Event(0);

--- a/language/evm/hardhat-examples/test/Event.truffle.test.js
+++ b/language/evm/hardhat-examples/test/Event.truffle.test.js
@@ -29,7 +29,7 @@ contract('Truffle-style testing for Event (the Move contract)', function (accoun
             { from: ZERO_ADDRESS, to: ZERO_ADDRESS, value: new BN(7) },
         );
     });
-    //// Enable this to show the events emitted.
+    // Enable this to show the events emitted.
     // it('display the events emitted', async function () {
     //     await this.event.emitTransfer(ZERO_ADDRESS, ZERO_ADDRESS, new BN(7));
     //     let events = await this.event.getPastEvents();

--- a/language/evm/hardhat-examples/test/FortyTwo.test.js
+++ b/language/evm/hardhat-examples/test/FortyTwo.test.js
@@ -1,6 +1,6 @@
 const { expect } = require("chai");
 
-const make_test = function(contract_name) {
+const make_test = function (contract_name) {
   return function () {
     before(async function () {
       this.FortyTwo = await ethers.getContractFactory(contract_name);
@@ -14,8 +14,8 @@ const make_test = function(contract_name) {
       expect(await this.fortyTwo.forty_two_as_u256()).to.be.equal(42);
     });
     it("forty_two_as_string() should return \"forty two\"", async function () {
-       expect(await this.fortyTwo.forty_two_as_string()).to.be.equal("forty two");
-     });
+      expect(await this.fortyTwo.forty_two_as_string()).to.be.equal("forty two");
+    });
     it("forty_two_plus_alpha(7) should return 49", async function () {
       expect(await this.fortyTwo.forty_two_plus_alpha(7)).to.be.equal(42 + 7);
     });

--- a/language/evm/hardhat-examples/test/Greeter.test.js
+++ b/language/evm/hardhat-examples/test/Greeter.test.js
@@ -2,7 +2,7 @@ const { expect } = require("chai");
 const { ethers } = require("hardhat");
 
 
-const make_test = function(contract_name) {
+const make_test = function (contract_name) {
   return function () {
     it("Should return the new greeting once it's changed", async function () {
       const Greeter = await ethers.getContractFactory(contract_name);

--- a/language/evm/hardhat-examples/test/Revert.test.js
+++ b/language/evm/hardhat-examples/test/Revert.test.js
@@ -1,7 +1,7 @@
 const { expect } = require("chai");
 const { ethers } = require("hardhat");
 
-const make_test = function(contract_name) {
+const make_test = function (contract_name) {
   return function () {
     before(async function () {
       this.Revert = await ethers.getContractFactory(contract_name);


### PR DESCRIPTION
This makes it possible to run hardhat tests in CI. 

Full list of changes:
- Added a script to install hardhat using npm.
- Added a new github workflow: `ci-test / hardhat-tests`
- Disabled a few broken tests