### PR TITLE
[move-lang][vm] Allow non-'static native context extensions. (#3)_4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,6 +148,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "better_any"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b359aebd937c17c725e19efcb661200883f04c49c53e7132224dac26da39d4a0"
+dependencies = [
+ "better_typeid_derive",
+]
+
+[[package]]
+name = "better_typeid_derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3deeecb812ca5300b7d3f66f730cc2ebd3511c3d36c691dd79c165d5b19a26e3"
+dependencies = [
+ "proc-macro2 1.0.28",
+ "quote 1.0.9",
+ "syn 1.0.74",
+]
+
+[[package]]
 name = "bimap"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2016,6 +2036,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bcs",
+ "better_any",
  "datatest-stable",
  "itertools 0.10.1",
  "move-binary-format",
@@ -2666,6 +2687,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bcs",
+ "better_any",
  "downcast-rs",
  "itertools 0.10.1",
  "move-binary-format",
@@ -2821,6 +2843,7 @@ name = "move-vm-runtime"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "better_any",
  "fail",
  "hex",
  "mirai-annotations",
@@ -4868,7 +4891,7 @@ version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ee73e6e4924fe940354b8d4d98cad5231175d615cd855b758adc658c0aac6a0"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "static_assertions",
 ]
 

--- a/language/extensions/async/move-async-vm/Cargo.toml
+++ b/language/extensions/async/move-async-vm/Cargo.toml
@@ -10,6 +10,7 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.52"
+better_any = "0.1.1"
 walkdir = "2.3.1"
 itertools = "0.10.0"
 smallvec = "1.6.1"

