### PR TITLE
Add alias to StructTag for compatibility with old serialized json. (#74)_36

### DIFF
--- a/language/move-core/types/src/language_storage.rs
+++ b/language/move-core/types/src/language_storage.rs
@@ -18,21 +18,22 @@ pub const CORE_CODE_ADDRESS: AccountAddress = AccountAddress::ONE;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Hash, Eq, Clone, PartialOrd, Ord)]
 pub enum TypeTag {
-    #[serde(rename(serialize = "bool", deserialize = "bool"))]
+    // alias for compatibility with old json serialized data.
+    #[serde(rename = "bool", alias = "Bool")]
     Bool,
-    #[serde(rename(serialize = "u8", deserialize = "u8"))]
+    #[serde(rename = "u8", alias = "U8")]
     U8,
-    #[serde(rename(serialize = "u64", deserialize = "u64"))]
+    #[serde(rename = "u64", alias = "U64")]
     U64,
-    #[serde(rename(serialize = "u128", deserialize = "u128"))]
+    #[serde(rename = "u128", alias = "U128")]
     U128,
-    #[serde(rename(serialize = "address", deserialize = "address"))]
+    #[serde(rename = "address", alias = "Address")]
     Address,
-    #[serde(rename(serialize = "signer", deserialize = "signer"))]
+    #[serde(rename = "signer", alias = "Signer")]
     Signer,
-    #[serde(rename(serialize = "vector", deserialize = "vector"))]
+    #[serde(rename = "vector", alias = "Vector")]
     Vector(Box<TypeTag>),
-    #[serde(rename(serialize = "struct", deserialize = "struct"))]
+    #[serde(rename = "struct", alias = "Struct")]
     Struct(StructTag),
 }
 
@@ -42,7 +43,8 @@ pub struct StructTag {
     pub module: Identifier,
     pub name: Identifier,
     // TODO: rename to "type_args" (or better "ty_args"?)
-    #[serde(rename(serialize = "type_args", deserialize = "type_args"))]
+    // alias for compatibility with old json serialized data.
+    #[serde(rename = "type_args", alias = "type_params")]
     pub type_params: Vec<TypeTag>,
 }
 

--- a/language/move-core/types/src/unit_tests/language_storage_test.rs
+++ b/language/move-core/types/src/unit_tests/language_storage_test.rs
@@ -1,7 +1,11 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::language_storage::ModuleId;
+use crate::{
+    account_address::AccountAddress,
+    identifier::{IdentStr, Identifier},
+    language_storage::{ModuleId, StructTag, TypeTag},
+};
 use bcs::test_helpers::assert_canonical_encode_decode;
 use proptest::prelude::*;
 
@@ -10,4 +14,39 @@ proptest! {
     fn test_module_id_canonical_roundtrip(module_id in any::<ModuleId>()) {
         assert_canonical_encode_decode(module_id);
     }
+}
+
+#[test]
+fn test_type_tag_deserialize_case_insensitive() {
+    let org_struct_tag = StructTag {
+        address: AccountAddress::ONE,
+        module: Identifier::from(IdentStr::new("TestModule").unwrap()),
+        name: Identifier::from(IdentStr::new("TestStruct").unwrap()),
+        type_params: vec![
+            TypeTag::U8,
+            TypeTag::U64,
+            TypeTag::U128,
+            TypeTag::Bool,
+            TypeTag::Address,
+            TypeTag::Signer,
+        ],
+    };
+
+    let current_json = serde_json::to_string(&org_struct_tag).unwrap();
+
+    let upper_case_json = format!(
+        r##"{{"address":"{}","module":"TestModule","name":"TestStruct","type_params":["U8","U64","U128","Bool","Address","Signer"]}}"##,
+        AccountAddress::ONE
+    );
+    let upper_case_decoded = serde_json::from_str(upper_case_json.as_str()).unwrap();
+    assert_eq!(org_struct_tag, upper_case_decoded);
+
+    let lower_case_json = format!(
+        r##"{{"address":"{}","module":"TestModule","name":"TestStruct","type_args":["u8","u64","u128","bool","address","signer"]}}"##,
+        AccountAddress::ONE
+    );
+    let lower_case_decoded = serde_json::from_str(lower_case_json.as_str()).unwrap();
+    assert_eq!(org_struct_tag, lower_case_decoded);
+
+    assert_eq!(current_json, lower_case_json);
 }


### PR DESCRIPTION
## Motivation

Add an alias to StructTag for compatibility with old serialized json.

When the TypeTag add serde(rename = "u8"), this break the compatibility with old version, so add a alias = "U8" for compatibility.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

CI/CD tests are covered.
