### PR TITLE
stub `impl TableResolver` for DeltaStorage

### DIFF
--- a/language/move-vm/test-utils/src/storage.rs
+++ b/language/move-vm/test-utils/src/storage.rs
@@ -111,6 +111,33 @@ impl<'a, 'b, S: ResourceResolver> ResourceResolver for DeltaStorage<'a, 'b, S> {
     }
 }
 
+#[cfg(feature = "table-extension")]
+impl<'a, 'b, S: TableResolver> TableResolver for DeltaStorage<'a, 'b, S> {
+    fn resolve_table_entry(
+        &self,
+        handle: &TableHandle,
+        key: &[u8],
+    ) -> std::result::Result<Option<Vec<u8>>, Error> {
+        // TODO: No support for table deltas
+        self.base.resolve_table_entry(handle, key)
+    }
+
+    fn table_size(&self, handle: &TableHandle) -> std::result::Result<usize, Error> {
+        // TODO: No support for table deltas
+        self.base.table_size(handle)
+    }
+
+    fn operation_cost(
+        &self,
+        op: TableOperation,
+        key_size: usize,
+        val_size: usize,
+    ) -> InternalGasUnits<GasCarrier> {
+        // TODO: No support for table deltas
+        self.base.operation_cost(op, key_size, val_size)
+    }
+}
+
 impl<'a, 'b, S: MoveResolver> DeltaStorage<'a, 'b, S> {
     pub fn new(base: &'a S, delta: &'b ChangeSet) -> Self {
         Self { base, delta }


### PR DESCRIPTION

## Motivation

To unblock downstream tests.

In Aptos repo we are trying to enforce the table extension to be installed everywhere, and this not supporting tables breaks compilation.



### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

y

## Test Plan

Downsteam tests pass
