### PR TITLE
Input and output with a 0x for hex output (#7)_6

### DIFF
--- a/language/tools/move-package/tests/test_sources/parsing/invalid_non_hex_address/Move.exp
+++ b/language/tools/move-package/tests/test_sources/parsing/invalid_non_hex_address/Move.exp
@@ -1,0 +1,1 @@
+Error parsing '[addresses]' section of manifest: Invalid address: Unable to parse AccountAddress

--- a/language/tools/move-package/tests/test_sources/parsing/invalid_non_hex_address/Move.toml
+++ b/language/tools/move-package/tests/test_sources/parsing/invalid_non_hex_address/Move.toml
@@ -1,0 +1,6 @@
+[package]
+name = "name"
+version = "0.1.2"
+
+[addresses]
+A = "1234"


### PR DESCRIPTION
### Motivation
Accepts 0x as an input, and will print the output as a 0x for AccountAddress. This removes confusion on whether it's in a different encoding, and keeps it simple.
### Testplan
Unit test cases are added to cover code changes in this PR. refer: ```language/move-core/types/src/account_address.rs```
