### PR TITLE
RFC: UnsafeStaticTableResolver

### DIFF
--- a/language/extensions/move-table-extension/sources/Table.move
+++ b/language/extensions/move-table-extension/sources/Table.move
@@ -7,7 +7,7 @@ module Extensions::Table {
 
     /// Create a new Table.
     public fun new<K, V: store>(): Table<K, V> {
-        Table{handle: new_table_handle()}
+        Table{handle: new_table_handle<K, V, Box<V>>()}
     }
 
     /// Destroy a table. The table must be empty to succeed.
@@ -82,7 +82,7 @@ module Extensions::Table {
 
     // Primitives which take as an additional type parameter `Box<V>`, so the implementation
     // can use this to determine serialization layout.
-    native fun new_table_handle(): u128;
+    native fun new_table_handle<K, V, B>(): u128;
     native fun add_box<K, V, B>(table: &mut Table<K, V>, key: &K, val: Box<V>);
     native fun borrow_box<K, V, B>(table: &Table<K, V>, key: &K): &Box<V>;
     native fun borrow_box_mut<K, V, B>(table: &mut Table<K, V>, key: &K): &mut Box<V>;

--- a/language/move-vm/test-utils/src/storage.rs
+++ b/language/move-vm/test-utils/src/storage.rs
@@ -269,6 +269,10 @@ impl InMemoryStorage {
                     table.remove(&key);
                 }
             }
+            assert_eq!(
+                table.len(),
+                (c.base_size as i128 + c.size_delta as i128) as usize
+            );
         }
     }
 

--- a/language/tools/move-unit-test/src/extensions.rs
+++ b/language/tools/move-unit-test/src/extensions.rs
@@ -11,7 +11,7 @@ use std::fmt::Write;
 #[cfg(feature = "table-extension")]
 use itertools::Itertools;
 #[cfg(feature = "table-extension")]
-use move_table_extension::NativeTableContext;
+use move_table_extension::{NativeTableContext, TableResolver};
 
 /// Print the change sets for available native context extensions.
 #[allow(unused)]

--- a/language/tools/move-unit-test/src/extensions.rs
+++ b/language/tools/move-unit-test/src/extensions.rs
@@ -12,19 +12,6 @@ use std::fmt::Write;
 use itertools::Itertools;
 #[cfg(feature = "table-extension")]
 use move_table_extension::NativeTableContext;
-#[cfg(feature = "table-extension")]
-use move_vm_test_utils::BlankStorage;
-#[cfg(feature = "table-extension")]
-use once_cell::sync::Lazy;
-
-/// Create all available native context extensions.
-#[allow(unused_mut, clippy::let_and_return)]
-pub(crate) fn new_extensions() -> NativeContextExtensions {
-    let mut e = NativeContextExtensions::default();
-    #[cfg(feature = "table-extension")]
-    create_table_extension(&mut e);
-    e
-}
 
 /// Print the change sets for available native context extensions.
 #[allow(unused)]
@@ -37,8 +24,11 @@ pub(crate) fn print_change_sets<W: Write>(_w: &mut W, mut extensions: NativeCont
 // Table Extensions
 
 #[cfg(feature = "table-extension")]
-fn create_table_extension(extensions: &mut NativeContextExtensions) {
-    extensions.add(NativeTableContext::new(0, &*DUMMY_RESOLVER));
+pub(crate) fn create_table_extension(
+    extensions: &mut NativeContextExtensions,
+    resolver: &dyn TableResolver,
+) {
+    extensions.add(NativeTableContext::new(0, resolver));
 }
 
 #[cfg(feature = "table-extension")]
@@ -69,6 +59,3 @@ fn print_table_extension<W: Write>(w: &mut W, extensions: &mut NativeContextExte
         }
     }
 }
-
-#[cfg(feature = "table-extension")]
-static DUMMY_RESOLVER: Lazy<BlankStorage> = Lazy::new(|| BlankStorage);

--- a/language/tools/move-unit-test/src/test_runner.rs
+++ b/language/tools/move-unit-test/src/test_runner.rs
@@ -250,6 +250,17 @@ impl<'a, 'b, W: Write> TestOutput<'a, 'b, W> {
 }
 
 impl SharedTestingConfig {
+    fn create_extensions(&self) -> NativeContextExtensions {
+        #[allow(unused_mut)]
+        let mut extensions = NativeContextExtensions::default();
+        #[cfg(feature = "table-extension")]
+        {
+            use crate::extensions::create_table_extension;
+            create_table_extension(&mut extensions, &self.starting_storage_state);
+        }
+        extensions
+    }
+
     fn execute_via_move_vm(
         &self,
         test_plan: &ModuleTestPlan,
@@ -262,7 +273,7 @@ impl SharedTestingConfig {
         TestRunInfo,
     ) {
         let move_vm = MoveVM::new(self.native_function_table.clone()).unwrap();
-        let extensions = extensions::new_extensions();
+        let extensions = self.create_extensions();
         let mut session =
             move_vm.new_session_with_extensions(&self.starting_storage_state, extensions);
         let mut gas_meter = GasStatus::new(&self.cost_table, GasUnits::new(self.execution_bound));


### PR DESCRIPTION
## Motivation

Because `pub trait Any: 'static` must be static, there's no way to create the `NativeTableContext` in production environment where the resolver has a shorter lifetime. 

This unsafe piece of code is the best I can come up with for now. Let me know how people envision us to proceed.

Also:
* Connected unit tests with `InMemoryStorage`.
* Fixed that `length()` queries storage for newly created tables in the current txn. (unbroken test with `InMemoryStorage`)
* Fixed that global_value() didn't consider deleted item in mem and didn't cache None's from the resolver. (added unit tests)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

Existing coverage, and downstream tests

## Related PRs

https://github.com/diem/move/pull/150
