### PR TITLE
[move-lang][vm] Allow non-`'static` native context extensions.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,6 +148,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "better_any"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b359aebd937c17c725e19efcb661200883f04c49c53e7132224dac26da39d4a0"
+dependencies = [
+ "better_typeid_derive",
+]
+
+[[package]]
+name = "better_typeid_derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3deeecb812ca5300b7d3f66f730cc2ebd3511c3d36c691dd79c165d5b19a26e3"
+dependencies = [
+ "proc-macro2 1.0.28",
+ "quote 1.0.9",
+ "syn 1.0.74",
+]
+
+[[package]]
 name = "bimap"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2016,6 +2036,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bcs",
+ "better_any",
  "datatest-stable",
  "itertools 0.10.1",
  "move-binary-format",
@@ -2662,6 +2683,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bcs",
+ "better_any",
  "downcast-rs",
  "itertools 0.10.1",
  "move-binary-format",
@@ -2817,6 +2839,7 @@ name = "move-vm-runtime"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "better_any",
  "fail",
  "hex",
  "mirai-annotations",
@@ -4864,7 +4887,7 @@ version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ee73e6e4924fe940354b8d4d98cad5231175d615cd855b758adc658c0aac6a0"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "static_assertions",
 ]
 

--- a/language/extensions/async/move-async-vm/Cargo.toml
+++ b/language/extensions/async/move-async-vm/Cargo.toml
@@ -10,6 +10,7 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.52"
+better_any = "0.1.1"
 walkdir = "2.3.1"
 itertools = "0.10.0"
 smallvec = "1.6.1"

--- a/language/extensions/async/move-async-vm/src/async_vm.rs
+++ b/language/extensions/async/move-async-vm/src/async_vm.rs
@@ -19,7 +19,8 @@ use move_core_types::{
 };
 use move_vm_runtime::{
     move_vm::MoveVM,
-    native_functions::{NativeContextExtensions, NativeFunction},
+    native_extensions::NativeContextExtensions,
+    native_functions::NativeFunction,
     session::{SerializedReturnValues, Session},
 };
 use move_vm_types::{
@@ -328,11 +329,11 @@ impl<'r, 'l, S: MoveResolver> AsyncSession<'r, 'l, S> {
     }
 }
 
