### PR TITLE
[move-vm] Expose more function and type APIs in the session

### DIFF
--- a/language/extensions/async/move-async-vm/src/async_vm.rs
+++ b/language/extensions/async/move-async-vm/src/async_vm.rs
@@ -158,7 +158,7 @@ impl<'r, 'l, S: MoveResolver> AsyncSession<'r, 'l, S> {
         let state_type_tag = TypeTag::Struct(actor.state_tag.clone());
         let state_type = self
             .vm_session
-            .get_type(&state_type_tag)
+            .load_type(&state_type_tag)
             .map_err(vm_error_to_async)?;
 
         // Check whether the actor state already exists.
@@ -251,7 +251,7 @@ impl<'r, 'l, S: MoveResolver> AsyncSession<'r, 'l, S> {
         let state_type_tag = TypeTag::Struct(actor.state_tag.clone());
         let state_type = self
             .vm_session
-            .get_type(&state_type_tag)
+            .load_type(&state_type_tag)
             .map_err(vm_error_to_async)?;
 
         let actor_state_global = self

--- a/language/move-vm/runtime/src/move_vm.rs
+++ b/language/move-vm/runtime/src/move_vm.rs
@@ -1,13 +1,18 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use std::sync::Arc;
+
 use crate::{
     data_cache::TransactionDataCache,
     native_functions::{NativeContextExtensions, NativeFunction},
     runtime::VMRuntime,
     session::Session,
 };
-use move_binary_format::errors::{Location, VMResult};
+use move_binary_format::{
+    errors::{Location, VMResult},
+    CompiledModule,
+};
 use move_core_types::{
     account_address::AccountAddress, identifier::Identifier, language_storage::ModuleId,
     resolver::MoveResolver,
@@ -58,13 +63,13 @@ impl MoveVM {
         &self,
         module_id: &ModuleId,
         remote: &'r S,
-    ) -> VMResult<()> {
+    ) -> VMResult<Arc<CompiledModule>> {
         self.runtime
             .loader()
             .load_module(
                 module_id,
                 &TransactionDataCache::new(remote, self.runtime.loader()),
             )
-            .map(|_| ())
+            .map(|arc_module| arc_module.arc_module())
     }
 }

--- a/language/move-vm/types/src/loaded_data/runtime_types.rs
+++ b/language/move-vm/types/src/loaded_data/runtime_types.rs
@@ -25,6 +25,9 @@ impl StructType {
     }
 }
 
+#[derive(Debug, Copy, Clone, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct CachedStructIndex(pub usize);
+
 #[derive(Debug, Clone, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub enum Type {
     Bool,
@@ -34,8 +37,8 @@ pub enum Type {
     Address,
     Signer,
     Vector(Box<Type>),
-    Struct(usize),
-    StructInstantiation(usize, Vec<Type>),
+    Struct(CachedStructIndex),
+    StructInstantiation(CachedStructIndex, Vec<Type>),
     Reference(Box<Type>),
     MutableReference(Box<Type>),
     TyParam(usize),


### PR DESCRIPTION
## Motivation

- Exposing more access to the cache gives adapters more flexibility
- Allows adapters to implement checks over cached data (without having to make their own cache)

## Test Plan

- eyes. endpoints are already tested, just now expoed

