### PR TITLE
[move package] rebuild only if sources have been modified or outputs are missing or outdated #97_63

### DIFF
--- a/language/tools/move-cli/src/sandbox/commands/test.rs
+++ b/language/tools/move-cli/src/sandbox/commands/test.rs
@@ -222,6 +222,29 @@ pub fn run_one(
     env::set_var(COLOR_MODE_ENV_VAR, "NONE");
     for args_line in args_file {
         let args_line = args_line?;
+
+        if let Some(external_cmd) = args_line.strip_prefix(">") {
+            let external_cmd = external_cmd.trim_start();
+            let mut cmd_iter = external_cmd.split_ascii_whitespace();
+
+            let external_program = cmd_iter.next().expect("empty external command");
+
+            let mut command = Command::new(external_program);
+            command.args(cmd_iter);
+            if let Some(work_dir) = temp_dir.as_ref() {
+                command.current_dir(&work_dir.1);
+            } else {
+                command.current_dir(exe_dir);
+            }
+            let cmd_output = command.output()?;
+
+            output += &format!("External Command `{}`:\n", external_cmd);
+            output += std::str::from_utf8(&cmd_output.stdout)?;
+            output += std::str::from_utf8(&cmd_output.stderr)?;
+
+            continue;
+        }
+
         if args_line.starts_with('#') {
             // allow comments in args.txt
             continue;

--- a/language/tools/move-cli/tests/build_tests/rebuild_after_adding_new_source/Move.toml
+++ b/language/tools/move-cli/tests/build_tests/rebuild_after_adding_new_source/Move.toml
@@ -1,0 +1,3 @@
+[package]
+name = "Foo"
+version = "0.0.0"

--- a/language/tools/move-cli/tests/build_tests/rebuild_after_adding_new_source/args.evm.exp
+++ b/language/tools/move-cli/tests/build_tests/rebuild_after_adding_new_source/args.evm.exp
@@ -1,0 +1,7 @@
+Command `package build -v --arch ethereum`:
+COMPILING Foo to Yul
+GENERATING EVM bytecote from Yul
+External Command `touch sources/Bar.move`:
+Command `package build -v --arch ethereum`:
+COMPILING Foo to Yul
+GENERATING EVM bytecote from Yul

--- a/language/tools/move-cli/tests/build_tests/rebuild_after_adding_new_source/args.evm.txt
+++ b/language/tools/move-cli/tests/build_tests/rebuild_after_adding_new_source/args.evm.txt
@@ -1,0 +1,3 @@
+package build -v --arch ethereum
+> touch sources/Bar.move
+package build -v --arch ethereum

--- a/language/tools/move-cli/tests/build_tests/rebuild_after_adding_new_source/sources/Foo.move
+++ b/language/tools/move-cli/tests/build_tests/rebuild_after_adding_new_source/sources/Foo.move
@@ -1,0 +1,1 @@
+module 0x1::Foo {}

--- a/language/tools/move-cli/tests/build_tests/rebuild_after_deleting_output_artifact/Move.toml
+++ b/language/tools/move-cli/tests/build_tests/rebuild_after_deleting_output_artifact/Move.toml
@@ -1,0 +1,3 @@
+[package]
+name = "Foo"
+version = "0.0.0"

--- a/language/tools/move-cli/tests/build_tests/rebuild_after_deleting_output_artifact/args.evm.exp
+++ b/language/tools/move-cli/tests/build_tests/rebuild_after_deleting_output_artifact/args.evm.exp
@@ -1,0 +1,17 @@
+Command `package build -v --arch ethereum`:
+COMPILING Foo to Yul
+GENERATING EVM bytecote from Yul
+Command `package build -v --arch ethereum`:
+CACHED Foo
+External Command `rm build/evm/Foo.yul`:
+Command `package build -v --arch ethereum`:
+COMPILING Foo to Yul
+GENERATING EVM bytecote from Yul
+External Command `rm build/evm/Foo.bin`:
+Command `package build -v --arch ethereum`:
+COMPILING Foo to Yul
+GENERATING EVM bytecote from Yul
+External Command `rm build/evm/Foo.abi.json`:
+Command `package build -v --arch ethereum`:
+COMPILING Foo to Yul
+GENERATING EVM bytecote from Yul

--- a/language/tools/move-cli/tests/build_tests/rebuild_after_deleting_output_artifact/args.evm.txt
+++ b/language/tools/move-cli/tests/build_tests/rebuild_after_deleting_output_artifact/args.evm.txt
@@ -1,0 +1,8 @@
+package build -v --arch ethereum
+package build -v --arch ethereum
+> rm build/evm/Foo.yul
+package build -v --arch ethereum
+> rm build/evm/Foo.bin
+package build -v --arch ethereum
+> rm build/evm/Foo.abi.json
+package build -v --arch ethereum

--- a/language/tools/move-cli/tests/build_tests/rebuild_after_deleting_output_artifact/sources/Foo.move
+++ b/language/tools/move-cli/tests/build_tests/rebuild_after_deleting_output_artifact/sources/Foo.move
@@ -1,0 +1,1 @@
+module 0x1::Foo {}

--- a/language/tools/move-cli/tests/build_tests/rebuild_after_touching_manifest/Move.toml
+++ b/language/tools/move-cli/tests/build_tests/rebuild_after_touching_manifest/Move.toml
@@ -1,0 +1,3 @@
+[package]
+name = "Foo"
+version = "0.0.0"

--- a/language/tools/move-cli/tests/build_tests/rebuild_after_touching_manifest/args.evm.exp
+++ b/language/tools/move-cli/tests/build_tests/rebuild_after_touching_manifest/args.evm.exp
@@ -1,0 +1,7 @@
+Command `package build -v --arch ethereum`:
+COMPILING Foo to Yul
+GENERATING EVM bytecote from Yul
+External Command `touch Move.toml`:
+Command `package build -v --arch ethereum`:
+COMPILING Foo to Yul
+GENERATING EVM bytecote from Yul

--- a/language/tools/move-cli/tests/build_tests/rebuild_after_touching_manifest/args.evm.txt
+++ b/language/tools/move-cli/tests/build_tests/rebuild_after_touching_manifest/args.evm.txt
@@ -1,0 +1,3 @@
+package build -v --arch ethereum
+> touch Move.toml
+package build -v --arch ethereum

--- a/language/tools/move-cli/tests/build_tests/rebuild_after_touching_manifest/sources/Foo.move
+++ b/language/tools/move-cli/tests/build_tests/rebuild_after_touching_manifest/sources/Foo.move
@@ -1,0 +1,1 @@
+module 0x1::Foo {}

--- a/language/tools/move-cli/tests/build_tests/rebuild_after_touching_source/Move.toml
+++ b/language/tools/move-cli/tests/build_tests/rebuild_after_touching_source/Move.toml
@@ -1,0 +1,3 @@
+[package]
+name = "Foo"
+version = "0.0.0"

--- a/language/tools/move-cli/tests/build_tests/rebuild_after_touching_source/args.evm.exp
+++ b/language/tools/move-cli/tests/build_tests/rebuild_after_touching_source/args.evm.exp
@@ -1,0 +1,7 @@
+Command `package build -v --arch ethereum`:
+COMPILING Foo to Yul
+GENERATING EVM bytecote from Yul
+External Command `touch sources/Foo.move`:
+Command `package build -v --arch ethereum`:
+COMPILING Foo to Yul
+GENERATING EVM bytecote from Yul

--- a/language/tools/move-cli/tests/build_tests/rebuild_after_touching_source/args.evm.txt
+++ b/language/tools/move-cli/tests/build_tests/rebuild_after_touching_source/args.evm.txt
@@ -1,0 +1,3 @@
+package build -v --arch ethereum
+> touch sources/Foo.move
+package build -v --arch ethereum

--- a/language/tools/move-cli/tests/build_tests/rebuild_after_touching_source/sources/Foo.move
+++ b/language/tools/move-cli/tests/build_tests/rebuild_after_touching_source/sources/Foo.move
@@ -1,0 +1,1 @@
+module 0x1::Foo {}

--- a/language/tools/move-cli/tests/build_tests/rebuild_no_modification/Move.toml
+++ b/language/tools/move-cli/tests/build_tests/rebuild_no_modification/Move.toml
@@ -1,0 +1,3 @@
+[package]
+name = "Foo"
+version = "0.0.0"

--- a/language/tools/move-cli/tests/build_tests/rebuild_no_modification/args.evm.exp
+++ b/language/tools/move-cli/tests/build_tests/rebuild_no_modification/args.evm.exp
@@ -1,0 +1,5 @@
+Command `package build -v --arch ethereum`:
+COMPILING Foo to Yul
+GENERATING EVM bytecote from Yul
+Command `package build -v --arch ethereum`:
+CACHED Foo

--- a/language/tools/move-cli/tests/build_tests/rebuild_no_modification/args.evm.txt
+++ b/language/tools/move-cli/tests/build_tests/rebuild_no_modification/args.evm.txt
@@ -1,0 +1,2 @@
+package build -v --arch ethereum
+package build -v --arch ethereum

--- a/language/tools/move-cli/tests/build_tests/rebuild_no_modification/sources/Foo.move
+++ b/language/tools/move-cli/tests/build_tests/rebuild_no_modification/sources/Foo.move
@@ -1,0 +1,1 @@
+module 0x1::Foo {}

--- a/language/tools/move-package/src/compilation/build_plan.rs
+++ b/language/tools/move-package/src/compilation/build_plan.rs
@@ -20,7 +20,9 @@ use super::{compiled_package::CompilationCachingStatus, package_layout::Compiled
 use {
     colored::Colorize,
     move_to_yul::{options::Options as MoveToYulOptions, run_to_yul},
+    std::{fs, io},
     termcolor::Buffer,
+    walkdir::WalkDir,
 };
 
 #[derive(Debug, Clone)]
@@ -28,6 +30,56 @@ pub struct BuildPlan {
     root: PackageName,
     sorted_deps: Vec<PackageName>,
     resolution_graph: ResolvedGraph,
+}
+
+#[cfg(feature = "evm-backend")]
+fn should_recompile(
+    source_paths: impl IntoIterator<Item = impl AsRef<Path>>,
+    output_paths: impl IntoIterator<Item = impl AsRef<Path>>,
+) -> Result<bool> {
+    let mut earliest_output_mod_time = None;
+    for output_path in output_paths.into_iter() {
+        match fs::metadata(output_path) {
+            Ok(meta) => {
+                let mod_time = meta
+                    .modified()
+                    .expect("failed to get file modification time");
+
+                match &mut earliest_output_mod_time {
+                    None => earliest_output_mod_time = Some(mod_time),
+                    Some(earliest_mod_time) => *earliest_mod_time = mod_time,
+                }
+            }
+            Err(err) => {
+                if let io::ErrorKind::NotFound = err.kind() {
+                    return Ok(true);
+                }
+                return Err(err.into());
+            }
+        }
+    }
+
+    let earliest_output_mod_time = match earliest_output_mod_time {
+        Some(mod_time) => mod_time,
+        None => panic!("no output files given -- this should not happen"),
+    };
+
+    for source_path in source_paths.into_iter() {
+        for entry in WalkDir::new(source_path) {
+            let entry = entry?;
+
+            let mod_time = entry
+                .metadata()?
+                .modified()
+                .expect("failed to get file modification time");
+
+            if mod_time > earliest_output_mod_time {
+                return Ok(true);
+            }
+        }
+    }
+
+    Ok(false)
 }
 
 impl BuildPlan {
@@ -113,14 +165,6 @@ impl BuildPlan {
 
         // Step 1: Compile Move into Yul
         //   Step 1a: Gather command line arguments for move-to-yul
-        let package_names = self
-            .resolution_graph
-            .package_table
-            .iter()
-            .map(|(name, _)| name.to_string())
-            .collect::<Vec<_>>()
-            .join(", ");
-
         let dependencies = self
             .resolution_graph
             .package_table
@@ -135,18 +179,18 @@ impl BuildPlan {
                     ))
                 }
             })
-            .collect();
+            .collect::<Vec<_>>();
 
         let sources = vec![format!(
             "{}/sources",
             root_package.package_path.to_string_lossy()
         )];
 
-        let named_address_mapping = self
-            .resolution_graph
-            .extract_named_address_mapping()
-            .map(|(name, addr)| format!("{}={}", name.as_str(), addr))
-            .collect();
+        let bytecode_output = format!(
+            "{}/{}.bin",
+            build_root_path.to_string_lossy(),
+            root_package.source_package.package.name
+        );
 
         let yul_output = format!(
             "{}/{}.yul",
@@ -159,7 +203,43 @@ impl BuildPlan {
             root_package.source_package.package.name
         );
 
-        //   Step 1b: Call move-to-yul
+        let output_paths = [&bytecode_output, &yul_output, &abi_output];
+
+        let package_names = self
+            .resolution_graph
+            .package_table
+            .iter()
+            .map(|(name, _)| name.to_string())
+            .collect::<Vec<_>>()
+            .join(", ");
+
+        let named_address_mapping = self
+            .resolution_graph
+            .extract_named_address_mapping()
+            .map(|(name, addr)| format!("{}={}", name.as_str(), addr))
+            .collect();
+
+        //   Step 1b: Check if a fresh compilation is really needed. Only recompile if either
+        //              a) Some of the output artifacts are missing
+        //              b) Any source files have been modified since last compile
+        let manifests = self
+            .resolution_graph
+            .package_table
+            .iter()
+            .map(|(_name, package)| format!("{}/Move.toml", package.package_path.to_string_lossy()))
+            .collect::<Vec<_>>();
+
+        let all_sources = manifests
+            .iter()
+            .chain(sources.iter())
+            .chain(dependencies.iter());
+
+        if !should_recompile(all_sources, output_paths)? {
+            writeln!(writer, "{} {}", "CACHED".bold().green(), package_names)?;
+            return Ok(());
+        }
+
+        //   Step 1c: Call move-to-yul
         writeln!(
             writer,
             "{} {} to Yul",
@@ -227,12 +307,6 @@ impl BuildPlan {
                 return Err(err.into());
             }
         };
-
-        let bytecode_output = format!(
-            "{}/{}.bin",
-            build_root_path.to_string_lossy(),
-            root_package.source_package.package.name
-        );
 
         writeln!(
             writer,

--- a/language/tools/move-package/src/lib.rs
+++ b/language/tools/move-package/src/lib.rs
@@ -1,8 +1,9 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-pub mod compilation;
 mod package_lock;
+
+pub mod compilation;
 pub mod resolution;
 pub mod source_package;
 


### PR DESCRIPTION
### Motivation

This implements some basic caching mechanism for move package build --arch ethereum. Recompilation will only be triggered when any of the following conditions is met:
1. Any of the sources has been modified, or more precisely, has a modification time later than those of the outputs.
2. Any expected output file is missing.

### Test Plan 
cargo test