### PR TITLE
[evm] Separated the Move contract tests from the Solidity contract tests

### DIFF
--- a/language/evm/hardhat-examples/compile_all_and_test.sh
+++ b/language/evm/hardhat-examples/compile_all_and_test.sh
@@ -4,4 +4,4 @@
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
-npx hardhat clean && python3 "$SCRIPT_DIR/compile_move.py" && npx hardhat test --no-compile
+npx hardhat compile && python3 "$SCRIPT_DIR/compile_move.py" && npx hardhat test --no-compile

--- a/language/evm/hardhat-examples/compile_sol_and_test.sh
+++ b/language/evm/hardhat-examples/compile_sol_and_test.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-# Copyright (c) The Diem Core Contributors
-# SPDX-License-Identifier: Apache-2.0
-
-npx hardhat clean && npx hardhat test

--- a/language/evm/hardhat-examples/contracts/Event.abi.json
+++ b/language/evm/hardhat-examples/contracts/Event.abi.json
@@ -95,5 +95,41 @@
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "x",
+        "type": "uint64"
+      },
+      {
+        "internalType": "string",
+        "name": "message",
+        "type": "string"
+      }
+    ],
+    "name": "emitMyEventWith",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "x",
+        "type": "uint64"
+      },
+      {
+        "internalType": "string",
+        "name": "message",
+        "type": "string"
+      }
+    ],
+    "name": "emitMyEventWithTwice",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
   }
 ]

--- a/language/evm/hardhat-examples/contracts/Event.move
+++ b/language/evm/hardhat-examples/contracts/Event.move
@@ -10,32 +10,43 @@ module 0x1::FortyTwo {
     public fun emitNothing(_x: u64) {
     }
 
-    #[callable(sig=b"emitEvent(uint64)")]
+    #[callable(sig=b"emitSimpleEvent(uint64)")]
     public fun emitSimpleEvent(x: u64) {
         emit(SimpleEvent{x});
     }
 
-    #[callable(sig=b"emitEventTwice(uint64)")]
+    #[callable(sig=b"emitSimpleEventTwice(uint64)")]
     public fun emitSimpleEventTwice(x: u64) {
         emit(SimpleEvent{x});
         emit(SimpleEvent{x: x+x});
     }
 
-    // TODO: move-to-yul does not support events with string args.
-    // #[event]
-    // struct MyEvent {
-    //     x: u64,
-    //     message: vector<u8>,
-    // }
+    #[event(sig=b"MyEvent(uint64,string)")]
+    struct MyEvent {
+        x: u64,
+        message: vector<u8>,
+    }
 
+    //TODO: move-to-yul does not support string literals.
     // #[callable(sig=b"emitMyEvent(uint64)")]
-    // public fun emitMyEvent(x: u64) {
+    // public fun emitMyEvent(x: u64, message) {
     //     emit(MyEvent{x, message: b"hello_event"});
     // }
 
     // #[callable(sig=b"emitMyEventTwice(uint64)")]
     // public fun emitMyEventTwice(x: u64) {
     //     emit(MyEvent{x, message: b"hello_event_#1"});
-    //     emit(MyEvent{x+x, message: b"hello_event_#2"});
+    //     emit(MyEvent{x: x+x, message: b"hello_event_#2"});
     // }
+
+    #[callable(sig=b"emitMyEventWith(uint64,string)")]
+    public fun emitMyEventWith(x: u64, message: vector<u8>) {
+        emit(MyEvent{x, message});
+    }
+
+    #[callable(sig=b"emitMyEventWithTwice(uint64,string)")]
+    public fun emitMyEventWithTwice(x: u64, message: vector<u8>) {
+        emit(MyEvent{x, message});
+        emit(MyEvent{x: x+x, message});
+    }
 }

--- a/language/evm/hardhat-examples/contracts/Event.sol
+++ b/language/evm/hardhat-examples/contracts/Event.sol
@@ -1,7 +1,7 @@
 //SPDX-License-Identifier: Unlicense
 pragma solidity ^0.8.0;
 
