### PR TITLE
[move-to-yul] Fix bugs #45_19

### DIFF
--- a/language/evm/hardhat-examples/contracts/ExternalCall/sources/ExternalCall.move
+++ b/language/evm/hardhat-examples/contracts/ExternalCall/sources/ExternalCall.move
@@ -67,35 +67,19 @@ module Evm::ExternalCall {
     public fun doSafeTransferAcceptanceCheck(from: address, to: address, tokenId: U256, data: vector<u8>) {
         if (isContract(to)) {
             let result = IERC721Receiver_try_call_onERC721Received(to, sender(), from, tokenId, data);
-             // TODO: the following code always aborts with "ok".
-            // if (ExternalResult::is_ok(&result)) {
-            //     abort_with(b"ok");
-            // } else if (ExternalResult::is_err_reason(&result)) {
-            //     abort_with(b"err_reason");
-            // } else if (ExternalResult::is_err_data(&result)) {
-            //     abort_with(b"err_data");
-            // } else if (ExternalResult::is_panic(&result)) {
-            //     abort_with(b"panic");
-            // } else {
-            //     abort_with(b"other");
-            // }
-
-            // The following code works fine.
-            if (ExternalResult::is_err_reason(&result)) {
-                // TODO: The following lines results in reverting without a reason string.
-                //       However, it is expected to revert with "ERC721ReceiverMock: reverting".
-                // let reason = ExternalResult::unwrap_err_reason(result);
-                // abort_with(reason);
-                abort_with(b"err_reason");
-            } else if (ExternalResult::is_err_data(&result)) {
-                abort_with(b"err_data");
-            } else if (ExternalResult::is_panic(&result)) {
-                abort_with(b"panic");
-            } else if (ExternalResult::is_ok(&result)) {
-                abort_with(b"ok");
-            } else {
-                abort_with(b"other");
-            }
+            if (ExternalResult::is_ok(&result)) {
+                 abort_with(b"ok");
+             } else if (ExternalResult::is_err_reason(&result)) {
+                 let reason = ExternalResult::unwrap_err_reason(result);
+                 abort_with(reason);
+                 //abort_with(b"err_reason");
+             } else if (ExternalResult::is_err_data(&result)) {
+                 abort_with(b"err_data");
+             } else if (ExternalResult::is_panic(&result)) {
+                 abort_with(b"panic");
+             } else {
+                 abort_with(b"other");
+             }
         }
     }
 

--- a/language/evm/hardhat-examples/test/ExternalCall.test.js
+++ b/language/evm/hardhat-examples/test/ExternalCall.test.js
@@ -84,7 +84,7 @@ contract('ExternalCall', function (accounts) {
             const receiver = await ERC721Receiver.new(RECEIVER_MAGIC_VALUE, Error.RevertWithMessage);
             await expectRevert(
                 this.externalCall.doSafeTransferAcceptanceCheck(this.externalCall.address, receiver.address, tokenId, data),
-                'err_reason',
+                'ERC721ReceiverMock: reverting',
             );
         });
         it('receiver reverting without error message', async function () {
@@ -119,26 +119,26 @@ contract('ExternalCall', function (accounts) {
             );
         });
         // TODO: Error with "Transaction ran out of gas"
-        // it('receiver reverting with error message', async function () {
-        //     const ids = [1,2,3];
-        //     const amounts = [10, 100, 1000];
-        //     const data = '0x42';
-        //     const receiver = await ERC1155Receiver.new(RECEIVER_SINGLE_MAGIC_VALUE, false, RECEIVER_BATCH_MAGIC_VALUE, true);
-        //     await expectRevert(
-        //         this.externalCall.doSafeBatchTransferAcceptanceCheck(this.externalCall.address, this.externalCall.address, receiver.address, ids, amounts, data),
-        //         'err_reason',
-        //     );
-        // });
+        it('receiver reverting with error message', async function () {
+             const ids = [1,2,3];
+             const amounts = [10, 100, 1000];
+             const data = '0x42';
+             const receiver = await ERC1155Receiver.new(RECEIVER_SINGLE_MAGIC_VALUE, false, RECEIVER_BATCH_MAGIC_VALUE, true);
+             await expectRevert(
+                 this.externalCall.doSafeBatchTransferAcceptanceCheck(this.externalCall.address, this.externalCall.address, receiver.address, ids, amounts, data),
+                 'err_reason',
+             );
+         });
         // TODO: Error with "Transaction ran out of gas"
-        // it('receiver reverting without error message', async function () {
-        //     const ids = [1,2,3];
-        //     const amounts = [10, 100, 1000];
-        //     const data = '0x42';
-        //     const receiver = await ERC721Receiver.new(RECEIVER_MAGIC_VALUE, Error.Panic);
-        //     await expectRevert(
-        //         this.externalCall.doSafeBatchTransferAcceptanceCheck(this.externalCall.address, this.externalCall.address, receiver.address, ids, amounts, data),
-        //         'err_data',
-        //     );
-        // });
+        it('receiver reverting without error message', async function () {
+             const ids = [1,2,3];
+             const amounts = [10, 100, 1000];
+             const data = '0x42';
+             const receiver = await ERC721Receiver.new(RECEIVER_MAGIC_VALUE, Error.Panic);
+             await expectRevert(
+                 this.externalCall.doSafeBatchTransferAcceptanceCheck(this.externalCall.address, this.externalCall.address, receiver.address, ids, amounts, data),
+                 'err_data',
+             );
+         });
     });
 });

