### PR TITLE
[move-to-yul] JSON-ABI generation

### DIFF
--- a/language/evm/hardhat-examples/compile_move.py
+++ b/language/evm/hardhat-examples/compile_move.py
@@ -110,6 +110,10 @@ def move_to_yul(path_source):
             for (name, addr) in named_address_mapping.items():
                 args.append("{}={}".format(name, addr))
 
+        path_abi = path.splitext(path_source)[0] + ".abi.json"
+        args.append("--abi-output")
+        args.append(path_abi)
+
         args.extend(["--", path_source])
 
         move_to_yul_res = subprocess.run(args, capture_output = True)
@@ -158,8 +162,8 @@ def gen_artifact(path_source, abi, bytecode):
 
 def run(path_source):
     print("Compiling {}...".format(path_source))
-    abi = load_abi(path_source)
     yul_code = move_to_yul(path_source)
+    abi = load_abi(path_source)
     bytecode = solc(path_source, yul_code)
     gen_artifact(path_source, abi, bytecode)
 

--- a/language/evm/hardhat-examples/contracts/ERC20DecimalsMock.abi.json
+++ b/language/evm/hardhat-examples/contracts/ERC20DecimalsMock.abi.json
@@ -1,375 +1,261 @@
 [
+{
+  "name": "Approval",
+  "type": "event",
+  "inputs": [
     {
-      "inputs": [
-        {
-          "internalType": "string",
-          "name": "name",
-          "type": "string"
-        },
-        {
-          "internalType": "string",
-          "name": "symbol",
-          "type": "string"
-        },
-        {
-          "internalType": "uint8",
-          "name": "decimals",
-          "type": "uint8"
-        }
-      ],
-      "stateMutability": "payable",
-      "type": "constructor"
+      "type": "address",
+      "indexed": true,
+      "name": "owner"
     },
     {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": true,
-          "internalType": "address",
-          "name": "owner",
-          "type": "address"
-        },
-        {
-          "indexed": true,
-          "internalType": "address",
-          "name": "spender",
-          "type": "address"
-        },
-        {
-          "indexed": false,
-          "internalType": "uint256",
-          "name": "value",
-          "type": "uint256"
-        }
-      ],
-      "name": "Approval",
-      "type": "event"
+      "type": "address",
+      "indexed": true,
+      "name": "spender"
     },
     {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": true,
-          "internalType": "address",
-          "name": "from",
-          "type": "address"
-        },
-        {
-          "indexed": true,
-          "internalType": "address",
-          "name": "to",
-          "type": "address"
-        },
-        {
-          "indexed": false,
-          "internalType": "uint256",
-          "name": "value",
-          "type": "uint256"
-        }
-      ],
-      "name": "Transfer",
-      "type": "event"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "owner",
-          "type": "address"
-        },
-        {
-          "internalType": "address",
-          "name": "spender",
-          "type": "address"
-        }
-      ],
-      "name": "allowance",
-      "outputs": [
-        {
-          "internalType": "uint256",
-          "name": "",
-          "type": "uint256"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "spender",
-          "type": "address"
-        },
-        {
-          "internalType": "uint256",
-          "name": "amount",
-          "type": "uint256"
-        }
-      ],
-      "name": "approve",
-      "outputs": [
-        {
-          "internalType": "bool",
-          "name": "",
-          "type": "bool"
-        }
-      ],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "owner",
-          "type": "address"
-        },
-        {
-          "internalType": "address",
-          "name": "spender",
-          "type": "address"
-        },
-        {
-          "internalType": "uint256",
-          "name": "value",
-          "type": "uint256"
-        }
-      ],
-      "name": "approveInternal",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "account",
-          "type": "address"
-        }
-      ],
-      "name": "balanceOf",
-      "outputs": [
-        {
-          "internalType": "uint256",
-          "name": "",
-          "type": "uint256"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "account",
-          "type": "address"
-        },
-        {
-          "internalType": "uint256",
-          "name": "amount",
-          "type": "uint256"
-        }
-      ],
-      "name": "burn",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "decimals",
-      "outputs": [
-        {
-          "internalType": "uint8",
-          "name": "",
-          "type": "uint8"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "spender",
-          "type": "address"
-        },
-        {
-          "internalType": "uint256",
-          "name": "subtractedValue",
-          "type": "uint256"
-        }
-      ],
-      "name": "decreaseAllowance",
-      "outputs": [
-        {
-          "internalType": "bool",
-          "name": "",
-          "type": "bool"
-        }
-      ],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "spender",
-          "type": "address"
-        },
-        {
-          "internalType": "uint256",
-          "name": "addedValue",
-          "type": "uint256"
-        }
-      ],
-      "name": "increaseAllowance",
-      "outputs": [
-        {
-          "internalType": "bool",
-          "name": "",
-          "type": "bool"
-        }
-      ],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "account",
-          "type": "address"
-        },
-        {
-          "internalType": "uint256",
-          "name": "amount",
-          "type": "uint256"
-        }
-      ],
-      "name": "mint",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "name",
-      "outputs": [
-        {
-          "internalType": "string",
-          "name": "",
-          "type": "string"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "symbol",
-      "outputs": [
-        {
-          "internalType": "string",
-          "name": "",
-          "type": "string"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "totalSupply",
-      "outputs": [
-        {
-          "internalType": "uint256",
-          "name": "",
-          "type": "uint256"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "to",
-          "type": "address"
-        },
-        {
-          "internalType": "uint256",
-          "name": "amount",
-          "type": "uint256"
-        }
-      ],
-      "name": "transfer",
-      "outputs": [
-        {
-          "internalType": "bool",
-          "name": "",
-          "type": "bool"
-        }
-      ],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "from",
-          "type": "address"
-        },
-        {
-          "internalType": "address",
-          "name": "to",
-          "type": "address"
-        },
-        {
-          "internalType": "uint256",
-          "name": "amount",
-          "type": "uint256"
-        }
-      ],
-      "name": "transferFrom",
-      "outputs": [
-        {
-          "internalType": "bool",
-          "name": "",
-          "type": "bool"
-        }
-      ],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "from",
-          "type": "address"
-        },
-        {
-          "internalType": "address",
-          "name": "to",
-          "type": "address"
-        },
-        {
-          "internalType": "uint256",
-          "name": "value",
-          "type": "uint256"
-        }
-      ],
-      "name": "transferInternal",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
+      "type": "uint256",
+      "indexed": false,
+      "name": "value"
     }
