### PR TITLE
[evm] make evm features non-default(#57)_26

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -119,7 +119,7 @@ jobs:
 
   unit-test:
     runs-on: ubuntu-20.04-xl
-    timeout-minutes: 60
+    timeout-minutes: 90
     needs: prepare
     if: ${{ needs.prepare.outputs.test-rust == 'true' }}
     container:
@@ -164,7 +164,7 @@ jobs:
 
   hardhat-tests:
     runs-on: ubuntu-20.04-xl
-    timeout-minutes: 20
+    timeout-minutes: 90
     needs: prepare
     if: ${{ needs.prepare.outputs.test-rust == 'true' }}
     container:
@@ -178,8 +178,7 @@ jobs:
       - uses: ./.github/actions/build-setup
       - uses: Swatinem/rust-cache@c5ed9ba6b7e1bb8aff90d43acd2f0af4990fa57c
       - name: compile and install move-cli
-        working-directory: language/tools/move-cli
-        run: "cargo install --path ."
+        run: "cargo install --features evm-backend --path language/tools/move-cli"
       - name: set up hardhat-move
         working-directory: language/evm/hardhat-move
         run: "npm install"
@@ -194,6 +193,27 @@ jobs:
         run: "npx hardhat test"
       # TODO: reenable this once we figure a way to keep package-lock.json stable.
       # - uses: ./.github/actions/build-teardown
+  move-cli-tests-evm:
+    runs-on: ubuntu-20.04-xl
+    timeout-minutes: 30
+    needs: prepare
+    steps:
+      - uses: actions/checkout@v2.4.0
+      - uses: ./.github/actions/build-setup
+      - uses: Swatinem/rust-cache@c5ed9ba6b7e1bb8aff90d43acd2f0af4990fa57c
+      - name: run EVM-based move cli tests
+        run: "cargo test --features evm-backend -p move-cli --test build_testsuite_evm --test move_unit_tests_evm"
+
+  move-unit-test-framework-tests-evm:
+    runs-on: ubuntu-20.04-xl
+    timeout-minutes: 30
+    needs: prepare
+    steps:
+      - uses: actions/checkout@v2.4.0
+      - uses: ./.github/actions/build-setup
+      - uses: Swatinem/rust-cache@c5ed9ba6b7e1bb8aff90d43acd2f0af4990fa57c
+      - name: run EVM-based move unit test framework tests
+        run: "cargo test --features evm-backend -p move-unit-test --test move_unit_test_testsuite"
       - name: Early terminate workflow
         if: ${{ failure() }}
         uses: ./.github/actions/early-terminator

--- a/language/tools/move-cli/Cargo.toml
+++ b/language/tools/move-cli/Cargo.toml
@@ -76,8 +76,7 @@ harness = false
 required-features = ["evm-backend"]
 
 [features]
-default = ["evm-backend"]
-evm-backend = ["move-unit-test/evm-backend", "move-package/evm-arch"]
+evm-backend = ["move-unit-test/evm-backend", "move-package/evm-backend"]
 
 address20 = ["move-stdlib/address20"]
 address32 = ["move-stdlib/address32"]

--- a/language/tools/move-package/Cargo.toml
+++ b/language/tools/move-package/Cargo.toml
@@ -49,5 +49,4 @@ name = "test_runner"
 harness = false
 
 [features]
-default = ["evm-arch"]
-evm-arch = ["move-to-yul", "evm-exec-utils", "termcolor", "hex"]
+evm-backend = ["move-to-yul", "evm-exec-utils", "termcolor", "hex"]

--- a/language/tools/move-package/src/compilation/build_plan.rs
+++ b/language/tools/move-package/src/compilation/build_plan.rs
@@ -16,7 +16,7 @@ use std::{
 
 use super::{compiled_package::CompilationCachingStatus, package_layout::CompiledPackageLayout};
 
-#[cfg(feature = "evm-arch")]
+#[cfg(feature = "evm-backend")]
 use {
     colored::Colorize,
     move_to_yul::{options::Options as MoveToYulOptions, run_to_yul},
@@ -100,7 +100,7 @@ impl BuildPlan {
             .unwrap())
     }
 
-    #[cfg(feature = "evm-arch")]
+    #[cfg(feature = "evm-backend")]
     pub fn compile_evm<W: Write>(&self, writer: &mut W) -> Result<()> {
         let root_package = &self.resolution_graph.package_table[&self.root];
         let project_root = match &self.resolution_graph.build_options.install_dir {

--- a/language/tools/move-package/src/lib.rs
+++ b/language/tools/move-package/src/lib.rs
@@ -35,7 +35,7 @@ pub enum Architecture {
 
     AsyncMove,
 
-    #[cfg(feature = "evm-arch")]
+    #[cfg(feature = "evm-backend")]
     Ethereum,
 }
 
@@ -46,7 +46,7 @@ impl fmt::Display for Architecture {
 
             Self::AsyncMove => write!(f, "async-move"),
 
-            #[cfg(feature = "evm-arch")]
+            #[cfg(feature = "evm-backend")]
             Self::Ethereum => write!(f, "ethereum"),
         }
     }
@@ -57,7 +57,7 @@ impl Architecture {
         IntoIterator::into_iter([
             Self::Move,
             Self::AsyncMove,
-            #[cfg(feature = "evm-arch")]
+            #[cfg(feature = "evm-backend")]
             Self::Ethereum,
         ])
     }
@@ -68,7 +68,7 @@ impl Architecture {
 
             "async-move" => Self::AsyncMove,
 
-            #[cfg(feature = "evm-arch")]
+            #[cfg(feature = "evm-backend")]
             "ethereum" => Self::Ethereum,
 
             _ => {
@@ -159,7 +159,7 @@ impl BuildConfig {
         Ok(self.compile_package_with_caching_info(path, writer)?.0)
     }
 
-    #[cfg(feature = "evm-arch")]
+    #[cfg(feature = "evm-backend")]
     pub fn compile_package_evm<W: Write>(self, path: &Path, writer: &mut W) -> Result<()> {
         let resolved_graph = self.resolution_graph_for_package(path)?;
         let mutx = PackageLock::lock();

--- a/language/tools/move-unit-test/Cargo.toml
+++ b/language/tools/move-unit-test/Cargo.toml
@@ -55,7 +55,6 @@ name = "move_unit_test_testsuite"
 harness = false
 
 [features]
-default = ["evm-backend"]
 evm-backend = ["move-to-yul", "evm-exec-utils", "evm", "primitive-types"]
 table-extension = [
  "move-vm-test-utils/table-extension"

--- a/language/tools/move-unit-test/src/test_reporter.rs
+++ b/language/tools/move-unit-test/src/test_reporter.rs
@@ -126,6 +126,7 @@ impl FailureReason {
         FailureReason::Property(details)
     }
 
+    #[cfg(feature = "evm-backend")]
     pub fn move_to_evm_error(diagnostics: String) -> Self {
         FailureReason::MoveToEVMError(diagnostics)
     }

--- a/x.toml
+++ b/x.toml
@@ -148,6 +148,7 @@ members = [
     "move-transactional-test-runner",
     "move-vm-integration-tests",
     "move-vm-transactional-tests",
+    "evm-exec-utils",
     "serializer-tests",
     "test-generation",
     "x",


### PR DESCRIPTION
## Motivation

This makes the EVM features non-default so that one doesn't have to install the ethereum toolchain if one doesn't need it

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

CI/CD tests are covered.