--- a/language/evm/move-to-yul/src/external_functions.rs
+++ b/language/evm/move-to-yul/src/external_functions.rs
@@ -202,6 +202,14 @@ impl NativeFunctions {
                 pos_var,
                 estimated_size
             );
+            let return_size = "returndatasize()".to_string();
+            emitln!(ctx.writer, "// set freeMemoryPointer");
+            emitln!(
+                ctx.writer,
+                "mstore({}, {})",
+                substitute_placeholders("${MEM_SIZE_LOC}").unwrap(),
+                end_var
+            );
             if !external_flag {
                 emitln!(
                     ctx.writer,
@@ -223,16 +231,6 @@ impl NativeFunctions {
                         pos_var
                     );
                 }
-                emitln!(
-                    ctx.writer,
-                    "// update freeMemoryPointer according to dynamic return size"
-                );
-                let return_size = "returndatasize()".to_string();
-                gen.parent.call_builtin(
-                    ctx,
-                    YulFunction::MallocAt,
-                    vec![end_var.clone(), return_size.clone()].into_iter(),
-                );
                 emitln!(
                     ctx.writer,
                     "// decode return parameters from external try-call into retVars"

--- a/language/evm/move-to-yul/tests/test-dispatcher/ExternalCall.exp
+++ b/language/evm/move-to-yul/tests/test-dispatcher/ExternalCall.exp
@@ -372,10 +372,10 @@ object "A2_M" {
                 mstore($t2, $Shl(0x81b91ddb, 224))
                 let $t3 := abi_encode_tuple_$uint256$_$A2_U256_U256$(add($t2, 4), v)
                 let $t4 := call(gas(), contract, 0,  $t2, sub($t3, $t2), $t2, 32)
+                // set freeMemoryPointer
+                mstore(0, $t3)
                 switch iszero($t4)
                 case 0 {
-                    // update freeMemoryPointer according to dynamic return size
-                    $MallocAt($t3, returndatasize())
                     // decode return parameters from external try-call into retVars
                     $result := abi_decode_tuple_$uint256$_$A2_U256_U256$_from_memory($t2, add($t2, returndatasize()))
                     $result := A2_ExternalResult_ok$A2_U256_U256$($result)
@@ -683,10 +683,10 @@ object "A2_M" {
                 mstore($t5, $Shl(0xb88d4fde, 224))
                 let $t6 := abi_encode_tuple_$address_address_uint256_bytes$_$address_address_A2_U256_U256_vec$u8$$(add($t5, 4), from, to, tokenId, data)
                 let $t7 := call(gas(), contract, 0,  $t5, sub($t6, $t5), $t5, 0)
+                // set freeMemoryPointer
+                mstore(0, $t6)
                 if iszero($t7) { $RevertForward() }
                 if $t7 {
-                    // update freeMemoryPointer according to dynamic return size
-                    $MallocAt($t6, returndatasize())
                     // decode return parameters from external try-call into retVars
                     abi_decode_tuple___from_memory($t5, add($t5, returndatasize()))
                 }
@@ -702,10 +702,10 @@ object "A2_M" {
                 mstore($t1, $Shl(0x48050dbe, 224))
                 let $t2 := abi_encode_tuple__(add($t1, 4))
                 let $t3 := call(gas(), contract, 0,  $t1, sub($t2, $t1), $t1, 0)
+                // set freeMemoryPointer
+                mstore(0, $t2)
                 if iszero($t3) { $RevertForward() }
                 if $t3 {
-                    // update freeMemoryPointer according to dynamic return size
-                    $MallocAt($t2, returndatasize())
                     // decode return parameters from external try-call into retVars
                     abi_decode_tuple___from_memory($t1, add($t1, returndatasize()))
                 }
@@ -716,12 +716,12 @@ object "A2_M" {
                 mstore($t3, $Shl(0xe520b193, 224))
                 let $t4 := abi_encode_tuple_$uint256_uint256__$_$A2_U256_U256_vec$A2_U256_U256$$(add($t3, 4), v, vec)
                 let $t5 := call(gas(), contract, 0,  $t3, sub($t4, $t3), $t3, 0)
+                // set freeMemoryPointer
+                mstore(0, $t4)
                 if iszero($t5) { $RevertForward() }
                 if $t5 {
                     // copy dynamic return data out
                     returndatacopy($t3, 0, returndatasize())
-                    // update freeMemoryPointer according to dynamic return size
-                    $MallocAt($t4, returndatasize())
                     // decode return parameters from external try-call into retVars
                     $result0, $result1 := abi_decode_tuple_$uint256___uint256$_$vec$A2_U256_U256$_A2_U256_U256$_from_memory($t3, add($t3, returndatasize()))
                 }
@@ -732,10 +732,10 @@ object "A2_M" {
                 mstore($t3, $Shl(0xe985e9c5, 224))
                 let $t4 := abi_encode_tuple_$address_address$_$address_address$(add($t3, 4), account, operator)
                 let $t5 := call(gas(), contract, 0,  $t3, sub($t4, $t3), $t3, 32)
+                // set freeMemoryPointer
+                mstore(0, $t4)
                 if iszero($t5) { $RevertForward() }
                 if $t5 {
-                    // update freeMemoryPointer according to dynamic return size
-                    $MallocAt($t4, returndatasize())
                     // decode return parameters from external try-call into retVars
                     $result := abi_decode_tuple_$bool$_$bool$_from_memory($t3, add($t3, returndatasize()))
                 }
@@ -788,10 +788,10 @@ object "A2_M" {
                 mstore($t1, $Shl(0xb76fa7ae, 224))
                 let $t2 := abi_encode_tuple__(add($t1, 4))
                 let $t3 := call(gas(), contract, 0,  $t1, sub($t2, $t1), $t1, 0)
+                // set freeMemoryPointer
+                mstore(0, $t2)
                 switch iszero($t3)
                 case 0 {
-                    // update freeMemoryPointer according to dynamic return size
-                    $MallocAt($t2, returndatasize())
                     // decode return parameters from external try-call into retVars
                     abi_decode_tuple___from_memory($t1, add($t1, returndatasize()))
                 }
@@ -1137,10 +1137,10 @@ object "A2_M" {
                 mstore($t1, $Shl(0x14056b3d, 224))
                 let $t2 := abi_encode_tuple__(add($t1, 4))
                 let $t3 := call(gas(), contract, 0,  $t1, sub($t2, $t1), $t1, 32)
+                // set freeMemoryPointer
+                mstore(0, $t2)
                 switch iszero($t3)
                 case 0 {
-                    // update freeMemoryPointer according to dynamic return size
-                    $MallocAt($t2, returndatasize())
                     // decode return parameters from external try-call into retVars
                     $result := abi_decode_tuple_$uint256$_$A2_U256_U256$_from_memory($t1, add($t1, returndatasize()))
                     $result := A2_ExternalResult_ok$A2_U256_U256$($result)
@@ -1458,12 +1458,6 @@ object "A2_M" {
                 offs := mload(0)
                 // pad to word size
                 mstore(0, add(offs, shl(5, shr(5, add(size, 31)))))
-            }
-            function $MallocAt(offs, size) {
-              let new_free_ptr := add(offs, $RoundUp(size))
-              // protect against overflow
-              if or(gt(new_free_ptr, 0xffffffffffffffff), lt(new_free_ptr, offs)) { $AbortBuiltin() }
-              mstore(0, new_free_ptr)
             }
             function $Free(offs, size) {
             }


### PR DESCRIPTION
## Motivation

See` ExternalCall.move.`

In the following code, it always falls into the ok branch:

```
// TODO: the following code always aborts with "ok".
            // if (ExternalResult::is_ok(&result)) {
            //     abort_with(b"ok");
            // } else if (ExternalResult::is_err_reason(&result)) {
            //     abort_with(b"err_reason");
            // } else if (ExternalResult::is_err_data(&result)) {
            //     abort_with(b"err_data");
            // } else if (ExternalResult::is_panic(&result)) {
            //     abort_with(b"panic");
            // } else {
            //     abort_with(b"other");
            // }
```
### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes
## Test Plan

CI/CD Tests are covered.