+  ],
+  "anonymous": false
+},
+{
+  "name": "Transfer",
+  "type": "event",
+  "inputs": [
+    {
+      "type": "address",
+      "indexed": true,
+      "name": "from"
+    },
+    {
+      "type": "address",
+      "indexed": true,
+      "name": "to"
+    },
+    {
+      "type": "uint256",
+      "indexed": false,
+      "name": "value"
+    }
+  ],
+  "anonymous": false
+},
+{
+  "name": "transfer",
+  "type": "function",
+  "inputs": [
+    {
+      "type": "address",
+      "name": "to"
+    },
+    {
+      "type": "uint256",
+      "name": "amount"
+    }
+  ],
+  "outputs": [
+    {
+      "type": "bool",
+      "name": ""
+    }
+  ],
+  "stateMutability": "nonpayable"
+},
+{
+  "name": "allowance",
+  "type": "function",
+  "inputs": [
+    {
+      "type": "address",
+      "name": "owner"
+    },
+    {
+      "type": "address",
+      "name": "spender"
+    }
+  ],
+  "outputs": [
+    {
+      "type": "uint256",
+      "name": ""
+    }
+  ],
+  "stateMutability": "view"
+},
+{
+  "name": "approve",
+  "type": "function",
+  "inputs": [
+    {
+      "type": "address",
+      "name": "spender"
+    },
+    {
+      "type": "uint256",
+      "name": "amount"
+    }
+  ],
+  "outputs": [
+    {
+      "type": "bool",
+      "name": ""
+    }
+  ],
+  "stateMutability": "nonpayable"
+},
+{
+  "name": "balanceOf",
+  "type": "function",
+  "inputs": [
+    {
+      "type": "address",
+      "name": "owner"
+    }
+  ],
+  "outputs": [
+    {
+      "type": "uint256",
+      "name": ""
+    }
+  ],
+  "stateMutability": "view"
+},
+{
+  "name": "name",
+  "type": "function",
+  "inputs": [],
+  "outputs": [
+    {
+      "type": "string",
+      "name": ""
+    }
+  ],
+  "stateMutability": "view"
+},
+{
+  "name": "symbol",
+  "type": "function",
+  "inputs": [],
+  "outputs": [
+    {
+      "type": "string",
+      "name": ""
+    }
+  ],
+  "stateMutability": "view"
+},
+{
+  "name": "decimals",
+  "type": "function",
+  "inputs": [],
+  "outputs": [
+    {
+      "type": "uint8",
+      "name": ""
+    }
+  ],
+  "stateMutability": "view"
+},
+{
+  "name": "decreaseAllowance",
+  "type": "function",
+  "inputs": [
+    {
+      "type": "address",
+      "name": "spender"
+    },
+    {
+      "type": "uint256",
+      "name": "subtractedValue"
+    }
+  ],
+  "outputs": [
+    {
+      "type": "bool",
+      "name": ""
+    }
+  ],
+  "stateMutability": "nonpayable"
+},
+{
+  "name": "increaseAllowance",
+  "type": "function",
+  "inputs": [
+    {
+      "type": "address",
+      "name": "spender"
+    },
+    {
+      "type": "uint256",
+      "name": "addedValue"
+    }
+  ],
+  "outputs": [
+    {
+      "type": "bool",
+      "name": ""
+    }
+  ],
+  "stateMutability": "nonpayable"
+},
+{
+  "name": "totalSupply",
+  "type": "function",
+  "inputs": [],
+  "outputs": [
+    {
+      "type": "uint256",
+      "name": ""
+    }
+  ],
+  "stateMutability": "view"
+},
+{
+  "name": "transferFrom",
+  "type": "function",
+  "inputs": [
+    {
+      "type": "address",
+      "name": "from"
+    },
+    {
+      "type": "address",
+      "name": "to"
+    },
+    {
+      "type": "uint256",
+      "name": "amount"
+    }
+  ],
+  "outputs": [
+    {
+      "type": "bool",
+      "name": ""
+    }
+  ],
+  "stateMutability": "nonpayable"
+},
+{
+  "name": "constructor",
+  "type": "constructor",
+  "inputs": [
+    {
+      "type": "string",
+      "name": "name"
+    },
+    {
+      "type": "string",
+      "name": "symbol"
+    },
+    {
+      "type": "uint8",
+      "name": "decimals"
+    }
+  ],
+  "outputs": [],
+  "stateMutability": "nonpayable"
+}
 ]

