### PR TITLE
fix test failure on compare lines ending with "\r\n" and "\n" (#132)_57

### DIFF
--- a/language/testing-infra/transactional-test-runner/src/framework.rs
+++ b/language/testing-infra/transactional-test-runner/src/framework.rs
@@ -724,7 +724,10 @@ fn handle_expected_output(test_path: &Path, output: impl AsRef<str>) -> Result<(
     if !exp_path.exists() {
         std::fs::write(&exp_path, "").unwrap();
     }
-    let expected_output = std::fs::read_to_string(&exp_path).unwrap();
+    let expected_output = std::fs::read_to_string(&exp_path)
+        .unwrap()
+        .replace("\r\n", "\n")
+        .replace("\r", "\n");
     if output != expected_output {
         let msg = format!(
             "Expected errors differ from actual errors:\n{}",


### PR DESCRIPTION
### Motivation

- fix test failure on compare lines ending with "\r\n" and "\n"

###  Test Plan

- Cargo test 