--- a/language/extensions/async/move-async-vm/src/natives.rs
+++ b/language/extensions/async/move-async-vm/src/natives.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::async_vm::Message;
+use better_any::{Tid, TidAble};
 use move_binary_format::errors::PartialVMResult;
 use move_core_types::{account_address::AccountAddress, identifier::Identifier};
 use move_vm_runtime::{
@@ -26,6 +27,7 @@ const EPOCH_TIME_INDEX: NativeCostIndex = NativeCostIndex::LENGTH;
 
 /// Environment extension for the Move VM which we pass down to native functions,
 /// to implement message sending and retrieval of actor address.
+#[derive(Tid)]
 pub struct AsyncExtension {
     pub current_actor: AccountAddress,
     pub sent: Vec<Message>,

--- a/language/extensions/move-table-extension/Cargo.toml
+++ b/language/extensions/move-table-extension/Cargo.toml
@@ -10,6 +10,7 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.52"
+better_any = "0.1.1"
 downcast-rs = "1.2.0"
 walkdir = "2.3.1"
 itertools = "0.10.0"

--- a/language/extensions/move-table-extension/src/lib.rs
+++ b/language/extensions/move-table-extension/src/lib.rs
@@ -6,6 +6,7 @@
 //! See [`Table.move`](../sources/Table.move) for language use.
 //! See [`README.md`](../README.md) for integration into an adapter.
 
+use better_any::{Tid, TidAble};
 use move_binary_format::errors::{PartialVMError, PartialVMResult};
 use move_core_types::{
     account_address::AccountAddress,
@@ -94,6 +95,7 @@ pub enum TableOperation {
 /// The native table context extension. This needs to be attached to the NativeContextExtensions
 /// value which is passed into session functions, so its accessible from natives of this
 /// extension.
+#[derive(Tid)]
 pub struct NativeTableContext<'a> {
     resolver: &'a dyn TableResolver,
     txn_hash: u128,

--- a/language/move-analyzer/src/completion.rs
+++ b/language/move-analyzer/src/completion.rs
@@ -137,9 +137,8 @@ pub fn on_completion_request(context: &Context, request: &Request) {
     }
 
     // The completion items we provide depend upon where the user's cursor is positioned.
-    let cursor = buffer
-        .map(|buf| get_cursor_token(buf, &parameters.text_document_position.position))
-        .flatten();
+    let cursor =
+        buffer.and_then(|buf| get_cursor_token(buf, &parameters.text_document_position.position));
 
     let mut items = vec![];
     match cursor {

--- a/language/move-binary-format/src/file_format_common.rs
+++ b/language/move-binary-format/src/file_format_common.rs
@@ -345,7 +345,7 @@ pub fn read_uleb128_as_u64(cursor: &mut Cursor<&[u8]>) -> Result<u64> {
         }
 
         shift += 7;
-        if shift > size_of::<u64>() * 8 {
+        if shift > u64::BITS {
             break;
         }
     }

--- a/language/move-binary-format/src/proptest_types/functions.rs
+++ b/language/move-binary-format/src/proptest_types/functions.rs
@@ -886,7 +886,7 @@ impl BytecodeGen {
             Vector(element_token) => BytecodeGen::check_signature_token(element_token),
             StructInstantiation(_, type_arguments) => type_arguments
                 .iter()
-                .all(|ty| BytecodeGen::check_signature_token(ty)),
+                .all(BytecodeGen::check_signature_token),
             Reference(_) | MutableReference(_) => false,
         }
     }

--- a/language/move-binary-format/src/proptest_types/types.rs
+++ b/language/move-binary-format/src/proptest_types/types.rs
@@ -145,6 +145,7 @@ pub struct StructDefinitionGen {
     name_idx: PropIndex,
     abilities: AbilitySetGen,
     type_parameters: Vec<(AbilitySetGen, bool)>,
+    #[allow(dead_code)]
     is_public: bool,
     field_defs: Option<Vec<FieldDefinitionGen>>,
 }

--- a/language/move-compiler/src/cfgir/borrows/state.rs
+++ b/language/move-compiler/src/cfgir/borrows/state.rs
@@ -306,7 +306,7 @@ impl BorrowState {
         assert!(full_borrows.is_empty());
         field_borrows
             .remove(&Self::local_label(local))
-            .unwrap_or_else(BTreeMap::new)
+            .unwrap_or_default()
     }
 
     fn resource_borrowed_by(&self, resource: &StructName) -> BTreeMap<RefID, Loc> {
@@ -314,7 +314,7 @@ impl BorrowState {
         assert!(full_borrows.is_empty());
         field_borrows
             .remove(&Self::resource_label(resource))
-            .unwrap_or_else(BTreeMap::new)
+            .unwrap_or_default()
     }
 
     // returns empty errors if borrowed_by is empty

--- a/language/move-compiler/src/cfgir/cfg.rs
+++ b/language/move-compiler/src/cfgir/cfg.rs
@@ -292,7 +292,7 @@ fn unreachable_loc_exp(parent_e: &Exp) -> Option<Loc> {
 
         E::Pack(_, _, fields) => fields.iter().find_map(|(_, _, e)| unreachable_loc_exp(e)),
 
-        E::ExpList(es) => es.iter().find_map(|item| unreachable_loc_item(item)),
+        E::ExpList(es) => es.iter().find_map(unreachable_loc_item),
     }
 }
 
@@ -517,7 +517,7 @@ pub struct ReverseBlockCFG<'a> {
 
 impl<'a> ReverseBlockCFG<'a> {
     pub fn new(forward_cfg: &'a mut BlockCFG, infinite_loop_starts: &BTreeSet<Label>) -> Self {
-        let blocks: &'a mut BasicBlocks = &mut forward_cfg.blocks;
+        let blocks: &'a mut BasicBlocks = forward_cfg.blocks;
         let forward_successors = &mut forward_cfg.successor_map;
         let forward_predecessor = &mut forward_cfg.predecessor_map;
         let end_blocks = {

--- a/language/move-compiler/src/cfgir/constant_fold.rs
+++ b/language/move-compiler/src/cfgir/constant_fold.rs
@@ -86,10 +86,7 @@ fn optimize_exp(e: &mut Exp) -> bool {
             .map(|(_, _, e)| optimize_exp(e))
             .any(|changed| changed),
 
-        E::ExpList(es) => es
-            .iter_mut()
-            .map(|item| optimize_exp_item(item))
-            .any(|changed| changed),
+        E::ExpList(es) => es.iter_mut().map(optimize_exp_item).any(|changed| changed),
 
         //************************************
         // Foldable cases

--- a/language/move-compiler/src/cfgir/eliminate_locals.rs
+++ b/language/move-compiler/src/cfgir/eliminate_locals.rs
@@ -221,7 +221,7 @@ mod count {
             E::BinopExp(e1, op, e2) => {
                 can_subst_exp_binary(op) && can_subst_exp_single(e1) && can_subst_exp_single(e2)
             }
-            E::ExpList(es) => es.iter().all(|i| can_subst_exp_item(i)),
+            E::ExpList(es) => es.iter().all(can_subst_exp_item),
             E::Pack(_, _, fields) => fields.iter().all(|(_, _, e)| can_subst_exp_single(e)),
             E::Vector(_, _, _, eargs) => can_subst_exp_single(eargs),
 

--- a/language/move-compiler/src/cfgir/translate.rs
+++ b/language/move-compiler/src/cfgir/translate.rs
@@ -48,18 +48,15 @@ impl<'env> Context<'env> {
         pre_compiled_lib: Option<&FullyCompiledProgram>,
         modules: &UniqueMap<ModuleIdent, H::ModuleDefinition>,
     ) -> Self {
-        let all_modules = modules.key_cloned_iter().chain(
-            pre_compiled_lib
-                .iter()
-                .map(|pre_compiled| {
-                    pre_compiled
-                        .hlir
-                        .modules
-                        .key_cloned_iter()
-                        .filter(|(mident, _m)| !modules.contains_key(mident))
-                })
-                .flatten(),
-        );
+        let all_modules = modules
+            .key_cloned_iter()
+            .chain(pre_compiled_lib.iter().flat_map(|pre_compiled| {
+                pre_compiled
+                    .hlir
+                    .modules
+                    .key_cloned_iter()
+                    .filter(|(mident, _m)| !modules.contains_key(mident))
+            }));
         let struct_declared_abilities = UniqueMap::maybe_from_iter(
             all_modules
                 .map(|(m, mdef)| (m, mdef.structs.ref_map(|_s, sdef| sdef.abilities.clone()))),

--- a/language/move-compiler/src/command_line/compiler.rs
+++ b/language/move-compiler/src/command_line/compiler.rs
@@ -582,7 +582,7 @@ fn generate_interface_files_for_deps(
 }
 
 pub fn generate_interface_files(
-    mv_file_locations: &mut Vec<AddressScopedFileIndexed>,
+    mv_file_locations: &mut [AddressScopedFileIndexed],
     interface_files_dir_opt: Option<String>,
     named_address_mapping: &BTreeMap<CompiledModuleId, String>,
     separate_by_hash: bool,

--- a/language/move-compiler/src/expansion/translate.rs
+++ b/language/move-compiler/src/expansion/translate.rs
@@ -523,8 +523,7 @@ fn flatten_attributes(
 ) -> E::Attributes {
     let all_attrs = attributes
         .into_iter()
-        .map(|attrs| attrs.value)
-        .flatten()
+        .flat_map(|attrs| attrs.value)
         .flat_map(|attr| attribute(context, attr_position, attr))
         .collect::<Vec<_>>();
     unique_attributes(context, attr_position, false, all_attrs)
@@ -688,7 +687,7 @@ fn module_members(
     if !always_add && members.contains_key(&mident) {
         return;
     }
-    let mut cur_members = members.remove(&mident).unwrap_or_else(ModuleMembers::new);
+    let mut cur_members = members.remove(&mident).unwrap_or_default();
     for mem in &m.members {
         use P::{SpecBlockMember_ as SBM, SpecBlockTarget_ as SBT, SpecBlock_ as SB};
         match mem {

--- a/language/move-compiler/src/hlir/translate.rs
+++ b/language/move-compiler/src/hlir/translate.rs
@@ -50,7 +50,7 @@ pub fn display_var(s: Symbol) -> DisplayVar {
         DisplayVar::Tmp
     } else {
         let mut orig = s.as_str().to_string();
-        orig.truncate(orig.find('#').unwrap_or_else(|| s.len()));
+        orig.truncate(orig.find('#').unwrap_or(s.len()));
         DisplayVar::Orig(orig)
     }
 }
@@ -1965,7 +1965,7 @@ fn remove_unused_bindings_command(unused: &BTreeSet<Var>, sp!(_, c_): &mut H::Co
     }
 }
 
-fn remove_unused_bindings_lvalues(unused: &BTreeSet<Var>, ls: &mut Vec<H::LValue>) {
+fn remove_unused_bindings_lvalues(unused: &BTreeSet<Var>, ls: &mut [H::LValue]) {
     ls.iter_mut()
         .for_each(|l| remove_unused_bindings_lvalue(unused, l))
 }

--- a/language/move-compiler/src/interface_generator.rs
+++ b/language/move-compiler/src/interface_generator.rs
@@ -162,10 +162,7 @@ fn write_module_id(
     match named_address_mapping.get(id) {
         None => format!(
             "{}::{}",
-            format!(
-                "{}",
-                NumericalAddress::new(id.address().into_bytes(), NumberFormat::Hex)
-            ),
+            NumericalAddress::new(id.address().into_bytes(), NumberFormat::Hex),
             id.name()
         ),
         Some(n) => format!("{}::{}", n.as_ref(), id.name()),

--- a/language/move-compiler/src/naming/translate.rs
+++ b/language/move-compiler/src/naming/translate.rs
@@ -57,18 +57,15 @@ impl<'env> Context<'env> {
     ) -> Self {
         use ResolvedType as RT;
         let all_modules = || {
-            prog.modules.key_cloned_iter().chain(
-                pre_compiled_lib
-                    .iter()
-                    .map(|pre_compiled| {
-                        pre_compiled
-                            .expansion
-                            .modules
-                            .key_cloned_iter()
-                            .filter(|(mident, _m)| !prog.modules.contains_key(mident))
-                    })
-                    .flatten(),
-            )
+            prog.modules
+                .key_cloned_iter()
+                .chain(pre_compiled_lib.iter().flat_map(|pre_compiled| {
+                    pre_compiled
+                        .expansion
+                        .modules
+                        .key_cloned_iter()
+                        .filter(|(mident, _m)| !prog.modules.contains_key(mident))
+                }))
         };
         let scoped_types = all_modules()
             .map(|(mident, mdef)| {

--- a/language/move-compiler/src/parser/lexer.rs
+++ b/language/move-compiler/src/parser/lexer.rs
@@ -552,14 +552,14 @@ fn find_token(
 fn get_name_len(text: &str) -> usize {
     text.chars()
         .position(|c| !matches!(c, 'a'..='z' | 'A'..='Z' | '_' | '0'..='9'))
-        .unwrap_or_else(|| text.len())
+        .unwrap_or(text.len())
 }
 
 fn get_decimal_number(text: &str) -> (Tok, usize) {
     let num_text_len = text
         .chars()
         .position(|c| !matches!(c, '0'..='9'))
-        .unwrap_or_else(|| text.len());
+        .unwrap_or(text.len());
     get_number_maybe_with_suffix(text, num_text_len)
 }
 
@@ -567,7 +567,7 @@ fn get_decimal_number(text: &str) -> (Tok, usize) {
 fn get_hex_number(text: &str) -> (Tok, usize) {
     let num_text_len = text
         .find(|c| !matches!(c, 'a'..='f' | 'A'..='F' | '0'..='9'))
-        .unwrap_or_else(|| text.len());
+        .unwrap_or(text.len());
     get_number_maybe_with_suffix(text, num_text_len)
 }
 

--- a/language/move-compiler/src/parser/merge_spec_modules.rs
+++ b/language/move-compiler/src/parser/merge_spec_modules.rs
@@ -106,7 +106,7 @@ fn extract_spec_module(
 
 fn merge_spec_modules(
     spec_modules: &mut BTreeMap<(Option<LeadingNameAccess_>, Symbol), ModuleDefinition>,
-    defs: &mut Vec<(NamedAddressMapIndex, Definition)>,
+    defs: &mut [(NamedAddressMapIndex, Definition)],
 ) {
     use Definition::*;
     // TODO check address mappings line up

--- a/language/move-compiler/src/parser/syntax.rs
+++ b/language/move-compiler/src/parser/syntax.rs
@@ -228,11 +228,11 @@ where
             ));
         }
         v.push(parse_list_item(context)?);
-        adjust_token(&mut context.tokens, end_token);
-        if match_token(&mut context.tokens, end_token)? {
+        adjust_token(context.tokens, end_token);
+        if match_token(context.tokens, end_token)? {
             break Ok(v);
         }
-        if !match_token(&mut context.tokens, Tok::Comma)? {
+        if !match_token(context.tokens, Tok::Comma)? {
             let current_loc = context.tokens.start_loc();
             let loc = make_loc(context.tokens.file_hash(), current_loc, current_loc);
             let loc2 = make_loc(context.tokens.file_hash(), start_loc, start_loc);

--- a/language/move-compiler/src/to_bytecode/translate.rs
+++ b/language/move-compiler/src/to_bytecode/translate.rs
@@ -48,16 +48,13 @@ fn extract_decls(
     >,
 ) {
     let pre_compiled_modules = || {
-        pre_compiled_lib
-            .iter()
-            .map(|pre_compiled| {
-                pre_compiled
-                    .cfgir
-                    .modules
-                    .key_cloned_iter()
-                    .filter(|(mident, _m)| !prog.modules.contains_key(mident))
-            })
-            .flatten()
+        pre_compiled_lib.iter().flat_map(|pre_compiled| {
+            pre_compiled
+                .cfgir
+                .modules
+                .key_cloned_iter()
+                .filter(|(mident, _m)| !prog.modules.contains_key(mident))
+        })
     };
 
     let mut max_ordering = 0;

--- a/language/move-compiler/src/typing/core.rs
+++ b/language/move-compiler/src/typing/core.rs
@@ -85,18 +85,16 @@ impl<'env> Context<'env> {
         pre_compiled_lib: Option<&FullyCompiledProgram>,
         prog: &N::Program,
     ) -> Self {
-        let all_modules = prog.modules.key_cloned_iter().chain(
-            pre_compiled_lib
-                .iter()
-                .map(|pre_compiled| {
-                    pre_compiled
-                        .naming
-                        .modules
-                        .key_cloned_iter()
-                        .filter(|(mident, _m)| !prog.modules.contains_key(mident))
-                })
-                .flatten(),
-        );
+        let all_modules = prog
+            .modules
+            .key_cloned_iter()
+            .chain(pre_compiled_lib.iter().flat_map(|pre_compiled| {
+                pre_compiled
+                    .naming
+                    .modules
+                    .key_cloned_iter()
+                    .filter(|(mident, _m)| !prog.modules.contains_key(mident))
+            }));
         let modules = UniqueMap::maybe_from_iter(all_modules.map(|(mident, mdef)| {
             let structs = mdef.structs.clone();
             let functions = mdef.functions.ref_map(|fname, fdef| FunctionInfo {

--- a/language/move-compiler/src/typing/expand.rs
+++ b/language/move-compiler/src/typing/expand.rs
@@ -34,7 +34,7 @@ pub fn function_signature(context: &mut Context, sig: &mut FunctionSignature) {
 // Types
 //**************************************************************************************************
 
-fn expected_types(context: &mut Context, ss: &mut Vec<Option<Type>>) {
+fn expected_types(context: &mut Context, ss: &mut [Option<Type>]) {
     for st_opt in ss.iter_mut().flatten() {
         type_(context, st_opt);
     }

--- a/language/move-compiler/src/typing/infinite_instantiations.rs
+++ b/language/move-compiler/src/typing/infinite_instantiations.rs
@@ -300,7 +300,7 @@ fn cycle_error(
     .unwrap();
     assert!(!cycle_nodes.is_empty());
     let next = |i| (i + 1) % cycle_nodes.len();
-    let prev = |i: usize| i.checked_sub(1).unwrap_or_else(|| cycle_nodes.len() - 1);
+    let prev = |i: usize| i.checked_sub(1).unwrap_or(cycle_nodes.len() - 1);
 
     assert!(&cycle_nodes[0] == critical_head);
     let param_info = &context.tparam_type_arguments[cycle_nodes[0]][cycle_nodes[next(0)]];

--- a/language/move-compiler/src/unit_test/filter_test_members.rs
+++ b/language/move-compiler/src/unit_test/filter_test_members.rs
@@ -154,13 +154,12 @@ fn filter_tests_from_definition(
                 .chain(specs.iter().flat_map(|spec| &spec.value.attributes));
 
             let diags: Diagnostics = script_attributes
-                .map(|attr| {
+                .flat_map(|attr| {
                     test_attributes(attr).into_iter().map(|(loc, _)| {
                         let msg = "Testing attributes are not allowed in scripts.";
                         diag!(Attributes::InvalidTest, (loc, msg))
                     })
                 })
-                .flatten()
                 .collect();
 
             if diags.is_empty() {

--- a/language/move-ir-compiler/move-ir-to-bytecode/src/compiler.rs
+++ b/language/move-ir-compiler/move-ir-to-bytecode/src/compiler.rs
@@ -614,7 +614,7 @@ fn struct_type_parameters(ast_tys: &[ast::StructTypeParameter]) -> Vec<StructTyp
 fn abilities(abilities: &BTreeSet<ast::Ability>) -> AbilitySet {
     abilities
         .iter()
-        .map(|a| ability(a))
+        .map(ability)
         .fold(AbilitySet::EMPTY, |acc, a| acc | a)
 }
 

--- a/language/move-ir-compiler/move-ir-to-bytecode/syntax/src/lexer.rs
+++ b/language/move-ir-compiler/move-ir-to-bytecode/syntax/src/lexer.rs
@@ -409,14 +409,14 @@ fn get_name_len(text: &str) -> usize {
     }
     text.chars()
         .position(|c| !matches!(c, 'a'..='z' | 'A'..='Z' | '$' | '_' | '0'..='9'))
-        .unwrap_or_else(|| text.len())
+        .unwrap_or(text.len())
 }
 
 fn get_decimal_number(text: &str) -> (Tok, usize) {
     let len = text
         .chars()
         .position(|c| !matches!(c, '0'..='9'))
-        .unwrap_or_else(|| text.len());
+        .unwrap_or(text.len());
     let rest = &text[len..];
     if rest.starts_with("u8") {
         (Tok::U8Value, len + 2)
@@ -433,7 +433,7 @@ fn get_decimal_number(text: &str) -> (Tok, usize) {
 fn get_hex_digits_len(text: &str) -> usize {
     text.chars()
         .position(|c| !matches!(c, 'a'..='f' | 'A'..='F' | '0'..='9'))
-        .unwrap_or_else(|| text.len())
+        .unwrap_or(text.len())
 }
 
 // Check for an optional sequence of hex digits following by a double quote, and return

--- a/language/move-ir-compiler/move-ir-to-bytecode/syntax/src/syntax.rs
+++ b/language/move-ir-compiler/move-ir-to-bytecode/syntax/src/syntax.rs
@@ -1853,9 +1853,9 @@ fn parse_function_decl(
     let func = Function_::new(
         visibility,
         args,
-        ret.unwrap_or_else(Vec::new),
+        ret.unwrap_or_default(),
         type_parameters,
-        acquires.unwrap_or_else(Vec::new),
+        acquires.unwrap_or_default(),
         specifications,
         if is_native {
             consume_token(tokens, Tok::Semicolon)?;

--- a/language/move-model/src/ast.rs
+++ b/language/move-model/src/ast.rs
@@ -689,7 +689,7 @@ impl ExpData {
         F: FnMut(NodeId) -> Option<NodeId>,
     {
         ExpRewriter {
-            exp_rewriter: &mut |e| Err(e),
+            exp_rewriter: &mut Err,
             node_rewriter,
         }
         .rewrite_exp(exp)

--- a/language/move-model/src/builder/exp_translator.rs
+++ b/language/move-model/src/builder/exp_translator.rs
@@ -39,6 +39,7 @@ pub(crate) struct ExpTranslator<'env, 'translator, 'module_translator> {
     pub local_table: LinkedList<BTreeMap<Symbol, LocalVarEntry>>,
     /// When compiling a condition, the result type of the function the condition is associated
     /// with.
+    #[allow(unused)]
     pub result_type: Option<Type>,
     /// Status for the `old(...)` expression form.
     pub old_status: OldExpStatus,

--- a/language/move-model/src/builder/model_builder.rs
+++ b/language/move-model/src/builder/model_builder.rs
@@ -76,6 +76,7 @@ pub(crate) struct SpecFunEntry {
 pub(crate) struct SpecVarEntry {
     pub loc: Loc,
     pub module_id: ModuleId,
+    #[allow(dead_code)]
     pub var_id: SpecVarId,
     pub type_params: Vec<(Symbol, Type)>,
     pub type_: Type,
@@ -106,6 +107,7 @@ pub(crate) struct StructEntry {
     pub loc: Loc,
     pub module_id: ModuleId,
     pub struct_id: StructId,
+    #[allow(dead_code)]
     pub is_resource: bool,
     pub type_params: Vec<(Symbol, Type)>,
     pub fields: Option<BTreeMap<Symbol, (usize, Type)>>,
@@ -118,6 +120,7 @@ pub(crate) struct StructEntry {
 pub(crate) struct FunEntry {
     pub loc: Loc,
     pub module_id: ModuleId,
+    #[allow(dead_code)]
     pub fun_id: FunId,
     pub visibility: FunctionVisibility,
     pub type_params: Vec<(Symbol, Type)>,

--- a/language/move-model/src/builder/module_builder.rs
+++ b/language/move-model/src/builder/module_builder.rs
@@ -1386,7 +1386,7 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
         if !et.parent.spec_block_lets.is_empty() {
             // Put them into a new scope, they can shadow outer names.
             et.enter_scope();
-            for (name, (post_state, node_id)) in et.parent.spec_block_lets.to_owned() {
+            for (name, (post_state, node_id)) in et.parent.spec_block_lets.clone() {
                 // If allow_old is true, we are looking at a condition in a post state like ensures.
                 // In this case all lets are available. If allow_old is false, only !post_state
                 // lets are available.

--- a/language/move-model/src/model.rs
+++ b/language/move-model/src/model.rs
@@ -2862,6 +2862,7 @@ pub struct FunctionData {
     arg_names: Vec<Symbol>,
 
     /// List of type argument names. Not in bytecode but obtained from AST.
+    #[allow(unused)]
     type_arg_names: Vec<Symbol>,
 
     /// Specification associated with this function.

--- a/language/move-prover/boogie-backend/src/spec_translator.rs
+++ b/language/move-prover/boogie-backend/src/spec_translator.rs
@@ -155,7 +155,8 @@ impl<'env> SpecTranslator<'env> {
                 .spec_vars
                 .get(&module_env.get_id().qualified(*id))
                 .unwrap_or(empty)
-                .to_owned()
+                .iter()
+                .cloned()
             {
                 let name = boogie_spec_var_name(
                     module_env,
@@ -206,7 +207,8 @@ impl<'env> SpecTranslator<'env> {
                 .spec_funs
                 .get(&module_env.get_id().qualified(*id))
                 .unwrap_or(empty)
-                .to_owned()
+                .iter()
+                .cloned()
             {
                 let name = boogie_spec_fun_name(module_env, *id, &type_inst);
                 if !translated.insert(name) {

--- a/language/move-prover/bytecode/src/verification_analysis.rs
+++ b/language/move-prover/bytecode/src/verification_analysis.rs
@@ -470,7 +470,7 @@ impl VerificationAnalysisProcessor {
             .collect();
         let mut done = BTreeSet::new();
         let mut result = vec![];
-        while let Some(caller_list) = worklist.iter().cloned().next() {
+        while let Some(caller_list) = worklist.iter().next().cloned() {
             worklist.remove(&caller_list);
             let caller_id = *caller_list.iter().last().unwrap();
             done.insert(caller_id);

--- a/language/move-prover/bytecode/src/verification_analysis_v2.rs
+++ b/language/move-prover/bytecode/src/verification_analysis_v2.rs
@@ -213,7 +213,7 @@ fn compute_non_inv_cause_chain(fun_env: &FunctionEnv<'_>) -> Vec<String> {
         .collect();
     let mut done = BTreeSet::new();
     let mut result = vec![];
-    while let Some(caller_list) = worklist.iter().cloned().next() {
+    while let Some(caller_list) = worklist.iter().next().cloned() {
         worklist.remove(&caller_list);
         let caller_id = *caller_list.iter().last().unwrap();
         done.insert(caller_id);

--- a/language/move-prover/bytecode/src/well_formed_instrumentation.rs
+++ b/language/move-prover/bytecode/src/well_formed_instrumentation.rs
@@ -64,7 +64,7 @@ impl FunctionTargetProcessor for WellFormedInstrumentationProcessor {
         }
 
         // Inject well-formedness assumption for used memory.
-        for mem in usage.accessed.all.clone() {
+        for mem in usage.accessed.all {
             let struct_env = builder.global_env().get_struct_qid(mem.to_qualified_id());
             if struct_env.is_native_or_intrinsic() {
                 // If this is native or intrinsic memory, skip this.

--- a/language/move-prover/move-docgen/src/docgen.rs
+++ b/language/move-prover/move-docgen/src/docgen.rs
@@ -706,7 +706,7 @@ impl<'env> Docgen<'env> {
             .join(format!(
                 "{}_{}_call_graph.svg",
                 fun_env.get_name_string().to_string().replace("::", "_"),
-                (if is_forward { "forward" } else { "backward" }).to_string()
+                (if is_forward { "forward" } else { "backward" })
             ));
 
         self.gen_svg_file(&out_file_path, &dot_src_lines.join("\n"));
@@ -754,7 +754,7 @@ impl<'env> Docgen<'env> {
             .join(format!(
                 "{}_{}_dep.svg",
                 module_name,
-                (if is_forward { "forward" } else { "backward" }).to_string()
+                (if is_forward { "forward" } else { "backward" })
             ));
 
         self.gen_svg_file(&out_file_path, &dot_src_lines.join("\n"));

--- a/language/move-prover/tools/spec-flatten/src/ast_print.rs
+++ b/language/move-prover/tools/spec-flatten/src/ast_print.rs
@@ -524,11 +524,7 @@ impl SpecPrinter<'_> {
         I: IntoIterator<Item = E>,
         F: Fn(E) -> Doc,
     {
-        Self::wrap(
-            "(",
-            Self::sep_comma_space(items.into_iter().map(|t| func(t))),
-            ")",
-        )
+        Self::wrap("(", Self::sep_comma_space(items.into_iter().map(func)), ")")
     }
 
     fn mk_inst<E, I, F>(base: Doc, items: I, func: F) -> Doc
@@ -538,11 +534,7 @@ impl SpecPrinter<'_> {
     {
         Self::concat([
             base,
-            Self::wrap(
-                "<",
-                Self::sep_comma_space(items.into_iter().map(|t| func(t))),
-                ">",
-            ),
+            Self::wrap("<", Self::sep_comma_space(items.into_iter().map(func)), ">"),
         ])
     }
 

--- a/language/move-symbol-pool/tests/symbol.rs
+++ b/language/move-symbol-pool/tests/symbol.rs
@@ -6,7 +6,7 @@ use move_symbol_pool::Symbol;
 #[test]
 #[allow(unused_must_use)]
 fn test_from() {
-    Symbol::from("this shouldn't panic");
+    let _ = Symbol::from("this shouldn't panic");
 }
 
 #[test]

--- a/language/move-vm/integration-tests/src/tests/bad_entry_point_tests.rs
+++ b/language/move-vm/integration-tests/src/tests/bad_entry_point_tests.rs
@@ -43,7 +43,7 @@ fn call_non_existent_function() {
     let code = r#"
         module {{ADDR}}::M {}
     "#;
-    let code = code.replace("{{ADDR}}", &format!("0x{}", TEST_ADDR.to_string()));
+    let code = code.replace("{{ADDR}}", &format!("0x{}", TEST_ADDR));
 
     let mut units = compile_units(&code).unwrap();
     let m = as_module(units.pop().unwrap());

--- a/language/move-vm/integration-tests/src/tests/bad_storage_tests.rs
+++ b/language/move-vm/integration-tests/src/tests/bad_storage_tests.rs
@@ -64,7 +64,7 @@ fn test_malformed_resource() {
             }
         }
     "#;
-    let code = code.replace("{{ADDR}}", &format!("0x{}", TEST_ADDR.to_string()));
+    let code = code.replace("{{ADDR}}", &format!("0x{}", TEST_ADDR));
     let mut units = compile_units(&code).unwrap();
 
     let s2 = as_script(units.pop().unwrap());
@@ -160,7 +160,7 @@ fn test_malformed_module() {
         }
     "#;
 
-    let code = code.replace("{{ADDR}}", &format!("0x{}", TEST_ADDR.to_string()));
+    let code = code.replace("{{ADDR}}", &format!("0x{}", TEST_ADDR));
     let mut units = compile_units(&code).unwrap();
 
     let m = as_module(units.pop().unwrap());
@@ -226,7 +226,7 @@ fn test_unverifiable_module() {
         }
     "#;
 
-    let code = code.replace("{{ADDR}}", &format!("0x{}", TEST_ADDR.to_string()));
+    let code = code.replace("{{ADDR}}", &format!("0x{}", TEST_ADDR));
     let mut units = compile_units(&code).unwrap();
     let m = as_module(units.pop().unwrap());
 
@@ -297,7 +297,7 @@ fn test_missing_module_dependency() {
             public fun bar() { M::foo(); }
         }
     "#;
-    let code = code.replace("{{ADDR}}", &format!("0x{}", TEST_ADDR.to_string()));
+    let code = code.replace("{{ADDR}}", &format!("0x{}", TEST_ADDR));
     let mut units = compile_units(&code).unwrap();
     let n = as_module(units.pop().unwrap());
     let m = as_module(units.pop().unwrap());
@@ -369,7 +369,7 @@ fn test_malformed_module_denpency() {
             public fun bar() { M::foo(); }
         }
     "#;
-    let code = code.replace("{{ADDR}}", &format!("0x{}", TEST_ADDR.to_string()));
+    let code = code.replace("{{ADDR}}", &format!("0x{}", TEST_ADDR));
     let mut units = compile_units(&code).unwrap();
     let n = as_module(units.pop().unwrap());
     let m = as_module(units.pop().unwrap());
@@ -447,7 +447,7 @@ fn test_unverifiable_module_dependency() {
             public fun bar() { M::foo(); }
         }
     "#;
-    let code = code.replace("{{ADDR}}", &format!("0x{}", TEST_ADDR.to_string()));
+    let code = code.replace("{{ADDR}}", &format!("0x{}", TEST_ADDR));
     let mut units = compile_units(&code).unwrap();
     let n = as_module(units.pop().unwrap());
     let m = as_module(units.pop().unwrap());
@@ -600,7 +600,7 @@ fn test_storage_returns_bogus_error_when_loading_resource() {
             }
         }
     "#;
-    let code = code.replace("{{ADDR}}", &format!("0x{}", TEST_ADDR.to_string()));
+    let code = code.replace("{{ADDR}}", &format!("0x{}", TEST_ADDR));
 
     let mut units = compile_units(&code).unwrap();
     let m = as_module(units.pop().unwrap());

--- a/language/move-vm/integration-tests/src/tests/mutated_accounts_tests.rs
+++ b/language/move-vm/integration-tests/src/tests/mutated_accounts_tests.rs
@@ -32,7 +32,7 @@ fn mutated_accounts() {
         }
     "#;
 
-    let code = code.replace("{{ADDR}}", &format!("0x{}", TEST_ADDR.to_string()));
+    let code = code.replace("{{ADDR}}", &format!("0x{}", TEST_ADDR));
     let mut units = compile_units(&code).unwrap();
     let m = as_module(units.pop().unwrap());
     let mut blob = vec![];

--- a/language/move-vm/runtime/Cargo.toml
+++ b/language/move-vm/runtime/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+better_any = "0.1.1"
 fail = "0.4.0"
 mirai-annotations = "1.10.1"
 once_cell = "1.7.2"

--- a/language/move-vm/runtime/src/interpreter.rs
+++ b/language/move-vm/runtime/src/interpreter.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     loader::{Function, Loader, Resolver},
-    native_functions::{NativeContext, NativeContextExtensions},
+    native_functions::NativeContext,
     trace,
 };
 use fail::fail_point;
@@ -27,6 +27,7 @@ use move_vm_types::{
     },
 };
 
+use crate::native_extensions::NativeContextExtensions;
 use std::{cmp::min, collections::VecDeque, fmt::Write, mem, sync::Arc};
 use tracing::error;
 

--- a/language/move-vm/runtime/src/lib.rs
+++ b/language/move-vm/runtime/src/lib.rs
@@ -17,6 +17,7 @@ mod interpreter;
 mod loader;
 pub mod logging;
 pub mod move_vm;
+pub mod native_extensions;
 pub mod native_functions;
 mod runtime;
 pub mod session;

--- a/language/move-vm/runtime/src/loader.rs
+++ b/language/move-vm/runtime/src/loader.rs
@@ -144,7 +144,7 @@ impl ModuleCache {
     // Retrieve a module by `ModuleId`. The module may have not been loaded yet in which
     // case `None` is returned
     fn module_at(&self, id: &ModuleId) -> Option<Arc<Module>> {
-        self.modules.get(id).map(|module| Arc::clone(module))
+        self.modules.get(id).map(Arc::clone)
     }
 
     // Retrieve a function by index
@@ -1342,8 +1342,9 @@ impl<'a> Resolver<'a> {
 // When code executes indexes in instructions are resolved against those runtime structure
 // so that any data needed for execution is immediately available
 #[derive(Debug)]
-#[allow(dead_code)]
+
 pub(crate) struct Module {
+    #[allow(dead_code)]
     id: ModuleId,
     // primitive pools
     module: Arc<CompiledModule>,
@@ -1356,6 +1357,7 @@ pub(crate) struct Module {
     // That is effectively an indirection over the ref table:
     // the instruction carries an index into this table which contains the index into the
     // glabal table of types. No instantiation of generic types is saved into the global table.
+    #[allow(dead_code)]
     struct_refs: Vec<CachedStructIndex>,
     structs: Vec<StructDef>,
     // materialized instantiations, whether partial or not
@@ -2015,6 +2017,7 @@ struct FieldHandle {
 struct FieldInstantiation {
     offset: usize,
     // `ModuelCache::structs` global table index. It is the generic type.
+    #[allow(unused)]
     owner: CachedStructIndex,
 }
 

--- a/language/move-vm/runtime/src/move_vm.rs
+++ b/language/move-vm/runtime/src/move_vm.rs
@@ -4,10 +4,8 @@
 use std::sync::Arc;
 
 use crate::{
-    data_cache::TransactionDataCache,
-    native_functions::{NativeContextExtensions, NativeFunction},
-    runtime::VMRuntime,
-    session::Session,
+    data_cache::TransactionDataCache, native_extensions::NativeContextExtensions,
+    native_functions::NativeFunction, runtime::VMRuntime, session::Session,
 };
 use move_binary_format::{
     errors::{Location, VMResult},
@@ -53,7 +51,7 @@ impl MoveVM {
     pub fn new_session_with_extensions<'r, S: MoveResolver>(
         &self,
         remote: &'r S,
-        extensions: NativeContextExtensions,
+        extensions: NativeContextExtensions<'r>,
     ) -> Session<'r, '_, S> {
         self.runtime.new_session_with_extensions(remote, extensions)
     }

--- a/language/move-vm/runtime/src/native_extensions.rs
+++ b/language/move-vm/runtime/src/native_extensions.rs
@@ -1,0 +1,82 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use better_any::{Tid, TidAble, TidExt};
+use std::{any::TypeId, collections::HashMap};
+
+/// A data type to represent a heterogeneous collection of extensions which are available to
+/// native functions. A value to this is passed into the session function execution.
+///
+/// The implementation uses the crate `better_any` which implements a version of the `Any`
+/// type, called `Tid<`a>`, which allows for up to one lifetime parameter. This
+/// avoids that extensions need to have `'static` lifetime, which `Any` requires. In order to make a
+/// struct suitable to be a 'Tid', use `#[derive(Tid)]` in the struct declaration. (See also
+/// tests at the end of this module.)
+#[derive(Default)]
+pub struct NativeContextExtensions<'a> {
+    map: HashMap<TypeId, Box<dyn Tid<'a>>>,
+}
+
+impl<'a> NativeContextExtensions<'a> {
+    pub fn add<T: TidAble<'a>>(&mut self, ext: T) {
+        assert!(
+            self.map.insert(T::id(), Box::new(ext)).is_none(),
+            "multiple extensions of the same type not allowed"
+        )
+    }
+
+    pub fn get<T: TidAble<'a>>(&self) -> &T {
+        self.map
+            .get(&T::id())
+            .expect("extension unknown")
+            .as_ref()
+            .downcast_ref::<T>()
+            .unwrap()
+    }
+
+    pub fn get_mut<T: TidAble<'a>>(&mut self) -> &mut T {
+        self.map
+            .get_mut(&T::id())
+            .expect("extension unknown")
+            .as_mut()
+            .downcast_mut::<T>()
+            .unwrap()
+    }
+
+    pub fn remove<T: TidAble<'a>>(&mut self) -> T {
+        // can't use expect below because it requires `T: Debug`.
+        match self
+            .map
+            .remove(&T::id())
+            .expect("extension unknown")
+            .downcast_box::<T>()
+        {
+            Ok(val) => *val,
+            Err(_) => panic!("downcast error"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::native_extensions::NativeContextExtensions;
+    use better_any::{Tid, TidAble};
+
+    #[derive(Tid)]
+    struct Ext<'a> {
+        a: &'a mut u64,
+    }
+
+    #[test]
+    fn non_static_ext() {
+        let mut v: u64 = 23;
+        let e = Ext { a: &mut v };
+        let mut exts = NativeContextExtensions::default();
+        exts.add(e);
+        *exts.get_mut::<Ext>().a += 1;
+        assert_eq!(*exts.get_mut::<Ext>().a, 24);
+        *exts.get_mut::<Ext>().a += 1;
+        let e1 = exts.remove::<Ext>();
+        assert_eq!(*e1.a, 25)
+    }
+}

--- a/language/move-vm/runtime/src/runtime.rs
+++ b/language/move-vm/runtime/src/runtime.rs
@@ -5,7 +5,8 @@ use crate::{
     data_cache::TransactionDataCache,
     interpreter::Interpreter,
     loader::{Function, Loader},
-    native_functions::{NativeContextExtensions, NativeFunction, NativeFunctions},
+    native_extensions::NativeContextExtensions,
+    native_functions::{NativeFunction, NativeFunctions},
     session::{LoadedFunctionInstantiation, SerializedReturnValues, Session},
 };
 use move_binary_format::{
@@ -58,7 +59,7 @@ impl VMRuntime {
     pub fn new_session_with_extensions<'r, S: MoveResolver>(
         &self,
         remote: &'r S,
-        native_extensions: NativeContextExtensions,
+        native_extensions: NativeContextExtensions<'r>,
     ) -> Session<'r, '_, S> {
         Session {
             runtime: self,

--- a/language/move-vm/runtime/src/session.rs
+++ b/language/move-vm/runtime/src/session.rs
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    data_cache::TransactionDataCache, native_functions::NativeContextExtensions, runtime::VMRuntime,
+    data_cache::TransactionDataCache, native_extensions::NativeContextExtensions,
+    runtime::VMRuntime,
 };
 use move_binary_format::{errors::*, file_format::LocalIndex};
 use move_core_types::{
@@ -23,7 +24,7 @@ use std::{borrow::Borrow, sync::Arc};
 pub struct Session<'r, 'l, S> {
     pub(crate) runtime: &'l VMRuntime,
     pub(crate) data_cache: TransactionDataCache<'r, 'l, S>,
-    pub(crate) native_extensions: NativeContextExtensions,
+    pub(crate) native_extensions: NativeContextExtensions<'r>,
 }
 
 /// Serialized return values from function/script execution
@@ -201,7 +202,7 @@ impl<'r, 'l, S: MoveResolver> Session<'r, 'l, S> {
     /// Same like `finish`, but also extracts the native context extensions from the session.
     pub fn finish_with_extensions(
         self,
-    ) -> VMResult<(ChangeSet, Vec<Event>, NativeContextExtensions)> {
+    ) -> VMResult<(ChangeSet, Vec<Event>, NativeContextExtensions<'r>)> {
         let Session {
             data_cache,
             native_extensions,

--- a/language/move-vm/runtime/src/unit_tests/vm_arguments_tests.rs
+++ b/language/move-vm/runtime/src/unit_tests/vm_arguments_tests.rs
@@ -772,9 +772,9 @@ fn call_missing_item() {
     let function_name = IdentStr::new("foo").unwrap();
     // mising module
     let move_vm = MoveVM::new(vec![]).unwrap();
+    let mut gas_status = GasStatus::new_unmetered();
     let mut remote_view = RemoteStore::new();
     let mut session = move_vm.new_session(&remote_view);
-    let mut gas_status = GasStatus::new_unmetered();
     let error = session
         .execute_function_bypass_visibility(
             id,
@@ -787,6 +787,7 @@ fn call_missing_item() {
         .unwrap();
     assert_eq!(error.major_status(), StatusCode::LINKER_ERROR);
     assert_eq!(error.status_type(), StatusType::Verification);
+    drop(session);
 
     // missing function
     remote_view.add_module(module);

--- a/language/testing-infra/module-generation/src/generator.rs
+++ b/language/testing-infra/module-generation/src/generator.rs
@@ -91,7 +91,7 @@ impl<'a> ModuleGenerator<'a> {
 
     fn identifier(&mut self) -> String {
         let len = self.gen.gen_range(10..self.options.max_string_size);
-        random_string(&mut self.gen, len)
+        random_string(self.gen, len)
     }
 
     fn base_type(&mut self, ty_param_context: &[&TypeVar]) -> Type {

--- a/language/testing-infra/test-generation/src/abstract_state.rs
+++ b/language/testing-infra/test-generation/src/abstract_state.rs
@@ -444,6 +444,7 @@ pub struct AbstractState {
 
     /// This graph stores borrow information needed to ensure that bytecode instructions
     /// are memory safe
+    #[allow(dead_code)]
     borrow_graph: BorrowGraph,
 
     pub call_graph: CallGraph,

--- a/language/testing-infra/test-generation/src/bytecode_generator.rs
+++ b/language/testing-infra/test-generation/src/bytecode_generator.rs
@@ -410,7 +410,7 @@ impl<'a> BytecodeGenerator<'a> {
                                 callable_fns[handle_idx as usize],
                             )
                         })
-                        .map(|handle| instruction(handle))
+                        .map(instruction)
                 }
                 BytecodeType::StructInstantiationIndex(instruction) => {
                     // Select a field definition from the module's field definitions

--- a/language/tools/mirai-dataflow-analysis/tests/datalog_tests.rs
+++ b/language/tools/mirai-dataflow-analysis/tests/datalog_tests.rs
@@ -115,7 +115,7 @@ fn execute_test(file_name: &str) -> usize {
 #[ignore]
 fn run_tests() {
     let test_path = PathBuf::from_str("./tests/ddlog_tests/").unwrap();
-    println!("{:?}", std::fs::canonicalize(test_path.to_owned()));
+    println!("{:?}", std::fs::canonicalize(&test_path));
     let files = gather_tests(test_path);
     let result = files.iter().fold(0, |acc, file| acc + execute_test(file));
     assert_eq!(result, 0);

--- a/language/tools/move-bytecode-viewer/src/source_viewer.rs
+++ b/language/tools/move-bytecode-viewer/src/source_viewer.rs
@@ -21,6 +21,7 @@ pub struct ModuleViewer {
     file_index: usize,
     source_code: Vec<String>,
     source_map: SourceMap,
+    #[allow(unused)]
     module: CompiledModule,
 }
 

--- a/language/tools/move-cli/src/sandbox/utils/on_disk_state_view.rs
+++ b/language/tools/move-cli/src/sandbox/utils/on_disk_state_view.rs
@@ -99,7 +99,7 @@ impl OnDiskStateView {
 
     fn get_addr_path(&self, addr: &AccountAddress) -> PathBuf {
         let mut path = self.storage_dir.clone();
-        path.push(format!("0x{}", addr.to_string()));
+        path.push(format!("0x{}", addr));
         path
     }
 

--- a/language/tools/move-cli/tests/build_testsuite.rs
+++ b/language/tools/move-cli/tests/build_testsuite.rs
@@ -5,16 +5,12 @@ use move_cli::sandbox::commands::test;
 
 use std::path::{Path, PathBuf};
 
-#[cfg(debug_assertions)]
-const CLI_EXE: &str = "../../../target/debug/move";
-#[cfg(not(debug_assertions))]
-const CLI_EXE: &str = "../../../target/release/move";
-
 fn run_all(args_path: &Path) -> datatest_stable::Result<()> {
+    let cli_exe = env!("CARGO_BIN_EXE_move");
     let use_temp_dir = !args_path.parent().unwrap().join("NO_TEMPDIR").exists();
     test::run_one(
         args_path,
-        &PathBuf::from(CLI_EXE),
+        &PathBuf::from(cli_exe),
         /* use_temp_dir */ use_temp_dir,
         /* track_cov */ false,
     )?;

--- a/language/tools/move-cli/tests/build_testsuite_evm.rs
+++ b/language/tools/move-cli/tests/build_testsuite_evm.rs
@@ -5,16 +5,12 @@ use move_cli::sandbox::commands::test;
 
 use std::path::{Path, PathBuf};
 
-#[cfg(debug_assertions)]
-const CLI_EXE: &str = "../../../target/debug/move";
-#[cfg(not(debug_assertions))]
-const CLI_EXE: &str = "../../../target/release/move";
-
 fn run_all(args_path: &Path) -> datatest_stable::Result<()> {
+    let cli_exe = env!("CARGO_BIN_EXE_move");
     let use_temp_dir = !args_path.parent().unwrap().join("NO_TEMPDIR").exists();
     test::run_one(
         args_path,
-        &PathBuf::from(CLI_EXE),
+        &PathBuf::from(cli_exe),
         /* use_temp_dir */ use_temp_dir,
         /* track_cov */ false,
     )?;

--- a/language/tools/move-cli/tests/cli_tests.rs
+++ b/language/tools/move-cli/tests/cli_tests.rs
@@ -7,13 +7,9 @@ use std::path::PathBuf;
 
 pub const CLI_METATEST_PATH: [&str; 3] = ["tests", "metatests", "args.txt"];
 
-#[cfg(debug_assertions)]
-pub const CLI_BINARY_PATH: [&str; 6] = ["..", "..", "..", "target", "debug", "move"];
-#[cfg(not(debug_assertions))]
-pub const CLI_BINARY_PATH: [&str; 6] = ["..", "..", "..", "target", "release", "move"];
-
 fn get_cli_binary_path() -> PathBuf {
-    CLI_BINARY_PATH.iter().collect()
+    let cli_exe = env!("CARGO_BIN_EXE_move");
+    PathBuf::from(cli_exe)
 }
 
 fn get_metatest_path() -> PathBuf {
@@ -40,18 +36,16 @@ fn run_metatest() {
 
 #[test]
 fn cross_process_locking_git_deps() {
-    #[cfg(debug_assertions)]
-    const CLI_EXE: &str = "../../../../../../target/debug/move";
-    #[cfg(not(debug_assertions))]
-    const CLI_EXE: &str = "../../../../../../target/release/move";
-    let handle = std::thread::spawn(|| {
-        std::process::Command::new(CLI_EXE)
+    let cli_exe = env!("CARGO_BIN_EXE_move");
+    let handle = std::thread::spawn(move || {
+        std::process::Command::new(cli_exe)
             .current_dir("./tests/cross_process_tests/Package1")
             .args(["package", "build"])
             .output()
             .expect("Package1 failed");
     });
-    std::process::Command::new(CLI_EXE)
+    let cli_exe = env!("CARGO_BIN_EXE_move").to_string();
+    std::process::Command::new(cli_exe)
         .current_dir("./tests/cross_process_tests/Package2")
         .args(["package", "build"])
         .output()

--- a/language/tools/move-cli/tests/move_unit_tests_evm.rs
+++ b/language/tools/move-cli/tests/move_unit_tests_evm.rs
@@ -5,16 +5,12 @@ use move_cli::sandbox::commands::test;
 
 use std::path::{Path, PathBuf};
 
-#[cfg(debug_assertions)]
-const CLI_EXE: &str = "../../../target/debug/move";
-#[cfg(not(debug_assertions))]
-const CLI_EXE: &str = "../../../target/release/move";
-
 fn run_all(args_path: &Path) -> datatest_stable::Result<()> {
+    let cli_exe = env!("CARGO_BIN_EXE_move");
     let use_temp_dir = !args_path.parent().unwrap().join("NO_TEMPDIR").exists();
     test::run_one(
         args_path,
-        &PathBuf::from(CLI_EXE),
+        &PathBuf::from(cli_exe),
         /* use_temp_dir */ use_temp_dir,
         /* track_cov */ false,
     )?;

--- a/language/tools/move-cli/tests/move_unit_tests_move_vm_and_stackless_vm.rs
+++ b/language/tools/move-cli/tests/move_unit_tests_move_vm_and_stackless_vm.rs
@@ -5,16 +5,12 @@ use move_cli::sandbox::commands::test;
 
 use std::path::{Path, PathBuf};
 
-#[cfg(debug_assertions)]
-const CLI_EXE: &str = "../../../target/debug/move";
-#[cfg(not(debug_assertions))]
-const CLI_EXE: &str = "../../../target/release/move";
-
 fn run_all(args_path: &Path) -> datatest_stable::Result<()> {
+    let cli_exe = env!("CARGO_BIN_EXE_move");
     let use_temp_dir = !args_path.parent().unwrap().join("NO_TEMPDIR").exists();
     test::run_one(
         args_path,
-        &PathBuf::from(CLI_EXE),
+        &PathBuf::from(cli_exe),
         /* use_temp_dir */ use_temp_dir,
         /* track_cov */ false,
     )?;

--- a/language/tools/move-cli/tests/sandbox_testsuite.rs
+++ b/language/tools/move-cli/tests/sandbox_testsuite.rs
@@ -5,16 +5,12 @@ use move_cli::sandbox::commands::test;
 
 use std::path::{Path, PathBuf};
 
-#[cfg(debug_assertions)]
-const CLI_EXE: &str = "../../../target/debug/move";
-#[cfg(not(debug_assertions))]
-const CLI_EXE: &str = "../../../target/release/move";
-
 fn run_all(args_path: &Path) -> datatest_stable::Result<()> {
+    let cli_exe = env!("CARGO_BIN_EXE_move");
     let use_temp_dir = !args_path.parent().unwrap().join("NO_TEMPDIR").exists();
     test::run_one(
         args_path,
-        &PathBuf::from(CLI_EXE),
+        &PathBuf::from(cli_exe),
         /* use_temp_dir */ use_temp_dir,
         /* track_cov */ false,
     )?;

--- a/language/tools/move-coverage/src/coverage_map.rs
+++ b/language/tools/move-coverage/src/coverage_map.rs
@@ -231,12 +231,11 @@ impl ExecCoverageMap {
 
         let compiled_modules = modules
             .into_iter()
-            .map(|(_, module_map)| {
+            .flat_map(|(_, module_map)| {
                 module_map
                     .into_iter()
                     .map(|(_, (module_path, compiled_module))| (module_path, compiled_module))
             })
-            .flatten()
             .collect();
 
         ExecCoverageMapWithModules {

--- a/language/tools/move-coverage/src/source_coverage.rs
+++ b/language/tools/move-coverage/src/source_coverage.rs
@@ -70,7 +70,7 @@ impl<'a> SourceCoverageBuilder<'a> {
             .function_defs()
             .iter()
             .enumerate()
-            .map(|(function_def_idx, function_def)| {
+            .flat_map(|(function_def_idx, function_def)| {
                 let fn_handle = module.function_handle_at(function_def.function);
                 let fn_name = module.identifier_at(fn_handle.name).to_owned();
                 let function_def_idx = FunctionDefinitionIndex(function_def_idx as u16);
@@ -123,7 +123,6 @@ impl<'a> SourceCoverageBuilder<'a> {
                 };
                 coverage.map(|x| (fn_name, x))
             })
-            .flatten()
             .collect();
 
         Self {

--- a/language/tools/move-disassembler/src/disassembler.rs
+++ b/language/tools/move-disassembler/src/disassembler.rs
@@ -911,7 +911,7 @@ impl<'a> Disassembler<'a> {
             .map(|(local_idx, (name, _))| {
                 let ty =
                     self.type_for_local(parameter_len + local_idx, signature, function_source_map)?;
-                Ok(format!("{}: {}", name.to_string(), ty))
+                Ok(format!("{}: {}", name, ty))
             })
             .collect::<Result<Vec<String>>>()?;
         Ok(locals_names_tys)
@@ -1076,7 +1076,7 @@ impl<'a> Disassembler<'a> {
                 .map(|(name, ty)| {
                     let ty_str =
                         self.disassemble_sig_tok(ty.0.clone(), &struct_source_map.type_parameters)?;
-                    Ok(format!("{}: {}", name.to_string(), ty_str))
+                    Ok(format!("{}: {}", name, ty_str))
                 })
                 .collect::<Result<Vec<String>>>()?,
         };
@@ -1101,8 +1101,7 @@ impl<'a> Disassembler<'a> {
 
     pub fn disassemble(&self) -> Result<String> {
         let name_opt = self.source_mapper.source_map.module_name_opt.as_ref();
-        let name =
-            name_opt.map(|(addr, n)| format!("{}.{}", addr.short_str_lossless(), n.to_string()));
+        let name = name_opt.map(|(addr, n)| format!("{}.{}", addr.short_str_lossless(), n));
         let version = format!("{}", self.source_mapper.bytecode.version());
         let header = match name {
             Some(s) => format!("module {}", s),

--- a/language/tools/move-unit-test/src/extensions.rs
+++ b/language/tools/move-unit-test/src/extensions.rs
@@ -5,7 +5,7 @@
 //! Such extensions are enabled by cfg features and must be compiled into the test
 //! to be usable.
 
-use move_vm_runtime::native_functions::NativeContextExtensions;
+use move_vm_runtime::native_extensions::NativeContextExtensions;
 use std::fmt::Write;
 
 #[cfg(feature = "table-extension")]
@@ -19,7 +19,7 @@ use once_cell::sync::Lazy;
 
 /// Create all available native context extensions.
 #[allow(unused_mut, clippy::let_and_return)]
-pub(crate) fn new_extensions() -> NativeContextExtensions {
+pub(crate) fn new_extensions<'a>() -> NativeContextExtensions<'a> {
     let mut e = NativeContextExtensions::default();
     #[cfg(feature = "table-extension")]
     create_table_extension(&mut e);

--- a/language/tools/move-unit-test/src/test_runner.rs
+++ b/language/tools/move-unit-test/src/test_runner.rs
@@ -38,7 +38,7 @@ use move_vm_types::gas_schedule::{zero_cost_schedule, GasStatus};
 use rayon::prelude::*;
 use std::{collections::BTreeMap, io::Write, marker::Send, sync::Mutex, time::Instant};
 
-use move_vm_runtime::native_functions::NativeContextExtensions;
+use move_vm_runtime::native_extensions::NativeContextExtensions;
 #[cfg(feature = "evm-backend")]
 use {
     evm::{backend::MemoryVicinity, ExitReason},

--- a/language/tools/read-write-set/src/lib.rs
+++ b/language/tools/read-write-set/src/lib.rs
@@ -72,7 +72,7 @@ impl ReadWriteSetAnalysis {
     /// Returns `None` if this function does not exist
     pub fn get_function_env(&self, module: &ModuleId, fun: &IdentStr) -> Option<FunctionEnv> {
         self.env
-            .find_function_by_language_storage_id_name(module, &fun.to_owned())
+            .find_function_by_language_storage_id_name(module, fun)
     }
 
     /// Normalize the analysis result computed from the move-prover pipeline.


### PR DESCRIPTION
## Motivation
Allow extensions to contain non-static references

This uses the Tid<'a> type from the [better_any](https://docs.rs/better_any/latest/better_any/) crate which acts as a replacement for the standard Any type in order to implement NativeContextExtensions. This allows the polymorphic values stored in the extensions to be non-'static, which Any does not.

As a consequence, it is now NativeContextExtensions<'a>, where 'a is placeholder for the lifetime of any references stored in some extensions. Only one lifetime parameter is allowed for such extensions because of restrictions of better_any.

A user of extensions should not see any of this, however, structures describing extensions must use #[derive(Tid)], and any type parameters those have must do as well. This is so the crate can compute a TypeId for such types.

The NativeContextExtensions<'a> type has been moved in its own module, and a test has been added to verify that this new feature works.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Modified  tests under integration,unit testsuite