--- a/language/evm/hardhat-examples/contracts/ERC20Mock.abi.json
+++ b/language/evm/hardhat-examples/contracts/ERC20Mock.abi.json
@@ -1,380 +1,337 @@
 [
+{
+  "name": "Approval",
+  "type": "event",
+  "inputs": [
     {
-      "inputs": [
-        {
-          "internalType": "string",
-          "name": "name",
-          "type": "string"
-        },
-        {
-          "internalType": "string",
-          "name": "symbol",
-          "type": "string"
-        },
-        {
-          "internalType": "address",
-          "name": "initialAccount",
-          "type": "address"
-        },
-        {
-          "internalType": "uint256",
-          "name": "initialBalance",
-          "type": "uint256"
-        }
-      ],
-      "stateMutability": "payable",
-      "type": "constructor"
+      "type": "address",
+      "indexed": true,
+      "name": "owner"
     },
     {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": true,
-          "internalType": "address",
-          "name": "owner",
-          "type": "address"
-        },
-        {
-          "indexed": true,
-          "internalType": "address",
-          "name": "spender",
-          "type": "address"
-        },
-        {
-          "indexed": false,
-          "internalType": "uint256",
-          "name": "value",
-          "type": "uint256"
-        }
-      ],
-      "name": "Approval",
-      "type": "event"
+      "type": "address",
+      "indexed": true,
+      "name": "spender"
     },
     {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": true,
-          "internalType": "address",
-          "name": "from",
-          "type": "address"
-        },
-        {
-          "indexed": true,
-          "internalType": "address",
-          "name": "to",
-          "type": "address"
-        },
-        {
-          "indexed": false,
-          "internalType": "uint256",
-          "name": "value",
-          "type": "uint256"
-        }
-      ],
-      "name": "Transfer",
-      "type": "event"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "owner",
-          "type": "address"
-        },
-        {
-          "internalType": "address",
-          "name": "spender",
-          "type": "address"
-        }
-      ],
-      "name": "allowance",
-      "outputs": [
-        {
-          "internalType": "uint256",
-          "name": "",
-          "type": "uint256"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "spender",
-          "type": "address"
-        },
-        {
-          "internalType": "uint256",
-          "name": "amount",
-          "type": "uint256"
-        }
-      ],
-      "name": "approve",
-      "outputs": [
-        {
-          "internalType": "bool",
-          "name": "",
-          "type": "bool"
-        }
-      ],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "owner",
-          "type": "address"
-        },
-        {
-          "internalType": "address",
-          "name": "spender",
-          "type": "address"
-        },
-        {
-          "internalType": "uint256",
-          "name": "value",
-          "type": "uint256"
-        }
-      ],
-      "name": "approveInternal",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "account",
-          "type": "address"
-        }
-      ],
-      "name": "balanceOf",
-      "outputs": [
-        {
-          "internalType": "uint256",
-          "name": "",
-          "type": "uint256"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "account",
-          "type": "address"
-        },
-        {
-          "internalType": "uint256",
-          "name": "amount",
-          "type": "uint256"
-        }
-      ],
-      "name": "burn",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "decimals",
-      "outputs": [
-        {
-          "internalType": "uint8",
-          "name": "",
-          "type": "uint8"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "spender",
-          "type": "address"
-        },
-        {
-          "internalType": "uint256",
-          "name": "subtractedValue",
-          "type": "uint256"
-        }
-      ],
-      "name": "decreaseAllowance",
-      "outputs": [
-        {
-          "internalType": "bool",
-          "name": "",
-          "type": "bool"
-        }
-      ],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "spender",
-          "type": "address"
-        },
-        {
-          "internalType": "uint256",
-          "name": "addedValue",
-          "type": "uint256"
-        }
-      ],
-      "name": "increaseAllowance",
-      "outputs": [
-        {
-          "internalType": "bool",
-          "name": "",
-          "type": "bool"
-        }
-      ],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "account",
-          "type": "address"
-        },
-        {
-          "internalType": "uint256",
-          "name": "amount",
-          "type": "uint256"
-        }
-      ],
-      "name": "mint",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "name",
-      "outputs": [
-        {
-          "internalType": "string",
-          "name": "",
-          "type": "string"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "symbol",
-      "outputs": [
-        {
-          "internalType": "string",
-          "name": "",
-          "type": "string"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "totalSupply",
-      "outputs": [
-        {
-          "internalType": "uint256",
-          "name": "",
-          "type": "uint256"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "to",
-          "type": "address"
-        },
-        {
-          "internalType": "uint256",
-          "name": "amount",
-          "type": "uint256"
-        }
-      ],
-      "name": "transfer",
-      "outputs": [
-        {
-          "internalType": "bool",
-          "name": "",
-          "type": "bool"
-        }
-      ],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "from",
-          "type": "address"
-        },
-        {
-          "internalType": "address",
-          "name": "to",
-          "type": "address"
-        },
-        {
-          "internalType": "uint256",
-          "name": "amount",
-          "type": "uint256"
-        }
-      ],
-      "name": "transferFrom",
-      "outputs": [
-        {
-          "internalType": "bool",
-          "name": "",
-          "type": "bool"
-        }
-      ],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "from",
-          "type": "address"
-        },
-        {
-          "internalType": "address",
-          "name": "to",
-          "type": "address"
-        },
-        {
-          "internalType": "uint256",
-          "name": "value",
-          "type": "uint256"
-        }
-      ],
-      "name": "transferInternal",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
+      "type": "uint256",
+      "indexed": false,
+      "name": "value"
     }
