### PR TITLE
[evm][move package] make --arch ethereum present in all builds, but return an error if feature evm-backend isn't enabled #106_67 AB#8969

### DIFF
--- a/language/tools/move-cli/src/package/cli.rs
+++ b/language/tools/move-cli/src/package/cli.rs
@@ -304,9 +304,12 @@ pub fn handle_package_commands(
                     config.compile_package(&rerooted_path, &mut std::io::stderr())?;
                 }
 
-                #[cfg(feature = "evm-backend")]
                 Architecture::Ethereum => {
+                    #[cfg(feature = "evm-backend")]
                     config.compile_package_evm(&rerooted_path, &mut std::io::stderr())?;
+
+                    #[cfg(not(feature = "evm-backend"))]
+                    bail!("The Ethereum architecture is not supported because move-cli was not compiled with feature flag `evm-backend`.");
                 }
             }
         }

--- a/language/tools/move-package/src/lib.rs
+++ b/language/tools/move-package/src/lib.rs
@@ -35,7 +35,6 @@ pub enum Architecture {
 
     AsyncMove,
 
-    #[cfg(feature = "evm-backend")]
     Ethereum,
 }
 
@@ -46,7 +45,6 @@ impl fmt::Display for Architecture {
 
             Self::AsyncMove => write!(f, "async-move"),
 
-            #[cfg(feature = "evm-backend")]
             Self::Ethereum => write!(f, "ethereum"),
         }
     }
@@ -68,7 +66,6 @@ impl Architecture {
 
             "async-move" => Self::AsyncMove,
 
-            #[cfg(feature = "evm-backend")]
             "ethereum" => Self::Ethereum,
 
             _ => {


### PR DESCRIPTION
## Motivation

Previously, the --arch ethereum option is only present when feature evm-backend is enabled, which ended up causing some confusion. This PR makes the option always available, but return an error if evm-backend isn't enabled when invoked.

## Test Plan
CI/CD Tests are covered