### PR TITLE
[language] Fix ControlFlowGraph trait

### DIFF
--- a/language/move-binary-format/src/control_flow_graph.rs
+++ b/language/move-binary-format/src/control_flow_graph.rs
@@ -22,7 +22,8 @@ pub trait ControlFlowGraph {
     /// Successors of the block ID in the bytecode vector
     fn successors(&self, block_id: BlockId) -> &Vec<BlockId>;
 
-    fn next_block(&self, block_id: BlockId) -> Option<CodeOffset>;
+    /// Return the next block in traversal order
+    fn next_block(&self, block_id: BlockId) -> Option<BlockId>;
 
     /// Iterator over the indexes of instructions in this block
     fn instr_indexes(&self, block_id: BlockId) -> Box<dyn Iterator<Item = CodeOffset>>;


### PR DESCRIPTION
Fix the signature of `next_block` and add documentation.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

The `next_block` method returns the next block, so the return type should be `BlockId` instead of `CodeOffset`.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Since `pub type BlockId = CodeOffset;`, this change won't affect execution.