+  ],
+  "anonymous": false
+},
+{
+  "name": "Transfer",
+  "type": "event",
+  "inputs": [
+    {
+      "type": "address",
+      "indexed": true,
+      "name": "from"
+    },
+    {
+      "type": "address",
+      "indexed": true,
+      "name": "to"
+    },
+    {
+      "type": "uint256",
+      "indexed": false,
+      "name": "value"
+    }
+  ],
+  "anonymous": false
+},
+{
+  "name": "transfer",
+  "type": "function",
+  "inputs": [
+    {
+      "type": "address",
+      "name": "to"
+    },
+    {
+      "type": "uint256",
+      "name": "amount"
+    }
+  ],
+  "outputs": [
+    {
+      "type": "bool",
+      "name": ""
+    }
+  ],
+  "stateMutability": "nonpayable"
+},
+{
+  "name": "allowance",
+  "type": "function",
+  "inputs": [
+    {
+      "type": "address",
+      "name": "owner"
+    },
+    {
+      "type": "address",
+      "name": "spender"
+    }
+  ],
+  "outputs": [
+    {
+      "type": "uint256",
+      "name": ""
+    }
+  ],
+  "stateMutability": "view"
+},
+{
+  "name": "approve",
+  "type": "function",
+  "inputs": [
+    {
+      "type": "address",
+      "name": "spender"
+    },
+    {
+      "type": "uint256",
+      "name": "amount"
+    }
+  ],
+  "outputs": [
+    {
+      "type": "bool",
+      "name": ""
+    }
+  ],
+  "stateMutability": "nonpayable"
+},
+{
+  "name": "approveInternal",
+  "type": "function",
+  "inputs": [
+    {
+      "type": "address",
+      "name": "owner"
+    },
+    {
+      "type": "address",
+      "name": "spender"
+    },
+    {
+      "type": "uint256",
+      "name": "value"
+    }
+  ],
+  "outputs": [],
+  "stateMutability": "nonpayable"
+},
+{
+  "name": "balanceOf",
+  "type": "function",
+  "inputs": [
+    {
+      "type": "address",
+      "name": "owner"
+    }
+  ],
+  "outputs": [
+    {
+      "type": "uint256",
+      "name": ""
+    }
+  ],
+  "stateMutability": "view"
+},
+{
+  "name": "burn",
+  "type": "function",
+  "inputs": [
+    {
+      "type": "address",
+      "name": "account"
+    },
+    {
+      "type": "uint256",
+      "name": "amount"
+    }
+  ],
+  "outputs": [],
+  "stateMutability": "nonpayable"
+},
+{
+  "name": "name",
+  "type": "function",
+  "inputs": [],
+  "outputs": [
+    {
+      "type": "string",
+      "name": ""
+    }
+  ],
+  "stateMutability": "view"
+},
+{
+  "name": "symbol",
+  "type": "function",
+  "inputs": [],
+  "outputs": [
+    {
+      "type": "string",
+      "name": ""
+    }
+  ],
+  "stateMutability": "view"
+},
+{
+  "name": "decimals",
+  "type": "function",
+  "inputs": [],
+  "outputs": [
+    {
+      "type": "uint8",
+      "name": ""
+    }
+  ],
+  "stateMutability": "view"
+},
+{
+  "name": "decreaseAllowance",
+  "type": "function",
+  "inputs": [
+    {
+      "type": "address",
+      "name": "spender"
+    },
+    {
+      "type": "uint256",
+      "name": "subtractedValue"
+    }
+  ],
+  "outputs": [
+    {
+      "type": "bool",
+      "name": ""
+    }
+  ],
+  "stateMutability": "nonpayable"
+},
+{
+  "name": "increaseAllowance",
+  "type": "function",
+  "inputs": [
+    {
+      "type": "address",
+      "name": "spender"
+    },
+    {
+      "type": "uint256",
+      "name": "addedValue"
+    }
+  ],
+  "outputs": [
+    {
+      "type": "bool",
+      "name": ""
+    }
+  ],
+  "stateMutability": "nonpayable"
+},
+{
+  "name": "mint",
+  "type": "function",
+  "inputs": [
+    {
+      "type": "address",
+      "name": "account"
+    },
+    {
+      "type": "uint256",
+      "name": "amount"
+    }
+  ],
+  "outputs": [],
+  "stateMutability": "nonpayable"
+},
+{
+  "name": "totalSupply",
+  "type": "function",
+  "inputs": [],
+  "outputs": [
+    {
+      "type": "uint256",
+      "name": ""
+    }
+  ],
+  "stateMutability": "view"
+},
+{
+  "name": "transferFrom",
+  "type": "function",
+  "inputs": [
+    {
+      "type": "address",
+      "name": "from"
+    },
+    {
+      "type": "address",
+      "name": "to"
+    },
+    {
+      "type": "uint256",
+      "name": "amount"
+    }
+  ],
+  "outputs": [
+    {
+      "type": "bool",
+      "name": ""
+    }
+  ],
+  "stateMutability": "nonpayable"
+},
+{
+  "name": "transferInternal",
+  "type": "function",
+  "inputs": [
+    {
+      "type": "address",
+      "name": "from"
+    },
+    {
+      "type": "address",
+      "name": "to"
+    },
+    {
+      "type": "uint256",
+      "name": "value"
+    }
+  ],
+  "outputs": [],
+  "stateMutability": "nonpayable"
+},
+{
+  "name": "constructor",
+  "type": "constructor",
+  "inputs": [
+    {
+      "type": "string",
+      "name": "name"
+    },
+    {
+      "type": "string",
+      "name": "symbol"
+    },
+    {
+      "type": "address",
+      "name": "initial_account"
+    },
+    {
+      "type": "uint256",
+      "name": "initial_balance"
+    }
+  ],
+  "outputs": [],
+  "stateMutability": "nonpayable"
+}
 ]

