### PR TITLE
[evm][move package] remove build dir before starting a new build #105_66

### DIFF
--- a/language/tools/move-package/src/compilation/build_plan.rs
+++ b/language/tools/move-package/src/compilation/build_plan.rs
@@ -248,6 +248,22 @@ impl BuildPlan {
             package_names
         )?;
 
+        if let Err(err) = std::fs::remove_dir_all(&build_root_path) {
+            match err.kind() {
+                io::ErrorKind::NotFound => (),
+                _ => {
+                    writeln!(
+                        writer,
+                        "{} Failed to remove build dir {}: {}",
+                        "ERROR".bold().red(),
+                        build_root_path.to_string_lossy(),
+                        err,
+                    )?;
+
+                    return Err(err.into());
+                }
+            }
+        }
         if let Err(err) = std::fs::create_dir_all(&build_root_path) {
             writeln!(
                 writer,
@@ -296,6 +312,7 @@ impl BuildPlan {
         }
 
         // Step 2: Compile Yul into bytecode using solc
+
         let yul_source = match std::fs::read_to_string(&yul_output) {
             Ok(yul_source) => yul_source,
             Err(err) => {


### PR DESCRIPTION
## Motivation

With this change, `move package build --arch Ethereum` now removes the` build/evm `directory before generating the new artifacts.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

CI/CD tests are covered.