-contract Event {
+contract Event_Sol {
     event SimpleEvent(uint64 x);
     event MyEvent(uint64 x, string message);
 
@@ -24,5 +24,14 @@ contract Event {
     function emitMyEventTwice(uint64 x) public {
         emit MyEvent(x, "hello_event_#1");
         emit MyEvent(x+x, "hello_event_#2");
+    }
+
+    function emitMyEventWith(uint64 x, string memory message) public {
+        emit MyEvent(x, message);
+    }
+
+    function emitMyEventWithTwice(uint64 x, string memory message) public {
+        emit MyEvent(x, message);
+        emit MyEvent(x+x, message);
     }
 }

--- a/language/evm/hardhat-examples/contracts/FortyTwo.sol
+++ b/language/evm/hardhat-examples/contracts/FortyTwo.sol
@@ -1,7 +1,7 @@
 //SPDX-License-Identifier: Unlicense
 pragma solidity ^0.8.0;
 
-contract FortyTwo {
+contract FortyTwo_Sol {
     function forty_two() public pure returns (uint64) {
         return 42;
     }

--- a/language/evm/hardhat-examples/contracts/Greeter.sol
+++ b/language/evm/hardhat-examples/contracts/Greeter.sol
@@ -1,7 +1,9 @@
 //SPDX-License-Identifier: Unlicense
 pragma solidity ^0.8.0;
 
-contract Greeter {
+import "hardhat/console.sol";
+
+contract Greeter_Sol {
     string private greeting;
 
     constructor(string memory _greeting) {

--- a/language/evm/hardhat-examples/contracts/Native.sol
+++ b/language/evm/hardhat-examples/contracts/Native.sol
@@ -1,7 +1,7 @@
 //SPDX-License-Identifier: Unlicense
 pragma solidity ^0.8.0;
 
-contract Native {
+contract Native_Sol {
     function getContractAddr() public view returns (address) {
         return address(this);
     }

--- a/language/evm/hardhat-examples/contracts/Revert.sol
+++ b/language/evm/hardhat-examples/contracts/Revert.sol
@@ -1,7 +1,7 @@
 //SPDX-License-Identifier: Unlicense
 pragma solidity ^0.8.0;
 
-contract Revert {
+contract Revert_Sol {
     function revertIf0(uint64 x) public pure returns (uint64) {
         if (x == 0) {
             revert();

--- a/language/evm/hardhat-examples/test/Event.test.js
+++ b/language/evm/hardhat-examples/test/Event.test.js
@@ -1,28 +1,42 @@
 const { expect } = require("chai");
 const { ethers } = require("hardhat");
 
-describe("Event", function () {
-  before(async function () {
-    this.Event = await ethers.getContractFactory("Event");
-    this.event = await this.Event.deploy();
-    await this.event.deployed();
-  });
-  it("emitSimpleEvent(42) should return an event", async function () {
-    const tx = this.event.emitSimpleEvent(42);
-    await expect(tx).to.emit(this.event, 'SimpleEvent').withArgs(42);
-  });
-  it("emitSimpleEventTwice(42) should return two events", async function () {
-      const tx = this.event.emitSimpleEventTwice(42);
+const make_test = function(contract_name) {
+  return function() {
+    before(async function () {
+      this.Event = await ethers.getContractFactory(contract_name);
+      this.event = await this.Event.deploy();
+      await this.event.deployed();
+    });
+    it("emitSimpleEvent(42) should return an event", async function () {
+      const tx = this.event.emitSimpleEvent(42);
       await expect(tx).to.emit(this.event, 'SimpleEvent').withArgs(42);
-      await expect(tx).to.emit(this.event, 'SimpleEvent').withArgs(84);
-  });
-  it("emitMyEvent(42) should return an event", async function () {
-    const tx = this.event.emitMyEvent(42);
-    await expect(tx).to.emit(this.event, 'MyEvent').withArgs(42, 'hello_event');
-  });
-  it("emitMyEventTwice(42) should return two events", async function () {
-      const tx = this.event.emitMyEventTwice(42);
-      await expect(tx).to.emit(this.event, 'MyEvent').withArgs(42, 'hello_event_#1');
-      await expect(tx).to.emit(this.event, 'MyEvent').withArgs(84, 'hello_event_#2');
-  });
-});
+    });
+    it("emitSimpleEventTwice(42) should return two events", async function () {
+        const tx = this.event.emitSimpleEventTwice(42);
+        await expect(tx).to.emit(this.event, 'SimpleEvent').withArgs(42);
+        await expect(tx).to.emit(this.event, 'SimpleEvent').withArgs(84);
+    });
+    it("emitMyEvent(42) should return an event", async function () {
+      const tx = this.event.emitMyEvent(42);
+      await expect(tx).to.emit(this.event, 'MyEvent').withArgs(42, 'hello_event');
+    });
+    it("emitMyEventTwice(42) should return two events", async function () {
+        const tx = this.event.emitMyEventTwice(42);
+        await expect(tx).to.emit(this.event, 'MyEvent').withArgs(42, 'hello_event_#1');
+        await expect(tx).to.emit(this.event, 'MyEvent').withArgs(84, 'hello_event_#2');
+    });
+    it("emitMyEventWith(42, 'hello_event') should return an event", async function () {
+      const tx = this.event.emitMyEventWith(42, "hello_event");
+      await expect(tx).to.emit(this.event, 'MyEvent').withArgs(42, 'hello_event');
+    });
+    it("emitMyEventWithTwice(42, 'hello_event') should return two events", async function () {
+        const tx = this.event.emitMyEventWithTwice(42, "hello_event");
+        await expect(tx).to.emit(this.event, 'MyEvent').withArgs(42, 'hello_event');
+        await expect(tx).to.emit(this.event, 'MyEvent').withArgs(84, 'hello_event');
+    });
+  }
+};
+
+describe("Event (the Move contract)", make_test('Event'));
+describe("Event_Sol (the Solidity contract)", make_test('Event_Sol'));

--- a/language/evm/hardhat-examples/test/FortyTwo.test.js
+++ b/language/evm/hardhat-examples/test/FortyTwo.test.js
@@ -1,6 +1,6 @@
 const { expect } = require("chai");
 
-describe("FortyTwo", function () {
+describe("FortyTwo (the Move contract)", function () {
   before(async function () {
     this.FortyTwo = await ethers.getContractFactory("FortyTwo");
     this.fortyTwo = await this.FortyTwo.deploy();
@@ -19,6 +19,30 @@ describe("FortyTwo", function () {
   // it("forty_two_as_string() should return \"forty two\"", async function () {
   //   expect(await this.fortyTwo.forty_two_as_string()).to.be.equal("forty two");
   // });
+
+  it("forty_two_plus_alpha(7) should return 49", async function () {
+    expect(await this.fortyTwo.forty_two_plus_alpha(7)).to.be.equal(42 + 7);
+  });
+});
+
+describe("FortyTwo_Sol (the Solidity contract)", function () {
+  before(async function () {
+    this.FortyTwo = await ethers.getContractFactory("FortyTwo_Sol");
+    this.fortyTwo = await this.FortyTwo.deploy();
+    await this.fortyTwo.deployed();
+  });
+
+  it("forty_two() should return 42", async function () {
+    expect(await this.fortyTwo.forty_two()).to.be.equal(42);
+  });
+
+  it("forty_two_as_u256() should return 42", async function () {
+    expect(await this.fortyTwo.forty_two_as_u256()).to.be.equal(42);
+  });
+
+  it("forty_two_as_string() should return \"forty two\"", async function () {
+    expect(await this.fortyTwo.forty_two_as_string()).to.be.equal("forty two");
+  });
 
   it("forty_two_plus_alpha(7) should return 49", async function () {
     expect(await this.fortyTwo.forty_two_plus_alpha(7)).to.be.equal(42 + 7);

--- a/language/evm/hardhat-examples/test/Greeter.test.js
+++ b/language/evm/hardhat-examples/test/Greeter.test.js
@@ -1,7 +1,7 @@
 const { expect } = require("chai");
 const { ethers } = require("hardhat");
 
-describe("Greeter", function () {
+describe("Greeter (the Move contract)", function () {
   it("Should return the new greeting once it's changed", async function () {
     const Greeter = await ethers.getContractFactory("Greeter");
     // TODO: fix constructor argument issue
@@ -12,6 +12,23 @@ describe("Greeter", function () {
     const setGreetingTx = await greeter.setGreeting("Hola, mundo!");
     // wait until the transaction is mined
     await setGreetingTx.wait();
+    expect(await greeter.greet()).to.equal("Hola, mundo!");
+  });
+});
+
+describe("Greeter_Sol (the Solidity Contract)", function () {
+  it("Should return the new greeting once it's changed", async function () {
+    const Greeter = await ethers.getContractFactory("Greeter_Sol");
+    const greeter = await Greeter.deploy("Hello, world!");
+    await greeter.deployed();
+
+    expect(await greeter.greet()).to.equal("Hello, world!");
+
+    const setGreetingTx = await greeter.setGreeting("Hola, mundo!");
+
+    // wait until the transaction is mined
+    await setGreetingTx.wait();
+
     expect(await greeter.greet()).to.equal("Hola, mundo!");
   });
 });

--- a/language/evm/hardhat-examples/test/Native.test.js
+++ b/language/evm/hardhat-examples/test/Native.test.js
@@ -1,18 +1,23 @@
 const { expect } = require("chai");
 const { ethers } = require("hardhat");
 
-describe("Native", function () {
-  before(async function () {
-    this.Native = await ethers.getContractFactory("Native");
-    this.native = await this.Native.deploy();
-    await this.native.deployed();
-  });
-  it("getContractAddr() should return the contract address", async function () {
-    const tx = this.native.getContractAddr();
-    expect(await tx).to.equal(this.native.address);
-  });
-  it("getSenderAddr() should return the sender address", async function () {
-    const tx = this.native.getSenderAddr();
-    expect(await tx).to.equal(this.native.signer.address);
-  });
-});
+const make_test = function(contract_name) {
+  return function () {
+    before(async function () {
+      this.Native = await ethers.getContractFactory(contract_name);
+      this.native = await this.Native.deploy();
+      await this.native.deployed();
+    });
+    it("getContractAddr() should return the contract address", async function () {
+      const tx = this.native.getContractAddr();
+      expect(await tx).to.equal(this.native.address);
+    });
+    it("getSenderAddr() should return the sender address", async function () {
+      const tx = this.native.getSenderAddr();
+      expect(await tx).to.equal(this.native.signer.address);
+    });
+  }
+};
+
+describe("Native (the Move contract)", make_test("Native"));
+describe("Native_Sol (the Solidity contract)", make_test("Native_Sol"));

--- a/language/evm/hardhat-examples/test/Revert.test.js
+++ b/language/evm/hardhat-examples/test/Revert.test.js
@@ -1,18 +1,23 @@
 const { expect } = require("chai");
 const { ethers } = require("hardhat");
 
-describe("Revert", function () {
-  before(async function () {
-    this.Revert = await ethers.getContractFactory("Revert");
-    this.revert = await this.Revert.deploy();
-    await this.revert.deployed();
-  });
-  it("revertIf0(0) should revert", async function () {
-    const tx = this.revert.revertIf0(0);
-    await expect(tx).to.be.reverted;
-  });
-  it("revertWithMessage() should revert with a message", async function () {
-    const tx = this.revert.revertWithMessage();
-    await expect(tx).to.be.revertedWith('error message');
-  });
-});
+const make_test = function(contract_name) {
+  return function () {
+    before(async function () {
+      this.Revert = await ethers.getContractFactory(contract_name);
+      this.revert = await this.Revert.deploy();
+      await this.revert.deployed();
+    });
+    it("revertIf0(0) should revert", async function () {
+      const tx = this.revert.revertIf0(0);
+      await expect(tx).to.be.reverted;
+    });
+    it("revertWithMessage() should revert with a message", async function () {
+      const tx = this.revert.revertWithMessage();
+      await expect(tx).to.be.revertedWith('error message');
+    });
+  }
+};
+
+describe("Revert (the Move contract)", make_test("Revert"));
+describe("Revert_Sol (the Solidity contract)", make_test("Revert_Sol"));

--- a/language/evm/hardhat-examples/test/Token.test.js
+++ b/language/evm/hardhat-examples/test/Token.test.js
@@ -1,6 +1,6 @@
 const { expect } = require("chai");
 
-describe("Token", function () {
+describe("Token (the Move contract)", function () {
     before(async function () {
         this.Token = await ethers.getContractFactory("Token");
         this.token = await this.Token.deploy("user");


### PR DESCRIPTION
- Added the suffix `_Sol` to the names of the Solidity contracts so that they don't conflict with the Move contract names

- Duplicated the hardhat tests, so one is for the Move contracts, and another is for the Solidity contracts, and they don't overlap

- Merged the automated test scripts. `compile_all_and_test.sh` will compile both Move and Solidity contracts and test them.

- Fixed the test failures in the Event contract. Closes #170 

TODO:
  - move-to-yul does not support string literals.


## Motivation

To update the hardhat examples for Move

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

./compile_all_and_test.sh