--- a/language/evm/hardhat-examples/contracts/Event.abi.json
+++ b/language/evm/hardhat-examples/contracts/Event.abi.json
@@ -1,235 +1,213 @@
 [
-  {
-      "anonymous": false,
-      "inputs": [
-          {
-              "indexed": false,
-              "internalType": "uint64",
-              "name": "x",
-              "type": "uint64"
-          }
-      ],
-      "name": "SimpleEvent",
-      "type": "event"
-  },
-  {
-      "anonymous": false,
-      "inputs": [
-          {
-              "indexed": false,
-              "internalType": "uint64",
-              "name": "x",
-              "type": "uint64"
-          },
-          {
-              "indexed": false,
-              "internalType": "string",
-              "name": "message",
-              "type": "string"
-          }
-      ],
-      "name": "MyEvent",
-      "type": "event"
-  },
-  {
-      "anonymous": false,
-      "inputs": [
-          {
-              "indexed": true,
-              "internalType": "address",
-              "name": "from",
-              "type": "address"
-          },
-          {
-              "indexed": true,
-              "internalType": "address",
-              "name": "to",
-              "type": "address"
-          },
-          {
-              "indexed": false,
-              "internalType": "uint256",
-              "name": "value",
-              "type": "uint256"
-          }
-      ],
-      "name": "Transfer",
-      "type": "event"
-  },
-  {
-      "inputs": [
-          {
-              "internalType": "uint64",
-              "name": "x",
-              "type": "uint64"
-          }
-      ],
-      "name": "emitSimpleEvent",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-  },
-  {
-      "inputs": [
-          {
-              "internalType": "uint64",
-              "name": "x",
-              "type": "uint64"
-          }
-      ],
-      "name": "emitSimpleEventTwice",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-  },
-  {
-      "inputs": [
-          {
-              "internalType": "uint64",
-              "name": "x",
-              "type": "uint64"
-          }
-      ],
-      "name": "emitNothing",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-  },
-  {
-      "inputs": [
-          {
-              "internalType": "uint64",
-              "name": "x",
-              "type": "uint64"
-          }
-      ],
-      "name": "emitMyEvent",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-  },
-  {
-      "inputs": [
-          {
-              "internalType": "uint64",
-              "name": "x",
-              "type": "uint64"
-          }
-      ],
-      "name": "emitMyEventTwice",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-  },
-  {
-      "inputs": [
-          {
-              "internalType": "uint64",
-              "name": "x",
-              "type": "uint64"
-          },
-          {
-              "internalType": "string",
-              "name": "message",
-              "type": "string"
-          }
-      ],
-      "name": "emitMyEventWith",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-  },
-  {
-      "inputs": [
-          {
-              "internalType": "uint64",
-              "name": "x",
-              "type": "uint64"
-          },
-          {
-              "internalType": "string",
-              "name": "message",
-              "type": "string"
-          }
-      ],
-      "name": "emitMyEventWithTwice",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-  },
-  {
-    "inputs": [
-        {
-            "internalType": "address",
-            "name": "from",
-            "type": "address"
-        },
-        {
-            "internalType": "address",
-            "name": "to",
-            "type": "address"
-        },
-        {
-            "internalType": "uint256",
-            "name": "value",
-            "type": "uint256"
-        }
-    ],
-    "name": "emitTransfer",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-        {
-            "indexed": false,
-            "internalType": "address",
-            "name": "x",
-            "type": "address"
-        }
-    ],
-    "name": "AddressEvent",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-        {
-            "indexed": false,
-            "internalType": "uint256",
-            "name": "x",
-            "type": "uint256"
-        }
-    ],
-    "name": "U256Event",
-    "type": "event"
-  },
-  {
-    "inputs": [
-        {
-            "internalType": "address",
-            "name": "a",
-            "type": "address"
-        }
-    ],
-    "name": "emitAddressEvent",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-      "inputs": [
-          {
-              "internalType": "uint256",
-              "name": "x",
-              "type": "uint256"
-          }
-      ],
-      "name": "emitU256Event",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-  }
+{
+  "name": "AddressEvent",
+  "type": "event",
+  "inputs": [
+    {
+      "type": "address",
+      "indexed": false,
+      "name": "a"
+    }
+  ],
+  "anonymous": false
+},
+{
+  "name": "MyEvent",
+  "type": "event",
+  "inputs": [
+    {
+      "type": "uint64",
+      "indexed": false,
+      "name": "x"
+    },
+    {
+      "type": "string",
+      "indexed": false,
+      "name": "message"
+    }
+  ],
+  "anonymous": false
+},
+{
+  "name": "SimpleEvent",
+  "type": "event",
+  "inputs": [
+    {
+      "type": "uint64",
+      "indexed": false,
+      "name": "x"
+    }
+  ],
+  "anonymous": false
+},
+{
+  "name": "Transfer",
+  "type": "event",
+  "inputs": [
+    {
+      "type": "address",
+      "indexed": true,
+      "name": "from"
+    },
+    {
+      "type": "address",
+      "indexed": true,
+      "name": "to"
+    },
+    {
+      "type": "uint256",
+      "indexed": false,
+      "name": "value"
+    }
+  ],
+  "anonymous": false
+},
+{
+  "name": "U256Event",
+  "type": "event",
+  "inputs": [
+    {
+      "type": "uint256",
+      "indexed": false,
+      "name": "x"
+    }
+  ],
+  "anonymous": false
+},
+{
+  "name": "emitAddressEvent",
+  "type": "function",
+  "inputs": [
+    {
+      "type": "address",
+      "name": "a"
+    }
+  ],
+  "outputs": [],
+  "stateMutability": "nonpayable"
+},
+{
+  "name": "emitMyEvent",
+  "type": "function",
+  "inputs": [
+    {
+      "type": "uint64",
+      "name": "x"
+    }
+  ],
+  "outputs": [],
+  "stateMutability": "nonpayable"
+},
+{
+  "name": "emitMyEventTwice",
+  "type": "function",
+  "inputs": [
+    {
+      "type": "uint64",
+      "name": "x"
+    }
+  ],
+  "outputs": [],
+  "stateMutability": "nonpayable"
+},
+{
+  "name": "emitMyEventWith",
+  "type": "function",
+  "inputs": [
+    {
+      "type": "uint64",
+      "name": "x"
+    },
+    {
+      "type": "string",
+      "name": "message"
+    }
+  ],
+  "outputs": [],
+  "stateMutability": "nonpayable"
+},
+{
+  "name": "emitMyEventWithTwice",
+  "type": "function",
+  "inputs": [
+    {
+      "type": "uint64",
+      "name": "x"
+    },
+    {
+      "type": "string",
+      "name": "message"
+    }
+  ],
+  "outputs": [],
+  "stateMutability": "nonpayable"
+},
+{
+  "name": "emitNothing",
+  "type": "function",
+  "inputs": [
+    {
+      "type": "uint64",
+      "name": "_x"
+    }
+  ],
+  "outputs": [],
+  "stateMutability": "nonpayable"
+},
+{
+  "name": "emitSimpleEvent",
+  "type": "function",
+  "inputs": [
+    {
+      "type": "uint64",
+      "name": "x"
+    }
+  ],
+  "outputs": [],
+  "stateMutability": "nonpayable"
+},
+{
+  "name": "emitSimpleEventTwice",
+  "type": "function",
+  "inputs": [
+    {
+      "type": "uint64",
+      "name": "x"
+    }
+  ],
+  "outputs": [],
+  "stateMutability": "nonpayable"
+},
+{
+  "name": "emitTransfer",
+  "type": "function",
+  "inputs": [
+    {
+      "type": "address",
+      "name": "from"
+    },
+    {
+      "type": "address",
+      "name": "to"
+    },
+    {
+      "type": "uint256",
+      "name": "value"
+    }
+  ],
+  "outputs": [],
+  "stateMutability": "nonpayable"
+},
+{
+  "name": "emitU256Event",
+  "type": "function",
+  "inputs": [
+    {
+      "type": "uint256",
+      "name": "x"
+    }
+  ],
+  "outputs": [],
+  "stateMutability": "nonpayable"
+}
 ]

--- a/language/evm/hardhat-examples/contracts/FortyTwo.abi.json
+++ b/language/evm/hardhat-examples/contracts/FortyTwo.abi.json
@@ -1,60 +1,55 @@
 [
-  {
-    "inputs": [],
-    "name": "forty_two",
-    "outputs": [
-      {
-        "internalType": "uint64",
-        "name": "",
-        "type": "uint64"
-      }
-    ],
-    "stateMutability": "pure",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "forty_two_as_u256",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
-    "stateMutability": "pure",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "uint64",
-        "name": "alpha",
-        "type": "uint64"
-      }
-    ],
-    "name": "forty_two_plus_alpha",
-    "outputs": [
-      {
-        "internalType": "uint64",
-        "name": "",
-        "type": "uint64"
-      }
-    ],
-    "stateMutability": "pure",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "forty_two_as_string",
-    "outputs": [
-      {
-        "internalType": "string",
-        "name": "",
-        "type": "string"
-      }
-    ],
-    "stateMutability": "pure",
-    "type": "function"
-  }
+{
+  "name": "forty_two",
+  "type": "function",
+  "inputs": [],
+  "outputs": [
+    {
+      "type": "uint64",
+      "name": ""
+    }
+  ],
+  "stateMutability": "pure"
+},
+{
+  "name": "forty_two_as_string",
+  "type": "function",
+  "inputs": [],
+  "outputs": [
+    {
+      "type": "string",
+      "name": ""
+    }
+  ],
+  "stateMutability": "pure"
+},
+{
+  "name": "forty_two_as_u256",
+  "type": "function",
+  "inputs": [],
+  "outputs": [
+    {
+      "type": "uint256",
+      "name": ""
+    }
+  ],
+  "stateMutability": "pure"
+},
+{
+  "name": "forty_two_plus_alpha",
+  "type": "function",
+  "inputs": [
+    {
+      "type": "uint64",
+      "name": "alpha"
+    }
+  ],
+  "outputs": [
+    {
+      "type": "uint64",
+      "name": ""
+    }
+  ],
+  "stateMutability": "pure"
+}
 ]

