### PR TITLE
Added support for preserving locations of aliased identifiers (#103)_48

### DIFF
--- a/language/move-compiler/src/expansion/translate.rs
+++ b/language/move-compiler/src/expansion/translate.rs
@@ -1570,12 +1570,12 @@ fn name_access_chain(
         (Access::ApplyPositional, PN::One(n))
         | (Access::ApplyNamed, PN::One(n))
         | (Access::Type, PN::One(n)) => match context.aliases.member_alias_get(&n) {
-            Some((mident, mem)) => EN::ModuleAccess(*mident, *mem),
+            Some((mident, mem)) => EN::ModuleAccess(mident, mem),
             None => EN::Name(n),
         },
         (Access::Term, PN::One(n)) if is_valid_struct_constant_or_schema_name(n.value.as_str()) => {
             match context.aliases.member_alias_get(&n) {
-                Some((mident, mem)) => EN::ModuleAccess(*mident, *mem),
+                Some((mident, mem)) => EN::ModuleAccess(mident, mem),
                 None => EN::Name(n),
             }
         }
@@ -1595,7 +1595,7 @@ fn name_access_chain(
                 ));
                 return None;
             }
-            Some(mident) => EN::ModuleAccess(*mident, n2),
+            Some(mident) => EN::ModuleAccess(mident, n2),
         },
         (_, PN::Three(sp!(ident_loc, (ln, n2)), n3)) => {
             let addr = address(context, /* suggest_declaration */ false, ln);
@@ -1620,7 +1620,7 @@ fn name_access_chain_to_module_ident(
                 ));
                 None
             }
-            Some(mident) => Some(*mident),
+            Some(mident) => Some(mident),
         },
         PN::Two(ln, n) => {
             let pmident_ = P::ModuleIdent_ {

--- a/language/move-compiler/tests/move_check/naming/friend_decl_self.exp
+++ b/language/move-compiler/tests/move_check/naming/friend_decl_self.exp
@@ -1,10 +1,11 @@
 error[E02011]: invalid 'friend' declaration
   ┌─ tests/move_check/naming/friend_decl_self.move:3:5
   │
-2 │ module M {
-  │        - Cannot declare the module itself as a friend
 3 │     friend Self;
-  │     ^^^^^^^^^^^^ Invalid friend declaration
+  │     ^^^^^^^^^^^^
+  │     │      │
+  │     │      Cannot declare the module itself as a friend
+  │     Invalid friend declaration
 
 error[E02011]: invalid 'friend' declaration
   ┌─ tests/move_check/naming/friend_decl_self.move:9:5


### PR DESCRIPTION
## Motivation

- In short, we want to preserve locations of identifiers that are aliases to modules or module-level definitions. It fixes the problem more generally (e.g., also for Pack and other AST nodes).


## Test Plan

CI/CD Tests were covered