-fn make_extensions(
+fn make_extensions<'a>(
     actor_addr: AccountAddress,
     virtual_time: u128,
     in_initializer: bool,
-) -> NativeContextExtensions {
+) -> NativeContextExtensions<'a> {
     let mut exts = NativeContextExtensions::default();
     exts.add(AsyncExtension {
         current_actor: actor_addr,

--- a/language/extensions/async/move-async-vm/src/natives.rs
+++ b/language/extensions/async/move-async-vm/src/natives.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::async_vm::Message;
+use better_any::{Tid, TidAble};
 use move_binary_format::errors::PartialVMResult;
 use move_core_types::{account_address::AccountAddress, identifier::Identifier};
 use move_vm_runtime::{
@@ -26,6 +27,7 @@ const EPOCH_TIME_INDEX: NativeCostIndex = NativeCostIndex::LENGTH;
 
 /// Environment extension for the Move VM which we pass down to native functions,
 /// to implement message sending and retrieval of actor address.
+#[derive(Tid)]
 pub struct AsyncExtension {
     pub current_actor: AccountAddress,
     pub sent: Vec<Message>,

--- a/language/extensions/move-table-extension/Cargo.toml
+++ b/language/extensions/move-table-extension/Cargo.toml
@@ -10,6 +10,7 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.52"
+better_any = "0.1.1"
 downcast-rs = "1.2.0"
 walkdir = "2.3.1"
 itertools = "0.10.0"

--- a/language/extensions/move-table-extension/src/lib.rs
+++ b/language/extensions/move-table-extension/src/lib.rs
@@ -6,6 +6,7 @@
 //! See [`Table.move`](../sources/Table.move) for language use.
 //! See [`README.md`](../README.md) for integration into an adapter.
 
+use better_any::{Tid, TidAble};
 use move_binary_format::errors::{PartialVMError, PartialVMResult};
 use move_core_types::{
     account_address::AccountAddress,
@@ -94,6 +95,7 @@ pub enum TableOperation {
 /// The native table context extension. This needs to be attached to the NativeContextExtensions
 /// value which is passed into session functions, so its accessible from natives of this
 /// extension.
+#[derive(Tid)]
 pub struct NativeTableContext<'a> {
     resolver: &'a dyn TableResolver,
     txn_hash: u128,

--- a/language/move-vm/runtime/Cargo.toml
+++ b/language/move-vm/runtime/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+better_any = "0.1.1"
 fail = "0.4.0"
 mirai-annotations = "1.10.1"
 once_cell = "1.7.2"

--- a/language/move-vm/runtime/src/interpreter.rs
+++ b/language/move-vm/runtime/src/interpreter.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     loader::{Function, Loader, Resolver},
-    native_functions::{NativeContext, NativeContextExtensions},
+    native_functions::NativeContext,
     trace,
 };
 use fail::fail_point;
@@ -27,6 +27,7 @@ use move_vm_types::{
     },
 };
 
+use crate::native_extensions::NativeContextExtensions;
 use std::{cmp::min, collections::VecDeque, fmt::Write, mem, sync::Arc};
 use tracing::error;
 

--- a/language/move-vm/runtime/src/lib.rs
+++ b/language/move-vm/runtime/src/lib.rs
@@ -17,6 +17,7 @@ mod interpreter;
 mod loader;
 pub mod logging;
 pub mod move_vm;
+pub mod native_extensions;
 pub mod native_functions;
 mod runtime;
 pub mod session;

--- a/language/move-vm/runtime/src/move_vm.rs
+++ b/language/move-vm/runtime/src/move_vm.rs
@@ -4,10 +4,8 @@
 use std::sync::Arc;
 
 use crate::{
-    data_cache::TransactionDataCache,
-    native_functions::{NativeContextExtensions, NativeFunction},
-    runtime::VMRuntime,
-    session::Session,
+    data_cache::TransactionDataCache, native_extensions::NativeContextExtensions,
+    native_functions::NativeFunction, runtime::VMRuntime, session::Session,
 };
 use move_binary_format::{
     errors::{Location, VMResult},
@@ -53,7 +51,7 @@ impl MoveVM {
     pub fn new_session_with_extensions<'r, S: MoveResolver>(
         &self,
         remote: &'r S,
-        extensions: NativeContextExtensions,
+        extensions: NativeContextExtensions<'r>,
     ) -> Session<'r, '_, S> {
         self.runtime.new_session_with_extensions(remote, extensions)
     }

--- a/language/move-vm/runtime/src/native_extensions.rs
+++ b/language/move-vm/runtime/src/native_extensions.rs
@@ -1,0 +1,82 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use better_any::{Tid, TidAble, TidExt};
+use std::{any::TypeId, collections::HashMap};
+
+/// A data type to represent a heterogeneous collection of extensions which are available to
+/// native functions. A value to this is passed into the session function execution.
+///
+/// The implementation uses the crate `better_any` which implements a version of the `Any`
+/// type, called `Tid<`a>`, which allows for up to one lifetime parameter. This
+/// avoids that extensions need to have `'static` lifetime, which `Any` requires. In order to make a
+/// struct suitable to be a 'Tid', use `#[derive(Tid)]` in the struct declaration. (See also
+/// tests at the end of this module.)
+#[derive(Default)]
+pub struct NativeContextExtensions<'a> {
+    map: HashMap<TypeId, Box<dyn Tid<'a>>>,
+}
+
+impl<'a> NativeContextExtensions<'a> {
+    pub fn add<T: TidAble<'a>>(&mut self, ext: T) {
+        assert!(
+            self.map.insert(T::id(), Box::new(ext)).is_none(),
+            "multiple extensions of the same type not allowed"
+        )
+    }
+
+    pub fn get<T: TidAble<'a>>(&self) -> &T {
+        self.map
+            .get(&T::id())
+            .expect("extension unknown")
+            .as_ref()
+            .downcast_ref::<T>()
+            .unwrap()
+    }
+
+    pub fn get_mut<T: TidAble<'a>>(&mut self) -> &mut T {
+        self.map
+            .get_mut(&T::id())
+            .expect("extension unknown")
+            .as_mut()
+            .downcast_mut::<T>()
+            .unwrap()
+    }
+
+    pub fn remove<T: TidAble<'a>>(&mut self) -> T {
+        // can't use expect below because it requires `T: Debug`.
+        match self
+            .map
+            .remove(&T::id())
+            .expect("extension unknown")
+            .downcast_box::<T>()
+        {
+            Ok(val) => *val,
+            Err(_) => panic!("downcast error"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::native_extensions::NativeContextExtensions;
+    use better_any::{Tid, TidAble};
+
+    #[derive(Tid)]
+    struct Ext<'a> {
+        a: &'a mut u64,
+    }
+
+    #[test]
+    fn non_static_ext() {
+        let mut v: u64 = 23;
+        let e = Ext { a: &mut v };
+        let mut exts = NativeContextExtensions::default();
+        exts.add(e);
+        *exts.get_mut::<Ext>().a += 1;
+        assert_eq!(*exts.get_mut::<Ext>().a, 24);
+        *exts.get_mut::<Ext>().a += 1;
+        let e1 = exts.remove::<Ext>();
+        assert_eq!(*e1.a, 25)
+    }
+}

--- a/language/move-vm/runtime/src/native_functions.rs
+++ b/language/move-vm/runtime/src/native_functions.rs
@@ -1,7 +1,9 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{interpreter::Interpreter, loader::Resolver};
+use crate::{
+    interpreter::Interpreter, loader::Resolver, native_extensions::NativeContextExtensions,
+};
 use move_binary_format::errors::{PartialVMError, PartialVMResult};
 use move_core_types::{
     account_address::AccountAddress,
@@ -15,7 +17,6 @@ use move_vm_types::{
     natives::function::NativeResult, values::Value,
 };
 use std::{
-    any::{Any, TypeId},
     collections::{HashMap, VecDeque},
     fmt::Write,
 };
@@ -76,63 +77,21 @@ impl NativeFunctions {
     }
 }
 
-pub struct NativeContext<'a> {
+pub struct NativeContext<'a, 'b> {
     interpreter: &'a mut Interpreter,
     data_store: &'a mut dyn DataStore,
     gas_status: &'a GasStatus<'a>,
     resolver: &'a Resolver<'a>,
-    extensions: &'a mut NativeContextExtensions,
+    extensions: &'a mut NativeContextExtensions<'b>,
 }
 
-/// A data type to represent a heterogeneous collection of extensions which are available to
-/// native functions. A reference to this is passed into the session function execution
-/// entry points.
-#[derive(Default)]
-pub struct NativeContextExtensions {
-    map: HashMap<TypeId, Box<dyn Any>>,
-}
-
-impl NativeContextExtensions {
-    pub fn add<T: Any>(&mut self, ext: T) {
-        assert!(
-            self.map.insert(TypeId::of::<T>(), Box::new(ext)).is_none(),
-            "multiple extensions of the same type not allowed"
-        )
-    }
-
-    pub fn get<T: Any>(&self) -> &T {
-        self.map
-            .get(&TypeId::of::<T>())
-            .expect("dynamic typing error")
-            .downcast_ref::<T>()
-            .unwrap()
-    }
-
-    pub fn get_mut<T: Any>(&mut self) -> &mut T {
-        self.map
-            .get_mut(&TypeId::of::<T>())
-            .expect("dynamic typing error")
-            .downcast_mut::<T>()
-            .unwrap()
-    }
-
-    pub fn remove<T: Any>(&mut self) -> T {
-        *self
-            .map
-            .remove(&TypeId::of::<T>())
-            .expect("dynamic typing error")
-            .downcast::<T>()
-            .unwrap()
-    }
-}
-
-impl<'a, 'b> NativeContext<'a> {
+impl<'a, 'b> NativeContext<'a, 'b> {
     pub(crate) fn new(
         interpreter: &'a mut Interpreter,
         data_store: &'a mut dyn DataStore,
         gas_status: &'a mut GasStatus,
         resolver: &'a Resolver<'a>,
-        extensions: &'a mut NativeContextExtensions,
+        extensions: &'a mut NativeContextExtensions<'b>,
     ) -> Self {
         Self {
             interpreter,
@@ -144,7 +103,7 @@ impl<'a, 'b> NativeContext<'a> {
     }
 }
 
-impl<'a> NativeContext<'a> {
+impl<'a, 'b> NativeContext<'a, 'b> {
     pub fn print_stack_trace<B: Write>(&self, buf: &mut B) -> PartialVMResult<()> {
         self.interpreter
             .debug_print_stack_trace(buf, self.resolver.loader())
@@ -180,11 +139,11 @@ impl<'a> NativeContext<'a> {
         }
     }
 
-    pub fn extensions(&self) -> &NativeContextExtensions {
+    pub fn extensions(&self) -> &NativeContextExtensions<'b> {
         self.extensions
     }
 
-    pub fn extensions_mut(&mut self) -> &mut NativeContextExtensions {
+    pub fn extensions_mut(&mut self) -> &mut NativeContextExtensions<'b> {
         self.extensions
     }
 }

--- a/language/move-vm/runtime/src/runtime.rs
+++ b/language/move-vm/runtime/src/runtime.rs
@@ -5,7 +5,8 @@ use crate::{
     data_cache::TransactionDataCache,
     interpreter::Interpreter,
     loader::{Function, Loader},
-    native_functions::{NativeContextExtensions, NativeFunction, NativeFunctions},
+    native_extensions::NativeContextExtensions,
+    native_functions::{NativeFunction, NativeFunctions},
     session::{LoadedFunctionInstantiation, SerializedReturnValues, Session},
 };
 use move_binary_format::{
@@ -58,7 +59,7 @@ impl VMRuntime {
     pub fn new_session_with_extensions<'r, S: MoveResolver>(
         &self,
         remote: &'r S,
-        native_extensions: NativeContextExtensions,
+        native_extensions: NativeContextExtensions<'r>,
     ) -> Session<'r, '_, S> {
         Session {
             runtime: self,

--- a/language/move-vm/runtime/src/session.rs
+++ b/language/move-vm/runtime/src/session.rs
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    data_cache::TransactionDataCache, native_functions::NativeContextExtensions, runtime::VMRuntime,
+    data_cache::TransactionDataCache, native_extensions::NativeContextExtensions,
+    runtime::VMRuntime,
 };
 use move_binary_format::{errors::*, file_format::LocalIndex};
 use move_core_types::{
@@ -23,7 +24,7 @@ use std::{borrow::Borrow, sync::Arc};
 pub struct Session<'r, 'l, S> {
     pub(crate) runtime: &'l VMRuntime,
     pub(crate) data_cache: TransactionDataCache<'r, 'l, S>,
-    pub(crate) native_extensions: NativeContextExtensions,
+    pub(crate) native_extensions: NativeContextExtensions<'r>,
 }
 
 /// Serialized return values from function/script execution
@@ -201,7 +202,7 @@ impl<'r, 'l, S: MoveResolver> Session<'r, 'l, S> {
     /// Same like `finish`, but also extracts the native context extensions from the session.
     pub fn finish_with_extensions(
         self,
-    ) -> VMResult<(ChangeSet, Vec<Event>, NativeContextExtensions)> {
+    ) -> VMResult<(ChangeSet, Vec<Event>, NativeContextExtensions<'r>)> {
         let Session {
             data_cache,
             native_extensions,

--- a/language/move-vm/runtime/src/unit_tests/vm_arguments_tests.rs
+++ b/language/move-vm/runtime/src/unit_tests/vm_arguments_tests.rs
@@ -772,9 +772,9 @@ fn call_missing_item() {
     let function_name = IdentStr::new("foo").unwrap();
     // mising module
     let move_vm = MoveVM::new(vec![]).unwrap();
+    let mut gas_status = GasStatus::new_unmetered();
     let mut remote_view = RemoteStore::new();
     let mut session = move_vm.new_session(&remote_view);
-    let mut gas_status = GasStatus::new_unmetered();
     let error = session
         .execute_function_bypass_visibility(
             id,
@@ -787,6 +787,7 @@ fn call_missing_item() {
         .unwrap();
     assert_eq!(error.major_status(), StatusCode::LINKER_ERROR);
     assert_eq!(error.status_type(), StatusType::Verification);
+    drop(session);
 
     // missing function
     remote_view.add_module(module);

--- a/language/tools/move-unit-test/src/extensions.rs
+++ b/language/tools/move-unit-test/src/extensions.rs
@@ -5,7 +5,7 @@
 //! Such extensions are enabled by cfg features and must be compiled into the test
 //! to be usable.
 
-use move_vm_runtime::native_functions::NativeContextExtensions;
+use move_vm_runtime::native_extensions::NativeContextExtensions;
 use std::fmt::Write;
 
 #[cfg(feature = "table-extension")]
@@ -19,7 +19,7 @@ use once_cell::sync::Lazy;
 
 /// Create all available native context extensions.
 #[allow(unused_mut, clippy::let_and_return)]
-pub(crate) fn new_extensions() -> NativeContextExtensions {
+pub(crate) fn new_extensions<'a>() -> NativeContextExtensions<'a> {
     let mut e = NativeContextExtensions::default();
     #[cfg(feature = "table-extension")]
     create_table_extension(&mut e);

--- a/language/tools/move-unit-test/src/test_runner.rs
+++ b/language/tools/move-unit-test/src/test_runner.rs
@@ -38,7 +38,7 @@ use move_vm_types::gas_schedule::{zero_cost_schedule, GasStatus};
 use rayon::prelude::*;
 use std::{collections::BTreeMap, io::Write, marker::Send, sync::Mutex, time::Instant};
 
-use move_vm_runtime::native_functions::NativeContextExtensions;
+use move_vm_runtime::native_extensions::NativeContextExtensions;
 #[cfg(feature = "evm-backend")]
 use {
     evm::{backend::MemoryVicinity, ExitReason},


### PR DESCRIPTION
This uses the `Tid<'a>` type from the [better_any](https://docs.rs/better_any/latest/better_any/) crate which acts as a replacement for the standard `Any` type in order to implement `NativeContextExtensions`. This allows the polymorphic values stored in the extensions to be non-`'static`, which `Any` does not.

As a consequence, it is now `NativeContextExtensions<'a>`, where `'a` is placeholder for the lifetime of any references stored in some extensions. Only one lifetime parameter is allowed for such extensions because of restrictions of `better_any`.

A user of extensions should not see any of this, however, structures describing extensions must use `#[derive(Tid)]`, and any type parameters those have must do as well. This is so the crate can compute a `TypeId` for such types.

The `NativeContextExtensions<'a>` type has been moved in its own module, and a test has been added to verify that this new feature works.

## Motivation

Allow extensions to contain non-static references, as e.g. for #194 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Added test