--- a/language/evm/hardhat-examples/contracts/Greeter.abi.json
+++ b/language/evm/hardhat-examples/contracts/Greeter.abi.json
@@ -1,41 +1,38 @@
 [
-  {
-    "inputs": [
-      {
-        "internalType": "string",
-        "name": "",
-        "type": "string"
-      }
-    ],
-    "name": "",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "constructor"
-  },
-  {
-    "inputs": [],
-    "name": "greet",
-    "outputs": [
-      {
-        "internalType": "string",
-        "name": "",
-        "type": "string"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "string",
-        "name": "_greeting",
-        "type": "string"
-      }
-    ],
-    "name": "setGreeting",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  }
+{
+  "name": "greet",
+  "type": "function",
+  "inputs": [],
+  "outputs": [
+    {
+      "type": "string",
+      "name": ""
+    }
+  ],
+  "stateMutability": "view"
+},
+{
+  "name": "setGreeting",
+  "type": "function",
+  "inputs": [
+    {
+      "type": "string",
+      "name": "greeting"
+    }
+  ],
+  "outputs": [],
+  "stateMutability": "nonpayable"
+},
+{
+  "name": "constructor",
+  "type": "constructor",
+  "inputs": [
+    {
+      "type": "string",
+      "name": "greeting"
+    }
+  ],
+  "outputs": [],
+  "stateMutability": "nonpayable"
+}
 ]

--- a/language/evm/hardhat-examples/contracts/Greeter.move
+++ b/language/evm/hardhat-examples/contracts/Greeter.move
@@ -18,7 +18,7 @@ module Evm::Greeter {
          );
     }
 
-    #[callable(sig=b"greet() returns (string)")]
+    #[callable(sig=b"greet() returns (string)"), view]
     public fun greet(): vector<u8> acquires State {
         borrow_global<State>(self()).greeting
     }

