### PR TITLE
Allow passing extensions to async move vm. (#121)_55 AB#8967

### DIFF
--- a/language/extensions/async/move-async-vm/src/async_vm.rs
+++ b/language/extensions/async/move-async-vm/src/async_vm.rs
@@ -77,7 +77,23 @@ impl AsyncVM {
         virtual_time: u128,
         move_resolver: &'r mut S,
     ) -> AsyncSession<'r, 'l, S> {
-        let extensions = make_extensions(for_actor, virtual_time, true);
+        self.new_session_with_extensions(
+            for_actor,
+            virtual_time,
+            move_resolver,
+            NativeContextExtensions::default(),
+        )
+    }
+
+    /// Creates a new session.
+    pub fn new_session_with_extensions<'r, 'l, S: MoveResolver>(
+        &'l self,
+        for_actor: AccountAddress,
+        virtual_time: u128,
+        move_resolver: &'r mut S,
+        ext: NativeContextExtensions<'r>,
+    ) -> AsyncSession<'r, 'l, S> {
+        let extensions = make_extensions(ext, for_actor, virtual_time, true);
         AsyncSession {
             vm: self,
             vm_session: self
@@ -328,12 +344,12 @@ impl<'r, 'l, S: MoveResolver> AsyncSession<'r, 'l, S> {
     }
 }
 
-fn make_extensions<'a>(
+fn make_extensions(
+    mut exts: NativeContextExtensions,
     actor_addr: AccountAddress,
     virtual_time: u128,
     in_initializer: bool,
-) -> NativeContextExtensions<'a> {
-    let mut exts = NativeContextExtensions::default();
+) -> NativeContextExtensions {
     exts.add(AsyncExtension {
         current_actor: actor_addr,
         sent: vec![],


### PR DESCRIPTION
## Motivation

Add an api for async move vm to allow an extension.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

cargo check