### PR TITLE
[table] adjustments #8_7

### DIFF
--- a/language/extensions/move-table-extension/sources/Table.move
+++ b/language/extensions/move-table-extension/sources/Table.move
@@ -2,7 +2,11 @@
 module Extensions::Table {
     use Std::Errors;
 
-    const ENOT_EMPTY: u64 = 0;
+    // native code raises this with  Errors::invalid_arguments()
+    const EALREADY_EXISTS: u64 = 100;
+    // native code raises this with Errors::invalid_arguments()
+    const ENOT_FOUND: u64 = 101;
+    const ENOT_EMPTY: u64 = 102;
 
     /// Type of tables
     struct Table<phantom K, phantom V> has store {

--- a/language/extensions/move-table-extension/tests/TableTests.move
+++ b/language/extensions/move-table-extension/tests/TableTests.move
@@ -41,7 +41,7 @@ module Extensions::TableTests {
     }
 
     #[test]
-    #[expected_failure(abort_code = 51155)]
+    #[expected_failure(abort_code = 1)]
     fun test_destroy_fails() {
         let t = T::new<u64, u64>();
         T::add(&mut t, &1, 2);

--- a/language/extensions/move-table-extension/tests/TableTests.move
+++ b/language/extensions/move-table-extension/tests/TableTests.move
@@ -213,5 +213,45 @@ module Extensions::TableTests {
         move_to(&s, S { t });
     }
 
+    #[test]
+    fun test_add_after_remove() {
+        let t = T::new<u64, u64>();
+        T::add(&mut t, &42, 42);
+        let forty_two = T::remove(&mut t, &42);
+        assert!(forty_two == 42, 101);
 
+        T::add(&mut t, &42, 0);
+        let zero = T::borrow(&mut t, &42);
+        assert!(*zero == 0, 102);
+
+        T::drop_unchecked(t)
+    }
+
+    #[test]
+    #[expected_failure(abort_code = 25524)]
+    fun test_remove_removed() {
+        let t = T::new<u64, u64>();
+        T::add(&mut t, &42, 42);
+        let forty_two = T::remove(&mut t, &42);
+        assert!(forty_two == 42, 101);
+
+        // remove removed value
+        let _r = T::remove(&mut t, &42);
+
+        T::drop_unchecked(t)
+    }
+
+    #[test]
+    #[expected_failure(abort_code = 25524)]
+    fun test_borrow_removed() {
+        let t = T::new<u64, u64>();
+        T::add(&mut t, &42, 42);
+        let forty_two = T::remove(&mut t, &42);
+        assert!(forty_two == 42, 101);
+
+        // borrow removed value
+        let _r = T::borrow(&mut t, &42);
+
+        T::drop_unchecked(t)
+    }
 }

--- a/language/extensions/move-table-extension/tests/TableTests.move
+++ b/language/extensions/move-table-extension/tests/TableTests.move
@@ -41,7 +41,7 @@ module Extensions::TableTests {
     }
 
     #[test]
-    #[expected_failure(abort_code = 1)]
+    #[expected_failure(abort_code = 26113)]
     fun test_destroy_fails() {
         let t = T::new<u64, u64>();
         T::add(&mut t, &1, 2);
@@ -180,7 +180,7 @@ module Extensions::TableTests {
     }
 
     #[test(s = @0x42)]
-    #[expected_failure(abort_code = 64237)]
+    #[expected_failure(abort_code = 25607)]
     fun test_insert_fail(s: signer) {
         let t = T::new<u64, u128>();
         assert!(!T::contains(&t, &42), 100);
@@ -193,7 +193,7 @@ module Extensions::TableTests {
     }
 
     #[test(s = @0x42)]
-    #[expected_failure(abort_code = 25524)]
+    #[expected_failure(abort_code = 25863)]
     fun test_borrow_fail(s: signer) {
         let t = T::new<u64, u128>();
         assert!(!T::contains(&t, &42), 100);
@@ -205,7 +205,7 @@ module Extensions::TableTests {
     }
 
     #[test(s = @0x42)]
-    #[expected_failure(abort_code = 25524)]
+    #[expected_failure(abort_code = 25863)]
     fun test_remove_fail(s: signer) {
         let t = T::new<u64, Balance>();
         let Balance { value } = T::remove(&mut t, &42); // should fail here since key 42 doesn't exist
@@ -228,7 +228,7 @@ module Extensions::TableTests {
     }
 
     #[test]
-    #[expected_failure(abort_code = 25524)]
+    #[expected_failure(abort_code = 25863)]
     fun test_remove_removed() {
         let t = T::new<u64, u64>();
         T::add(&mut t, &42, 42);
@@ -242,7 +242,7 @@ module Extensions::TableTests {
     }
 
     #[test]
-    #[expected_failure(abort_code = 25524)]
+    #[expected_failure(abort_code = 25863)]
     fun test_borrow_removed() {
         let t = T::new<u64, u64>();
         T::add(&mut t, &42, 42);

--- a/language/move-vm/test-utils/src/storage.rs
+++ b/language/move-vm/test-utils/src/storage.rs
@@ -57,10 +57,6 @@ impl TableResolver for BlankStorage {
         Ok(None)
     }
 
-    fn table_size(&self, _handle: &TableHandle) -> Result<usize, Error> {
-        Ok(0)
-    }
-
     fn operation_cost(
         &self,
         _op: TableOperation,
@@ -120,11 +116,6 @@ impl<'a, 'b, S: TableResolver> TableResolver for DeltaStorage<'a, 'b, S> {
     ) -> std::result::Result<Option<Vec<u8>>, Error> {
         // TODO: No support for table deltas
         self.base.resolve_table_entry(handle, key)
-    }
-
-    fn table_size(&self, handle: &TableHandle) -> std::result::Result<usize, Error> {
-        // TODO: No support for table deltas
-        self.base.table_size(handle)
     }
 
     fn operation_cost(
@@ -342,13 +333,6 @@ impl TableResolver for InMemoryStorage {
         key: &[u8],
     ) -> std::result::Result<Option<Vec<u8>>, Error> {
         Ok(self.tables.get(handle).and_then(|t| t.get(key).cloned()))
-    }
-
-    fn table_size(&self, handle: &TableHandle) -> std::result::Result<usize, Error> {
-        self.tables
-            .get(handle)
-            .map(|t| t.len())
-            .ok_or_else(|| anyhow!("table undefined"))
     }
 
     fn operation_cost(


### PR DESCRIPTION
### Motivation

1.manage the size from Move, instead of the extention. This way, the storage doesn't need to store a metadata item for the table.
2.fix issues with items created and removed in the same session before hitting storage.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

yes

### Testplan
Unit test cases are added for Table length and size at ```language/extensions/move-table-extension/tests/TableTests.move```