--- a/language/evm/hardhat-examples/contracts/Native.abi.json
+++ b/language/evm/hardhat-examples/contracts/Native.abi.json
@@ -1,28 +1,26 @@
 [
+{
+  "name": "getContractAddr",
+  "type": "function",
+  "inputs": [],
+  "outputs": [
     {
-      "inputs": [],
-      "name": "getContractAddr",
-      "outputs": [
-        {
-          "internalType": "address",
-          "name": "",
-          "type": "address"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "getSenderAddr",
-      "outputs": [
-        {
-          "internalType": "address",
-          "name": "",
-          "type": "address"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
+      "type": "address",
+      "name": ""
     }
-  ]
+  ],
+  "stateMutability": "view"
+},
+{
+  "name": "getSenderAddr",
+  "type": "function",
+  "inputs": [],
+  "outputs": [
+    {
+      "type": "address",
+      "name": ""
+    }
+  ],
+  "stateMutability": "view"
+}
+]

--- a/language/evm/hardhat-examples/contracts/Revert.abi.json
+++ b/language/evm/hardhat-examples/contracts/Revert.abi.json
@@ -1,34 +1,21 @@
 [
+{
+  "name": "revertIf0",
+  "type": "function",
+  "inputs": [
     {
-        "inputs": [
-        {
-            "internalType": "uint64",
-            "name": "x",
-            "type": "uint64"
-        }
-        ],
-        "name": "revertIf0",
-        "outputs": [
-        {
-            "internalType": "uint64",
-            "name": "",
-            "type": "uint64"
-        }
-        ],
-        "stateMutability": "pure",
-        "type": "function"
-    },
-    {
-        "inputs": [],
-        "name": "revertWithMessage",
-        "outputs": [
-        {
-            "internalType": "uint64",
-            "name": "",
-            "type": "uint64"
-        }
-        ],
-        "stateMutability": "pure",
-        "type": "function"
+      "type": "uint64",
+      "name": "x"
     }
+  ],
+  "outputs": [],
+  "stateMutability": "pure"
+},
+{
+  "name": "revertWithMessage",
+  "type": "function",
+  "inputs": [],
+  "outputs": [],
+  "stateMutability": "pure"
+}
 ]

--- a/language/evm/hardhat-examples/contracts/Token.abi.json
+++ b/language/evm/hardhat-examples/contracts/Token.abi.json
@@ -1,102 +1,92 @@
 [
-  {
-    "inputs": [
-      {
-        "internalType": "string",
-        "name": "",
-        "type": "string"
-      }
-    ],
-    "name": "",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "constructor"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "name": "balanceOf",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
-    "stateMutability": "pure",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "name",
-    "outputs": [
-      {
-        "internalType": "string",
-        "name": "",
-        "type": "string"
-      }
-    ],
-    "stateMutability": "pure",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "totalSupply",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
-    "stateMutability": "pure",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      },
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
-    "name": "mint",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      },
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
-    "name": "transfer",
-    "outputs": [
-      {
-        "internalType": "bool",
-        "name": "",
-        "type": "bool"
-      }
-    ],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  }
+{
+  "name": "transfer",
+  "type": "function",
+  "inputs": [
+    {
+      "type": "address",
+      "name": "to"
+    },
+    {
+      "type": "uint256",
+      "name": "amount"
+    }
+  ],
+  "outputs": [
+    {
+      "type": "bool",
+      "name": ""
+    }
+  ],
+  "stateMutability": "nonpayable"
+},
+{
+  "name": "balanceOf",
+  "type": "function",
+  "inputs": [
+    {
+      "type": "address",
+      "name": "owner"
+    }
+  ],
+  "outputs": [
+    {
+      "type": "uint256",
+      "name": ""
+    }
+  ],
+  "stateMutability": "view"
+},
+{
+  "name": "name",
+  "type": "function",
+  "inputs": [],
+  "outputs": [
+    {
+      "type": "string",
+      "name": ""
+    }
+  ],
+  "stateMutability": "view"
+},
+{
+  "name": "mint",
+  "type": "function",
+  "inputs": [
+    {
+      "type": "address",
+      "name": "account"
+    },
+    {
+      "type": "uint256",
+      "name": "amount"
+    }
+  ],
+  "outputs": [],
+  "stateMutability": "nonpayable"
+},
+{
+  "name": "totalSupply",
+  "type": "function",
+  "inputs": [],
+  "outputs": [
+    {
+      "type": "uint256",
+      "name": ""
+    }
+  ],
+  "stateMutability": "view"
+},
+{
+  "name": "constructor",
+  "type": "constructor",
+  "inputs": [
+    {
+      "type": "string",
+      "name": "name"
+    }
+  ],
+  "outputs": [],
+  "stateMutability": "nonpayable"
+}
 ]

--- a/language/evm/hardhat-examples/test/Event.truffle.test.js
+++ b/language/evm/hardhat-examples/test/Event.truffle.test.js
@@ -12,21 +12,21 @@ contract('Truffle-style testing for Event (the Move contract)', function (accoun
         expectEvent(
             await this.event.emitSimpleEvent(42),
             'SimpleEvent',
-            { x: new BN(42) },
+            [new BN(42)],
         );
     });
     it('emits an MyEvent', async function () {
         expectEvent(
             await this.event.emitMyEvent(7),
             'MyEvent',
-            { x: new BN(7) },
+            [new BN(7)],
         );
     });
     it('emits an Transfer event', async function () {
         expectEvent(
             await this.event.emitTransfer(ZERO_ADDRESS, ZERO_ADDRESS, 7),
             'Transfer',
-            { from: ZERO_ADDRESS, to: ZERO_ADDRESS, value: new BN(7) },
+            [ZERO_ADDRESS, ZERO_ADDRESS, new BN(7)],
         );
     });
     // Enable this to show the events emitted.

--- a/language/evm/move-to-yul/src/abi_signature.rs
+++ b/language/evm/move-to-yul/src/abi_signature.rs
@@ -1,0 +1,111 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+// This file defines functions for generating JSON-ABI.
+
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    attributes::FunctionAttribute,
+    events::EventSignature,
+    solidity_ty::{SoliditySignature, SolidityType},
+};
+
+#[derive(Serialize, Deserialize)]
+pub(crate) struct ABIJsonArg {
+    #[serde(rename = "type")]
+    pub ty: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub indexed: Option<bool>,
+    pub name: String,
+}
+
+#[derive(Serialize, Deserialize)]
+pub(crate) struct ABIJsonSignature {
+    pub name: String,
+    #[serde(rename = "type")]
+    pub ty: String,
+    pub inputs: Vec<ABIJsonArg>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub outputs: Option<Vec<ABIJsonArg>>,
+    #[serde(rename = "stateMutability", skip_serializing_if = "Option::is_none")]
+    pub state_mutability: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub anonymous: Option<bool>,
+}
+
+impl ABIJsonArg {
+    pub(crate) fn from_ty(ty: &SolidityType, name: String) -> Self {
+        ABIJsonArg {
+            ty: ty.to_string(),
+            indexed: None,
+            name,
+        }
+    }
+
+    pub(crate) fn from_event_ty(ty: &SolidityType, indexed: bool, name: String) -> Self {
+        ABIJsonArg {
+            ty: ty.to_string(),
+            indexed: Some(indexed),
+            name,
+        }
+    }
+}
+
+impl ABIJsonSignature {
+    pub(crate) fn from_solidity_sig(
+        sig: &SoliditySignature,
+        attr: Option<FunctionAttribute>,
+        fun_typ: &str,
+    ) -> Self {
+        let name = sig.sig_name.clone();
+        let mut inputs = vec![];
+        let mut outputs = vec![];
+        for (ty, para_name, _) in &sig.para_types {
+            inputs.push(ABIJsonArg::from_ty(ty, para_name.clone()));
+        }
+        for (ty, _) in &sig.ret_types {
+            outputs.push(ABIJsonArg::from_ty(ty, "".to_string()));
+        }
+        let state_mutability = (if let Some(FunctionAttribute::View) = attr {
+            "view"
+        } else if let Some(FunctionAttribute::Pure) = attr {
+            "pure"
+        } else if let Some(FunctionAttribute::Payable) = attr {
+            "payable"
+        } else {
+            "nonpayable"
+        })
+        .to_string();
+        let anonymous = None;
+        ABIJsonSignature {
+            name,
+            ty: fun_typ.to_string(),
+            inputs,
+            outputs: Some(outputs),
+            state_mutability: Some(state_mutability),
+            anonymous,
+        }
+    }
+
+    pub(crate) fn from_event_sig(sig: &EventSignature) -> Self {
+        let name = sig.event_name.clone();
+        let ty = "event".to_string();
+        let mut inputs = vec![];
+        for (_, ty, _, indexed_flag, ev_name) in &sig.para_types {
+            inputs.push(ABIJsonArg::from_event_ty(
+                ty,
+                *indexed_flag,
+                ev_name.clone(),
+            ));
+        }
+        ABIJsonSignature {
+            name,
+            ty,
+            inputs,
+            outputs: None,
+            state_mutability: None,
+            anonymous: Some(false),
+        }
+    }
+}

