### PR TITLE
exclude &signer in view_function_arguments (#77)_39

### DIFF
--- a/language/tools/move-resource-viewer/src/lib.rs
+++ b/language/tools/move-resource-viewer/src/lib.rs
@@ -111,7 +111,11 @@ impl<'a, T: MoveResolver + ?Sized> MoveValueAnnotator<'a, T> {
             .cache
             .resolve_function_arguments(module, function)?
             .into_iter()
-            .filter(|t| !matches!(t, FatType::Signer))
+            .filter(|t| match t {
+                FatType::Signer => false,
+                FatType::Reference(inner) => !matches!(&**inner, FatType::Signer),
+                _ => true,
+            })
             .collect();
         anyhow::ensure!(
             types.len() == args.len(),

--- a/language/tools/move-resource-viewer/src/resolver.rs
+++ b/language/tools/move-resource-viewer/src/resolver.rs
@@ -164,9 +164,11 @@ impl<'a, T: MoveResolver + ?Sized> Resolver<'a, T> {
                 ))
             }
             SignatureToken::TypeParameter(idx) => FatType::TyParam(*idx as usize),
-            SignatureToken::MutableReference(_) | SignatureToken::Reference(_) => {
-                return Err(anyhow!("Unexpected Reference"))
-            }
+            SignatureToken::MutableReference(_) => return Err(anyhow!("Unexpected Reference")),
+            SignatureToken::Reference(inner) => match **inner {
+                SignatureToken::Signer => FatType::Reference(Box::new(FatType::Signer)),
+                _ => return Err(anyhow!("Unexpected Reference")),
+            },
         })
     }
 


### PR DESCRIPTION
## Motivation

As script function can support more flexible parameters, we plan to enable passing signer reference instead of signer in script and script function to reduce redundant code. Ex: developer has to write script function taking signer and a internal version of script function to take &signer so that they can test with internal version of function without worrying about the signer value being "moved". This leads to lot of code duplication and force developer to understand unnecessary language details.

The move viewer also has the same assumption that should be relaxed. When API reads the onchain TXN data and rendered the data for better visualization. It needs to convert the txn args back from BCS to it original string representation. When it does this converion, It has the assumption that txn args don't include signer. But once we allow users to use &signer in entry function. Signer reference should be excluded from the txn args as well.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

CI/CD tests are covered.