--- a/language/evm/move-to-yul/src/external_functions.rs
+++ b/language/evm/move-to-yul/src/external_functions.rs
@@ -25,7 +25,7 @@ pub(crate) fn define_external_fun(
 ) {
     let fun = ctx.env.get_function(fun_id.to_qualified_id());
     let mut sig = SoliditySignature::create_default_solidity_signature(ctx, &fun);
-    let parsed_sig_opt = SoliditySignature::parse_into_solidity_signature(solidity_sig_str);
+    let parsed_sig_opt = SoliditySignature::parse_into_solidity_signature(solidity_sig_str, &fun);
     // Check compatibility
     if let Ok(parsed_sig) = parsed_sig_opt {
         if !parsed_sig.check_sig_compatibility_for_external_fun(ctx, &fun) {
@@ -131,13 +131,13 @@ pub(crate) fn define_external_fun(
             .para_types
             .clone()
             .into_iter()
-            .map(|(ty, _)| ty)
+            .map(|(ty, _, _)| ty)
             .collect::<Vec<_>>();
         let sig_para_locs = sig
             .para_types
             .clone()
             .into_iter()
-            .map(|(_, loc)| loc)
+            .map(|(_, _, loc)| loc)
             .collect_vec();
         let encode =
             gen.parent
@@ -261,7 +261,11 @@ impl SoliditySignature {
         fun: &FunctionEnv<'_>,
     ) -> bool {
         let para_types = fun.get_parameter_types();
-        let sig_para_vec = self.para_types.iter().map(|(ty, _)| ty).collect::<Vec<_>>();
+        let sig_para_vec = self
+            .para_types
+            .iter()
+            .map(|(ty, _, _)| ty)
+            .collect::<Vec<_>>();
         if para_types.len() != sig_para_vec.len() + 1 {
             // the extra (first) parameter of the move function is the address of the target contract
             return false;

--- a/language/evm/move-to-yul/src/lib.rs
+++ b/language/evm/move-to-yul/src/lib.rs
@@ -3,6 +3,7 @@
 
 #![forbid(unsafe_code)]
 
+mod abi_signature;
 mod attributes;
 mod context;
 mod dispatcher_generator;
@@ -35,7 +36,7 @@ pub fn run_to_yul_errors_to_stderr(options: Options) -> anyhow::Result<()> {
 }
 
 /// Run move-to-yul compiler and print errors to given writer.
-pub fn run_to_yul<W: WriteColor>(error_writer: &mut W, options: Options) -> anyhow::Result<()> {
+pub fn run_to_yul<W: WriteColor>(error_writer: &mut W, mut options: Options) -> anyhow::Result<()> {
     // Run the model builder.
     let addrs = parse_addresses_from_options(options.named_address_mapping.clone())?;
     let env = run_model_builder_with_options(
@@ -50,14 +51,19 @@ pub fn run_to_yul<W: WriteColor>(error_writer: &mut W, options: Options) -> anyh
         error_writer,
         "exiting with Move build errors",
     )?;
-    let (_, content) = Generator::run(&options, &env);
+    let (_, content, abi_content) = Generator::run(&options, &env);
     check_errors(
         &env,
         &options,
         error_writer,
         "exiting with Yul generation errors",
     )?;
+    if let Some(i) = options.output.rfind('.') {
+        options.abi_output = format!("{}.abi.json", &options.output[..i]);
+    }
+    println!("{}, {}", options.abi_output, options.output);
     fs::write(options.output, &content)?;
+    fs::write(options.abi_output, &abi_content)?;
     Ok(())
 }
 

--- a/language/evm/move-to-yul/src/options.rs
+++ b/language/evm/move-to-yul/src/options.rs
@@ -49,6 +49,8 @@ pub struct Options {
     pub experiments: Vec<String>,
     /// Sources to compile (positional arg)
     pub sources: Vec<String>,
+    #[clap(long = "abi-output", default_value = "output.abi.json")]
+    pub abi_output: String,
 }
 
 impl Default for Options {

--- a/language/evm/move-to-yul/tests/dispatcher_testsuite.rs
+++ b/language/evm/move-to-yul/tests/dispatcher_testsuite.rs
@@ -64,7 +64,7 @@ fn compile_yul_to_bytecode_bytes(filename: &str) -> Result<Vec<u8>> {
         ModelBuilderOptions::default(),
     )?;
     let options = Options::default();
-    let (_, out) = Generator::run(&options, &env);
+    let (_, out, _) = Generator::run(&options, &env);
     let (bc, _) = compile::solc_yul(&out, false)?;
     Ok(bc)
 }

--- a/language/evm/move-to-yul/tests/test-dispatcher/ExternalCallFailure.exp
+++ b/language/evm/move-to-yul/tests/test-dispatcher/ExternalCallFailure.exp
@@ -110,7 +110,7 @@ error: solidity signature is not compatible with the move signature
 8 │     public native fun failure_2(add: u128, i:u8);
   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: solidity signature is not compatible with the move signature
+error: error happens when parsing the signature
   ┌─ tests/test-dispatcher/ExternalCallFailure.move:5:5
   │
 5 │     public native fun failure_1();

--- a/language/evm/move-to-yul/tests/test-dispatcher/signature-parsing-test/baseline/parsing_failure/IllegalTypeList.exp
+++ b/language/evm/move-to-yul/tests/test-dispatcher/signature-parsing-test/baseline/parsing_failure/IllegalTypeList.exp
@@ -577,7 +577,7 @@ error: error happens when parsing the return types in the signature
 25 │ │     }
    │ ╰─────^
 
-error: illegal type name
+error: error happens when parsing the signature
    ┌─ tests/test-dispatcher/signature-parsing-test/baseline/parsing_failure/IllegalTypeList.move:28:5
    │
 28 │ ╭     fun illegal_char_2() {

--- a/language/evm/move-to-yul/tests/test-dispatcher/signature-parsing-test/baseline/parsing_failure/IllegalTypeList.move
+++ b/language/evm/move-to-yul/tests/test-dispatcher/signature-parsing-test/baseline/parsing_failure/IllegalTypeList.move
@@ -92,5 +92,4 @@ module 0x2::M {
     fun illegal_address_2(x: address) : address {
         x
     }
-
 }

--- a/language/evm/move-to-yul/tests/testsuite.rs
+++ b/language/evm/move-to-yul/tests/testsuite.rs
@@ -56,7 +56,7 @@ fn test_runner(path: &Path) -> datatest_stable::Result<()> {
             options.experiments.push(exp.clone());
             format!("{}.{}", EXP_EXT, exp)
         };
-        let (_, mut out) = Generator::run(&options, &env);
+        let (_, mut out, _) = Generator::run(&options, &env);
         if !env.has_errors() {
             out = format!("{}\n\n{}", out, compile_check(&options, &out));
 


### PR DESCRIPTION
## Motivation

This PR adds support for generating the file *abi_output.abi.json* that includes the JSON ABI for the constructor, events and callable functions when compiling the move contract. Users can also specify the name of the output file by using the command option: --abi-output *abi-filename*. For the hardhat examples, abi.json file can be automatically generated.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

./compile_all_and_test.sh
