### PR TITLE
[file-format] Introduce metadata in file format (unused for now) #123_73 

### DIFF
--- a/language/extensions/async/move-async-vm/tests/testsuite.rs
+++ b/language/extensions/async/move-async-vm/tests/testsuite.rs
@@ -155,7 +155,7 @@ impl Harness {
             self.log(format!("publishing {}", id));
             session
                 .get_move_session()
-                .publish_module(cu.serialize(), test_account(), gas)?
+                .publish_module(cu.serialize(None), test_account(), gas)?
         }
         Ok(())
     }
@@ -367,7 +367,7 @@ impl<'a> ModuleResolver for HarnessProxy<'a> {
             .harness
             .module_cache
             .get(id.name())
-            .map(|c| c.serialize()))
+            .map(|c| c.serialize(None)))
     }
 }
 

--- a/language/move-binary-format/serializer-tests/tests/serializer_tests.rs
+++ b/language/move-binary-format/serializer-tests/tests/serializer_tests.rs
@@ -12,6 +12,7 @@ proptest! {
 
         let deserialized_module = CompiledModule::deserialize(&serialized)
             .expect("deserialization should work");
+
         prop_assert_eq!(module, deserialized_module);
     }
 }

--- a/language/move-binary-format/src/deserializer.rs
+++ b/language/move-binary-format/src/deserializer.rs
@@ -3,7 +3,8 @@
 
 use crate::{check_bounds::BoundsChecker, errors::*, file_format::*, file_format_common::*};
 use move_core_types::{
-    account_address::AccountAddress, identifier::Identifier, vm_status::StatusCode,
+    account_address::AccountAddress, identifier::Identifier, metadata::Metadata,
+    vm_status::StatusCode,
 };
 use std::{collections::HashSet, convert::TryInto, io::Read};
 
@@ -217,6 +218,14 @@ fn load_constant_size(cursor: &mut VersionedCursor) -> BinaryLoaderResult<usize>
     read_uleb_internal(cursor, CONSTANT_SIZE_MAX)
 }
 
+fn load_metadata_key_size(cursor: &mut VersionedCursor) -> BinaryLoaderResult<usize> {
+    read_uleb_internal(cursor, METADATA_KEY_SIZE_MAX)
+}
+
+fn load_metadata_value_size(cursor: &mut VersionedCursor) -> BinaryLoaderResult<usize> {
+    read_uleb_internal(cursor, METADATA_VALUE_SIZE_MAX)
+}
+
 fn load_identifier_size(cursor: &mut VersionedCursor) -> BinaryLoaderResult<usize> {
     read_uleb_internal(cursor, IDENTIFIER_SIZE_MAX)
 }
@@ -385,6 +394,7 @@ trait CommonTables {
     fn get_identifiers(&mut self) -> &mut IdentifierPool;
     fn get_address_identifiers(&mut self) -> &mut AddressIdentifierPool;
     fn get_constant_pool(&mut self) -> &mut ConstantPool;
+    fn get_metadata(&mut self) -> &mut Vec<Metadata>;
 }
 
 impl CommonTables for CompiledScript {
@@ -419,6 +429,10 @@ impl CommonTables for CompiledScript {
     fn get_constant_pool(&mut self) -> &mut ConstantPool {
         &mut self.constant_pool
     }
+
+    fn get_metadata(&mut self) -> &mut Vec<Metadata> {
+        &mut self.metadata
+    }
 }
 
 impl CommonTables for CompiledModule {
@@ -452,6 +466,10 @@ impl CommonTables for CompiledModule {
 
     fn get_constant_pool(&mut self) -> &mut ConstantPool {
         &mut self.constant_pool
+    }
+
+    fn get_metadata(&mut self) -> &mut Vec<Metadata> {
+        &mut self.metadata
     }
 }
 
@@ -502,6 +520,17 @@ fn build_common_tables(
             }
             TableType::CONSTANT_POOL => {
                 load_constant_pool(binary, table, common.get_constant_pool())?;
+            }
+            TableType::METADATA => {
+                if binary.version() < VERSION_5 {
+                    return Err(
+                        PartialVMError::new(StatusCode::MALFORMED).with_message(format!(
+                            "metadata declarations not applicable in bytecode version {}",
+                            binary.version()
+                        )),
+                    );
+                }
+                load_metadata(binary, table, common.get_metadata())?;
             }
             TableType::IDENTIFIERS => {
                 load_identifiers(binary, table, common.get_identifiers())?;
@@ -561,6 +590,7 @@ fn build_module_tables(
             | TableType::IDENTIFIERS
             | TableType::ADDRESS_IDENTIFIERS
             | TableType::CONSTANT_POOL
+            | TableType::METADATA
             | TableType::SIGNATURES => {
                 continue;
             }
@@ -584,7 +614,8 @@ fn build_script_tables(
             | TableType::SIGNATURES
             | TableType::IDENTIFIERS
             | TableType::ADDRESS_IDENTIFIERS
-            | TableType::CONSTANT_POOL => {
+            | TableType::CONSTANT_POOL
+            | TableType::METADATA => {
                 continue;
             }
             TableType::STRUCT_DEFS
@@ -781,7 +812,38 @@ fn load_constant_pool(
 /// Build a single `Constant`
 fn load_constant(cursor: &mut VersionedCursor) -> BinaryLoaderResult<Constant> {
     let type_ = load_signature_token(cursor)?;
-    let size = load_constant_size(cursor)?;
+    let data = load_byte_blob(cursor, load_constant_size)?;
+    Ok(Constant { type_, data })
+}
+
+/// Builds a metadata vector.
+fn load_metadata(
+    binary: &VersionedBinary,
+    table: &Table,
+    metadata: &mut Vec<Metadata>,
+) -> BinaryLoaderResult<()> {
+    let start = table.offset as usize;
+    let end = start + table.count as usize;
+    let mut cursor = binary.new_cursor(start, end);
+    while cursor.position() < u64::from(table.count) {
+        metadata.push(load_metadata_entry(&mut cursor)?)
+    }
+    Ok(())
+}
+
+/// Build a single metadata entry.
+fn load_metadata_entry(cursor: &mut VersionedCursor) -> BinaryLoaderResult<Metadata> {
+    let key = load_byte_blob(cursor, load_metadata_key_size)?;
+    let value = load_byte_blob(cursor, load_metadata_value_size)?;
+    Ok(Metadata { key, value })
+}
+
+/// Helper to load a byte blob with specific size loader.
+fn load_byte_blob(
+    cursor: &mut VersionedCursor,
+    size_loader: impl Fn(&mut VersionedCursor) -> BinaryLoaderResult<usize>,
+) -> BinaryLoaderResult<Vec<u8>> {
+    let size = size_loader(cursor)?;
     let mut data: Vec<u8> = vec![0u8; size];
     let count = cursor.read(&mut data).map_err(|_| {
         PartialVMError::new(StatusCode::MALFORMED)
@@ -789,9 +851,9 @@ fn load_constant(cursor: &mut VersionedCursor) -> BinaryLoaderResult<Constant> {
     })?;
     if count != size {
         return Err(PartialVMError::new(StatusCode::MALFORMED)
-            .with_message("Bad Constant data size".to_string()));
+            .with_message("Bad byte blob size".to_string()));
     }
-    Ok(Constant { type_, data })
+    Ok(data)
 }
 
 /// Builds the `SignaturePool`.
@@ -1419,6 +1481,7 @@ impl TableType {
             0xD => Ok(TableType::FIELD_HANDLE),
             0xE => Ok(TableType::FIELD_INST),
             0xF => Ok(TableType::FRIEND_DECLS),
+            0x10 => Ok(TableType::METADATA),
             _ => Err(PartialVMError::new(StatusCode::UNKNOWN_TABLE_TYPE)),
         }
     }

--- a/language/move-binary-format/src/file_format.rs
+++ b/language/move-binary-format/src/file_format.rs
@@ -37,6 +37,7 @@ use move_core_types::{
     account_address::AccountAddress,
     identifier::{IdentStr, Identifier},
     language_storage::ModuleId,
+    metadata::Metadata,
     vm_status::StatusCode,
 };
 #[cfg(any(test, feature = "fuzzing"))]
@@ -1715,11 +1716,12 @@ pub struct CompiledScript {
     /// Constant pool. The constant values used in the transaction.
     pub constant_pool: ConstantPool,
 
+    pub metadata: Vec<Metadata>,
+
+    pub code: CodeUnit,
     pub type_parameters: Vec<AbilitySet>,
 
     pub parameters: SignatureIndex,
-
-    pub code: CodeUnit,
 }
 
 impl CompiledScript {
@@ -1766,6 +1768,8 @@ pub struct CompiledModule {
     pub address_identifiers: AddressIdentifierPool,
     /// Constant pool. The constant values used in the module.
     pub constant_pool: ConstantPool,
+
+    pub metadata: Vec<Metadata>,
 
     /// Types defined in this module.
     pub struct_defs: Vec<StructDefinition>,
@@ -1817,6 +1821,7 @@ impl Arbitrary for CompiledScript {
                         identifiers,
                         address_identifiers,
                         constant_pool: vec![],
+                        metadata: vec![],
                         type_parameters,
                         parameters,
                         code,
@@ -1877,6 +1882,7 @@ impl Arbitrary for CompiledModule {
                         identifiers,
                         address_identifiers,
                         constant_pool: vec![],
+                        metadata: vec![],
                         struct_defs,
                         function_defs,
                     }
@@ -1947,6 +1953,7 @@ pub fn empty_module() -> CompiledModule {
         identifiers: vec![self_module_name().to_owned()],
         address_identifiers: vec![AccountAddress::ZERO],
         constant_pool: vec![],
+        metadata: vec![],
         function_defs: vec![],
         struct_defs: vec![],
         struct_handles: vec![],
@@ -2027,6 +2034,7 @@ pub fn empty_script() -> CompiledScript {
         identifiers: vec![],
         address_identifiers: vec![],
         constant_pool: vec![],
+        metadata: vec![],
 
         type_parameters: vec![],
         parameters: SignatureIndex(0),

--- a/language/move-binary-format/src/file_format_common.rs
+++ b/language/move-binary-format/src/file_format_common.rs
@@ -61,6 +61,9 @@ pub const IDENTIFIER_SIZE_MAX: u64 = 65535;
 
 pub const CONSTANT_SIZE_MAX: u64 = 65535;
 
+pub const METADATA_KEY_SIZE_MAX: u64 = 1023;
+pub const METADATA_VALUE_SIZE_MAX: u64 = 65535;
+
 pub const SIGNATURE_SIZE_MAX: u64 = 255;
 
 pub const ACQUIRES_COUNT_MAX: u64 = 255;
@@ -96,6 +99,7 @@ pub enum TableType {
     FIELD_HANDLE            = 0xD,
     FIELD_INST              = 0xE,
     FRIEND_DECLS            = 0xF,
+    METADATA                = 0x10,
 }
 
 /// Constants for signature blob values.
@@ -376,10 +380,15 @@ pub const VERSION_4: u32 = 4;
 
 /// Version 5: changes compared with version 4
 ///  +/- script and public(script) verification is now adapter specific
+///  + metadata
 pub const VERSION_5: u32 = 5;
 
 // Mark which version is the latest version
 pub const VERSION_MAX: u32 = VERSION_5;
+
+// Mark which oldest version is supported.
+// TODO(#145): finish v4 compatibility; as of now, only metadata is implemented
+pub const VERSION_MIN: u32 = VERSION_5;
 
 pub(crate) mod versioned_data {
     use crate::{errors::*, file_format_common::*};

--- a/language/move-binary-format/src/proptest_types.rs
+++ b/language/move-binary-format/src/proptest_types.rs
@@ -16,6 +16,7 @@ use proptest::{
 
 mod constants;
 mod functions;
+mod metadata;
 mod signature;
 mod types;
 
@@ -25,6 +26,7 @@ use functions::{
 };
 
 use crate::proptest_types::{
+    metadata::MetadataGen,
     signature::SignatureGen,
     types::{StDefnMaterializeState, StructDefinitionGen, StructHandleGen},
 };
@@ -131,6 +133,7 @@ impl CompiledModuleStrategyGen {
         let address_pool_strat = btree_set(any::<AccountAddress>(), 1..=self.size);
         let identifiers_strat = btree_set(any::<Identifier>(), 5..=self.size + 5);
         let constant_pool_strat = ConstantPoolGen::strategy(0..=self.size, 0..=self.size);
+        let metadata_strat = MetadataGen::strategy(0..=self.size);
 
         // The number of PropIndex instances in each tuple represents the number of pointers out
         // from an instance of that particular kind of node.
@@ -200,7 +203,12 @@ impl CompiledModuleStrategyGen {
         // Note that prop_test only allows a tuple of length up to 10
         (
             self_idx_strat,
-            (address_pool_strat, identifiers_strat, constant_pool_strat),
+            (
+                address_pool_strat,
+                identifiers_strat,
+                constant_pool_strat,
+                metadata_strat,
+            ),
             module_handles_strat,
             (struct_handles_strat, struct_defs_strat),
             random_sigs_strat,
@@ -210,7 +218,7 @@ impl CompiledModuleStrategyGen {
             .prop_map(
                 |(
                     self_idx_gen,
-                    (address_identifier_gens, identifier_gens, constant_pool_gen),
+                    (address_identifier_gens, identifier_gens, constant_pool_gen, metdata_gen),
                     module_handles_gen,
                     (struct_handle_gens, struct_def_gens),
                     random_sigs_gens,
@@ -225,6 +233,7 @@ impl CompiledModuleStrategyGen {
                     let identifiers_len = identifiers.len();
                     let constant_pool = constant_pool_gen.constant_pool();
                     let constant_pool_len = constant_pool.len();
+                    let metadata = metdata_gen.metadata();
 
                     //
                     // module handles
@@ -377,6 +386,7 @@ impl CompiledModuleStrategyGen {
                         identifiers,
                         address_identifiers,
                         constant_pool,
+                        metadata,
                     }
                 },
             )

--- a/language/move-binary-format/src/proptest_types/metadata.rs
+++ b/language/move-binary-format/src/proptest_types/metadata.rs
@@ -1,0 +1,36 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use move_core_types::metadata::Metadata;
+use proptest::{
+    arbitrary::any,
+    collection::{btree_set, vec, SizeRange},
+    strategy::Strategy,
+};
+
+// A metadata generation strategy.
+#[derive(Clone, Debug)]
+pub struct MetadataGen {
+    blobs: Vec<Vec<u8>>,
+}
+
+impl MetadataGen {
+    // Return a `Strategy` that builds Metadata vectors based on the given size.
+    pub fn strategy(blob_size: impl Into<SizeRange>) -> impl Strategy<Value = Self> {
+        btree_set(vec(any::<u8>(), 0..=20), blob_size).prop_map(|blobs| Self {
+            blobs: blobs.into_iter().collect(),
+        })
+    }
+
+    // Return the metadata
+    pub fn metadata(self) -> Vec<Metadata> {
+        let mut metadata = vec![];
+        for blob in self.blobs {
+            metadata.push(Metadata {
+                key: blob.clone(),
+                value: blob,
+            })
+        }
+        metadata
+    }
+}

--- a/language/move-binary-format/src/serializer.rs
+++ b/language/move-binary-format/src/serializer.rs
@@ -6,17 +6,37 @@
 //! This module exposes two entry points for serialization of `CompiledScript` and
 //! `CompiledModule`. The entry points are exposed on the main structs `CompiledScript` and
 //! `CompiledModule`.
+//!
+//! **Versioning**
+//!
+//! A note about versioning. The serializer supports writing file_format versions >= v5. The
+//! entry points get the version number passed in and generate compatible formats. However,
+//! not all of the newer language constructs might be supported for older versions, leading to
+//! serialization errors.
 
 use crate::{file_format::*, file_format_common::*};
 use anyhow::{bail, Result};
-use move_core_types::{account_address::AccountAddress, identifier::Identifier};
+use move_core_types::{
+    account_address::AccountAddress, identifier::Identifier, metadata::Metadata,
+};
 
 impl CompiledScript {
     /// Serializes a `CompiledScript` into a binary. The mutable `Vec<u8>` will contain the
     /// binary blob on return.
     pub fn serialize(&self, binary: &mut Vec<u8>) -> Result<()> {
+        self.serialize_for_version(None, binary)
+    }
+
+    /// Serialize into binary, at given version.
+    pub fn serialize_for_version(
+        &self,
+        bytecode_version: Option<u32>,
+        binary: &mut Vec<u8>,
+    ) -> Result<()> {
+        let version = bytecode_version.unwrap_or(VERSION_MAX);
+        validate_version(version)?;
         let mut binary_data = BinaryData::from(binary.clone());
-        let mut ser = ScriptSerializer::new(VERSION_MAX);
+        let mut ser = ScriptSerializer::new(version);
         let mut temp = BinaryData::new();
 
         ser.common.serialize_common_tables(&mut temp, self)?;
@@ -135,6 +155,14 @@ fn serialize_constant_size(binary: &mut BinaryData, len: usize) -> Result<()> {
     write_as_uleb128(binary, len as u64, CONSTANT_SIZE_MAX)
 }
 
+fn serialize_metadata_key_size(binary: &mut BinaryData, len: usize) -> Result<()> {
+    write_as_uleb128(binary, len as u64, METADATA_KEY_SIZE_MAX)
+}
+
+fn serialize_metadata_value_size(binary: &mut BinaryData, len: usize) -> Result<()> {
+    write_as_uleb128(binary, len as u64, METADATA_VALUE_SIZE_MAX)
+}
+
 fn serialize_field_count(binary: &mut BinaryData, len: usize) -> Result<()> {
     write_as_uleb128(binary, len as u64, FIELD_COUNT_MAX)
 }
@@ -171,12 +199,36 @@ fn serialize_local_index(binary: &mut BinaryData, idx: u8) -> Result<()> {
     write_as_uleb128(binary, idx, LOCAL_INDEX_MAX)
 }
 
+fn validate_version(version: u32) -> Result<()> {
+    if !(VERSION_MIN..=VERSION_MAX).contains(&version) {
+        bail!(
+            "The requested bytecode version {} is not supported. Only {} to {} are.",
+            version,
+            VERSION_MIN,
+            VERSION_MAX
+        )
+    } else {
+        Ok(())
+    }
+}
+
 impl CompiledModule {
     /// Serializes a `CompiledModule` into a binary. The mutable `Vec<u8>` will contain the
     /// binary blob on return.
     pub fn serialize(&self, binary: &mut Vec<u8>) -> Result<()> {
+        self.serialize_for_version(None, binary)
+    }
+
+    /// Serialize into binary, at given version.
+    pub fn serialize_for_version(
+        &self,
+        bytecode_version: Option<u32>,
+        binary: &mut Vec<u8>,
+    ) -> Result<()> {
+        let version = bytecode_version.unwrap_or(VERSION_MAX);
+        validate_version(version)?;
         let mut binary_data = BinaryData::from(binary.clone());
-        let mut ser = ModuleSerializer::new(VERSION_MAX);
+        let mut ser = ModuleSerializer::new(version);
         let mut temp = BinaryData::new();
         ser.serialize_tables(&mut temp, self)?;
         if temp.len() > u32::max_value() as usize {
@@ -217,6 +269,7 @@ struct CommonSerializer {
     identifiers: (u32, u32),
     address_identifiers: (u32, u32),
     constant_pool: (u32, u32),
+    metadata: (u32, u32),
 }
 
 /// Holds data to compute the header of a module binary.
@@ -283,6 +336,7 @@ trait CommonTables {
     fn get_address_identifiers(&self) -> &[AccountAddress];
     fn get_constant_pool(&self) -> &[Constant];
     fn get_signatures(&self) -> &[Signature];
+    fn get_metadata(&self) -> &[Metadata];
 }
 
 impl CommonTables for CompiledScript {
@@ -317,6 +371,10 @@ impl CommonTables for CompiledScript {
     fn get_signatures(&self) -> &[Signature] {
         &self.signatures
     }
+
+    fn get_metadata(&self) -> &[Metadata] {
+        &self.metadata
+    }
 }
 
 impl CommonTables for CompiledModule {
@@ -350,6 +408,10 @@ impl CommonTables for CompiledModule {
 
     fn get_signatures(&self) -> &[Signature] {
         &self.signatures
+    }
+
+    fn get_metadata(&self) -> &[Metadata] {
+        &self.metadata
     }
 }
 
@@ -457,11 +519,25 @@ fn serialize_address(binary: &mut BinaryData, address: &AccountAddress) -> Resul
 /// - `data` bytes in increasing index order
 fn serialize_constant(binary: &mut BinaryData, constant: &Constant) -> Result<()> {
     serialize_signature_token(binary, &constant.type_)?;
-    serialize_constant_size(binary, constant.data.len())?;
-    for byte in &constant.data {
+    serialize_byte_blob(binary, serialize_constant_size, &constant.data)
+}
+
+/// Serialize a metadata entry.
+fn serialize_metadata_entry(binary: &mut BinaryData, metadata: &Metadata) -> Result<()> {
+    serialize_byte_blob(binary, serialize_metadata_key_size, &metadata.key)?;
+    serialize_byte_blob(binary, serialize_metadata_value_size, &metadata.value)
+}
+
+/// Serialize a byte blob.
+fn serialize_byte_blob(
+    binary: &mut BinaryData,
+    size_serializer: impl Fn(&mut BinaryData, usize) -> Result<()>,
+    blob: &[u8],
+) -> Result<()> {
+    size_serializer(binary, blob.len())?;
+    for byte in blob {
         binary.push(*byte)?;
     }
-
     Ok(())
 }
 
@@ -908,6 +984,7 @@ impl CommonSerializer {
             identifiers: (0, 0),
             address_identifiers: (0, 0),
             constant_pool: (0, 0),
+            metadata: (0, 0),
         }
     }
 
@@ -969,6 +1046,15 @@ impl CommonSerializer {
             self.constant_pool.0,
             self.constant_pool.1,
         )?;
+        if self.major_version >= VERSION_5 {
+            // Metadata was not introduced before v5, so do not generate it for lower versions.
+            serialize_table_index(
+                binary,
+                TableType::METADATA,
+                self.metadata.0,
+                self.metadata.1,
+            )?;
+        }
         Ok(())
     }
 
@@ -987,6 +1073,9 @@ impl CommonSerializer {
         self.serialize_identifiers(binary, tables.get_identifiers())?;
         self.serialize_address_identifiers(binary, tables.get_address_identifiers())?;
         self.serialize_constants(binary, tables.get_constant_pool())?;
+        if self.major_version >= VERSION_5 {
+            self.serialize_metadata(binary, tables.get_metadata())?;
+        }
         Ok(())
     }
 
@@ -1109,6 +1198,19 @@ impl CommonSerializer {
                 serialize_constant(binary, constant)?;
             }
             self.constant_pool.1 = checked_calculate_table_size(binary, self.constant_pool.0)?;
+        }
+        Ok(())
+    }
+
+    /// Serializes metadata.
+    fn serialize_metadata(&mut self, binary: &mut BinaryData, metadata: &[Metadata]) -> Result<()> {
+        if !metadata.is_empty() {
+            self.table_count += 1;
+            self.metadata.0 = check_index_in_binary(binary.len())?;
+            for entry in metadata {
+                serialize_metadata_entry(binary, entry)?;
+            }
+            self.metadata.1 = checked_calculate_table_size(binary, self.metadata.0)?;
         }
         Ok(())
     }

--- a/language/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/generic_ops_tests.rs
+++ b/language/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/generic_ops_tests.rs
@@ -170,6 +170,7 @@ fn make_module() -> CompiledModule {
                 data: AccountAddress::random().to_vec(),
             },
         ],
+        metadata: vec![],
         field_handles: vec![],
         friend_decls: vec![],
         struct_def_instantiations: vec![],

--- a/language/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/signature_tests.rs
+++ b/language/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/signature_tests.rs
@@ -93,6 +93,7 @@ fn no_verify_locals_good() {
         ],
         address_identifiers: vec![AccountAddress::new([0; AccountAddress::LENGTH])],
         constant_pool: vec![],
+        metadata: vec![],
         struct_defs: vec![],
         function_defs: vec![
             FunctionDefinition {

--- a/language/move-command-line-common/src/env.rs
+++ b/language/move-command-line-common/src/env.rs
@@ -1,6 +1,18 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+/// An environment variable which can be set to cause the move compiler to generate
+/// file formats at a given version. Only version v5 and greater are supported.
+const BYTECODE_VERSION_ENV_VAR: &str = "MOVE_BYTECODE_VERSION";
+
+/// Get the bytecode version from the environment variable.
+// TODO: This should be configurable via toml and command line flags. See also #129.
+pub fn get_bytecode_version_from_env() -> Option<u32> {
+    std::env::var(BYTECODE_VERSION_ENV_VAR)
+        .ok()
+        .and_then(|s| s.parse::<u32>().ok())
+}
+
 pub fn read_env_var(v: &str) -> String {
     std::env::var(v).unwrap_or_else(|_| String::new())
 }

--- a/language/move-compiler/src/bin/move-build.rs
+++ b/language/move-compiler/src/bin/move-build.rs
@@ -77,10 +77,17 @@ pub fn main() -> anyhow::Result<()> {
 
     let interface_files_dir = format!("{}/generated_interface_files", out_dir);
     let named_addr_map = verify_and_create_named_address_mapping(named_addresses)?;
+    let bytecode_version = flags.bytecode_version();
     let (files, compiled_units) =
         move_compiler::Compiler::from_files(source_files, dependencies, named_addr_map)
             .set_interface_files_dir(interface_files_dir)
             .set_flags(flags)
             .build_and_report()?;
-    move_compiler::output_compiled_units(emit_source_map, files, compiled_units, &out_dir)
+    move_compiler::output_compiled_units(
+        bytecode_version,
+        emit_source_map,
+        files,
+        compiled_units,
+        &out_dir,
+    )
 }

--- a/language/move-compiler/src/command_line/compiler.rs
+++ b/language/move-compiler/src/command_line/compiler.rs
@@ -535,6 +535,7 @@ pub fn sanity_check_compiled_units(
 
 /// Given a file map and a set of compiled programs, saves the compiled programs to disk
 pub fn output_compiled_units(
+    bytecode_version: Option<u32>,
     emit_source_maps: bool,
     files: FilesSourceText,
     compiled_units: Vec<AnnotatedCompiledUnit>,
@@ -557,7 +558,7 @@ pub fn output_compiled_units(
             }
 
             $path.set_extension(MOVE_COMPILED_EXTENSION);
-            fs::write($path.as_path(), &$unit.serialize())?
+            fs::write($path.as_path(), &$unit.serialize(bytecode_version))?
         }};
     }
 

--- a/language/move-compiler/src/command_line/mod.rs
+++ b/language/move-compiler/src/command_line/mod.rs
@@ -24,6 +24,8 @@ pub const TEST_SHORT: char = 't';
 
 pub const FLAVOR: &str = "flavor";
 
+pub const BYTECODE_VERSION: &str = "bytecode-version";
+
 pub const COLOR_MODE_ENV_VAR: &str = "COLOR_MODE";
 
 pub const MOVE_COMPILED_INTERFACES_DIR: &str = "mv_interfaces";

--- a/language/move-compiler/src/compiled_unit.rs
+++ b/language/move-compiler/src/compiled_unit.rs
@@ -188,15 +188,15 @@ impl CompiledUnit {
         }
     }
 
-    pub fn serialize(&self) -> Vec<u8> {
+    pub fn serialize(&self, bytecode_version: Option<u32>) -> Vec<u8> {
         let mut serialized = Vec::<u8>::new();
         match self {
-            Self::Module(NamedCompiledModule { module, .. }) => {
-                module.serialize(&mut serialized).unwrap()
-            }
-            Self::Script(NamedCompiledScript { script, .. }) => {
-                script.serialize(&mut serialized).unwrap()
-            }
+            Self::Module(NamedCompiledModule { module, .. }) => module
+                .serialize_for_version(bytecode_version, &mut serialized)
+                .unwrap(),
+            Self::Script(NamedCompiledScript { script, .. }) => script
+                .serialize_for_version(bytecode_version, &mut serialized)
+                .unwrap(),
         };
         serialized
     }

--- a/language/move-compiler/src/shared/mod.rs
+++ b/language/move-compiler/src/shared/mod.rs
@@ -275,6 +275,12 @@ pub struct Flags {
     )]
     flavor: String,
 
+    /// Bytecode version.
+    #[clap(
+        long = cli::BYTECODE_VERSION,
+    )]
+    bytecode_version: Option<u32>,
+
     /// If set, source files will not shadow dependency files. If the same file is passed to both,
     /// an error will be raised
     #[clap(
@@ -291,6 +297,7 @@ impl Flags {
             test: false,
             shadow: false,
             flavor: "".to_string(),
+            bytecode_version: None,
         }
     }
 
@@ -299,6 +306,7 @@ impl Flags {
             test: true,
             shadow: false,
             flavor: "".to_string(),
+            bytecode_version: None,
         }
     }
 
@@ -330,6 +338,10 @@ impl Flags {
 
     pub fn has_flavor(&self, flavor: &str) -> bool {
         self.flavor == flavor
+    }
+
+    pub fn bytecode_version(&self) -> Option<u32> {
+        self.bytecode_version
     }
 }
 

--- a/language/move-core/types/src/lib.rs
+++ b/language/move-core/types/src/lib.rs
@@ -10,6 +10,7 @@ pub mod errmap;
 pub mod gas_schedule;
 pub mod identifier;
 pub mod language_storage;
+pub mod metadata;
 pub mod move_resource;
 pub mod parser;
 #[cfg(any(test, feature = "fuzzing"))]

--- a/language/move-core/types/src/metadata.rs
+++ b/language/move-core/types/src/metadata.rs
@@ -1,0 +1,11 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+/// Representation of metadata,
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct Metadata {
+    /// The key identifying the type of metadata.
+    pub key: Vec<u8>,
+    /// The value of the metadata.
+    pub value: Vec<u8>,
+}

--- a/language/move-ir-compiler/move-ir-to-bytecode/src/compiler.rs
+++ b/language/move-ir-compiler/move-ir-to-bytecode/src/compiler.rs
@@ -381,6 +381,7 @@ pub fn compile_script<'a>(
         identifiers,
         address_identifiers,
         constant_pool,
+        metadata: vec![],
 
         type_parameters: sig.type_parameters,
         parameters: parameters_sig_idx,
@@ -477,6 +478,7 @@ pub fn compile_module<'a>(
         identifiers,
         address_identifiers,
         constant_pool,
+        metadata: vec![],
         struct_defs,
         function_defs,
     };
@@ -555,6 +557,7 @@ fn compile_explicit_dependency_declarations(
             identifiers,
             address_identifiers,
             constant_pool,
+            metadata: vec![],
             struct_defs: vec![],
             function_defs: vec![],
         };

--- a/language/move-model/src/lib.rs
+++ b/language/move-model/src/lib.rs
@@ -414,6 +414,7 @@ fn script_into_module(compiled_script: CompiledScript) -> CompiledModule {
         identifiers: script.identifiers,
         address_identifiers: script.address_identifiers,
         constant_pool: script.constant_pool,
+        metadata: script.metadata,
 
         struct_defs: vec![],
         function_defs: vec![main_def],

--- a/language/move-vm/runtime/src/unit_tests/vm_arguments_tests.rs
+++ b/language/move-vm/runtime/src/unit_tests/vm_arguments_tests.rs
@@ -52,6 +52,7 @@ fn make_script(parameters: Signature) -> Vec<u8> {
         identifiers: vec![],
         address_identifiers: vec![],
         constant_pool: vec![],
+        metadata: vec![],
 
         type_parameters: vec![],
         parameters: parameters_idx,
@@ -115,6 +116,7 @@ fn make_script_with_non_linking_structs(parameters: Signature) -> Vec<u8> {
         ],
         address_identifiers: vec![AccountAddress::random()],
         constant_pool: vec![],
+        metadata: vec![],
 
         type_parameters: vec![],
         parameters: parameters_idx,
@@ -190,6 +192,7 @@ fn make_module_with_function(
         ],
         address_identifiers: vec![AccountAddress::random()],
         constant_pool: vec![],
+        metadata: vec![],
 
         struct_defs: vec![StructDefinition {
             struct_handle: StructHandleIndex(0),

--- a/language/tools/move-cli/src/base/commands/compile.rs
+++ b/language/tools/move-cli/src/base/commands/compile.rs
@@ -1,10 +1,10 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::BTreeMap;
-
 use anyhow::Result;
+use move_command_line_common::env::get_bytecode_version_from_env;
 use move_compiler::{self, shared::NumericalAddress, Compiler, Flags};
+use std::collections::BTreeMap;
 
 /// Compile the user modules in `sources` against the dependencies in `interface_files`, placing
 /// the resulting binaries in `output_dir`.
@@ -24,5 +24,11 @@ pub fn compile(
         Compiler::from_files(sources, interface_files, named_address_mapping)
             .set_flags(Flags::empty().set_sources_shadow_deps(sources_shadow_deps))
             .build_and_report()?;
-    move_compiler::output_compiled_units(emit_source_map, files, compiled_units, output_dir)
+    move_compiler::output_compiled_units(
+        get_bytecode_version_from_env(),
+        emit_source_map,
+        files,
+        compiled_units,
+        output_dir,
+    )
 }

--- a/language/tools/move-cli/src/sandbox/commands/publish.rs
+++ b/language/tools/move-cli/src/sandbox/commands/publish.rs
@@ -9,6 +9,7 @@ use crate::{
     NativeFunctionRecord,
 };
 use anyhow::{bail, Result};
+use move_command_line_common::env::get_bytecode_version_from_env;
 use move_core_types::gas_schedule::CostTable;
 use move_package::compilation::compiled_package::CompiledPackage;
 use move_vm_runtime::move_vm::MoveVM;
@@ -51,6 +52,8 @@ pub fn publish(
         }
     }
 
+    let bytecode_version = get_bytecode_version_from_env();
+
     // use the the publish_module API from the VM if we do not allow breaking changes
     if !ignore_breaking_changes {
         let vm = MoveVM::new(natives).unwrap();
@@ -61,7 +64,7 @@ pub fn publish(
         match override_ordering {
             None => {
                 for unit in package.root_modules() {
-                    let module_bytes = unit.unit.serialize();
+                    let module_bytes = unit.unit.serialize(bytecode_version);
                     let id = module(&unit.unit)?.self_id();
                     let sender = *id.address();
 
@@ -86,7 +89,7 @@ pub fn publish(
                     match module_map.get(name) {
                         None => bail!("Invalid module name in publish ordering: {}", name),
                         Some(unit) => {
-                            let module_bytes = unit.unit.serialize();
+                            let module_bytes = unit.unit.serialize(bytecode_version);
                             module_bytes_vec.push(module_bytes);
                             if sender_opt.is_none() {
                                 sender_opt = Some(*module(&unit.unit)?.self_id().address());
@@ -132,7 +135,7 @@ pub fn publish(
         let mut serialized_modules = vec![];
         for unit in package.all_modules() {
             let id = module(&unit.unit)?.self_id();
-            let module_bytes = unit.unit.serialize();
+            let module_bytes = unit.unit.serialize(bytecode_version);
             serialized_modules.push((id, module_bytes));
         }
         state.save_modules(&serialized_modules)?;

--- a/language/tools/move-cli/src/sandbox/commands/run.rs
+++ b/language/tools/move-cli/src/sandbox/commands/run.rs
@@ -10,6 +10,7 @@ use crate::{
 };
 use anyhow::{anyhow, bail, Result};
 use move_binary_format::file_format::CompiledModule;
+use move_command_line_common::env::get_bytecode_version_from_env;
 use move_core_types::{
     account_address::AccountAddress,
     errmap::ErrorMapping,
@@ -41,6 +42,7 @@ pub fn run(
     if !script_path.exists() {
         bail!("Script file {:?} does not exist", script_path)
     };
+    let bytecode_version = get_bytecode_version_from_env();
 
     let bytecode = if is_bytecode_file(script_path) {
         assert!(
@@ -59,7 +61,7 @@ move run` must be applied to a module inside `storage/`",
             .find(|unit| unit.unit.source_map().check(&file_contents));
         // script source file; package is already compiled so load it up
         match script_opt {
-            Some(unit) => unit.unit.serialize(),
+            Some(unit) => unit.unit.serialize(bytecode_version),
             None => bail!("Unable to find script in file {:?}", script_path),
         }
     };

--- a/language/tools/move-cli/src/sandbox/utils/package_context.rs
+++ b/language/tools/move-cli/src/sandbox/utils/package_context.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use crate::{sandbox::utils::OnDiskStateView, DEFAULT_BUILD_DIR};
 use anyhow::Result;
+use move_command_line_common::env::get_bytecode_version_from_env;
 use move_package::{compilation::compiled_package::CompiledPackage, BuildConfig};
 use std::path::{Path, PathBuf};
 
@@ -32,6 +33,7 @@ impl PackageContext {
     /// to be run before every command that needs a state view, i.e., `publish`, `run`,
     /// `view`, and `doctor`.
     pub fn prepare_state(&self, storage_dir: &Path) -> Result<OnDiskStateView> {
+        let bytecode_version = get_bytecode_version_from_env();
         let state = OnDiskStateView::create(self.build_dir.as_path(), storage_dir)?;
 
         // preload the storage with library modules (if such modules do not exist yet)
@@ -49,7 +51,7 @@ impl PackageContext {
         for module in new_modules {
             let self_id = module.self_id();
             let mut module_bytes = vec![];
-            module.serialize(&mut module_bytes)?;
+            module.serialize_for_version(bytecode_version, &mut module_bytes)?;
             serialized_modules.push((self_id, module_bytes));
         }
         state.save_modules(&serialized_modules)?;

--- a/language/tools/move-package/src/compilation/compiled_package.rs
+++ b/language/tools/move-package/src/compilation/compiled_package.rs
@@ -16,8 +16,12 @@ use move_abigen::{Abigen, AbigenOptions};
 use move_binary_format::file_format::{CompiledModule, CompiledScript};
 use move_bytecode_source_map::utils::source_map_from_file;
 use move_bytecode_utils::Modules;
-use move_command_line_common::files::{
-    extension_equals, find_filenames, MOVE_COMPILED_EXTENSION, MOVE_EXTENSION, SOURCE_MAP_EXTENSION,
+use move_command_line_common::{
+    env::get_bytecode_version_from_env,
+    files::{
+        extension_equals, find_filenames, MOVE_COMPILED_EXTENSION, MOVE_EXTENSION,
+        SOURCE_MAP_EXTENSION,
+    },
 };
 use move_compiler::{
     compiled_unit::{
@@ -341,7 +345,10 @@ impl OnDiskCompiledPackage {
             category_dir
                 .join(&file_path)
                 .with_extension(MOVE_COMPILED_EXTENSION),
-            compiled_unit.unit.serialize().as_slice(),
+            compiled_unit
+                .unit
+                .serialize(get_bytecode_version_from_env())
+                .as_slice(),
         )?;
         self.save_under(
             CompiledPackageLayout::SourceMaps
@@ -574,7 +581,11 @@ impl CompiledPackage {
             }
 
             if resolution_graph.build_options.generate_abis {
-                compiled_abis = Some(Self::build_abis(&model, &root_compiled_units));
+                compiled_abis = Some(Self::build_abis(
+                    get_bytecode_version_from_env(),
+                    &model,
+                    &root_compiled_units,
+                ));
             }
         };
 
@@ -717,14 +728,21 @@ impl CompiledPackage {
     }
 
     fn build_abis(
+        bytecode_version: Option<u32>,
         model: &GlobalEnv,
         compiled_units: &[CompiledUnitWithSource],
     ) -> Vec<(String, Vec<u8>)> {
         let bytecode_map: BTreeMap<_, _> = compiled_units
             .iter()
             .map(|unit| match &unit.unit {
-                CompiledUnit::Script(script) => (script.name.to_string(), unit.unit.serialize()),
-                CompiledUnit::Module(module) => (module.name.to_string(), unit.unit.serialize()),
+                CompiledUnit::Script(script) => (
+                    script.name.to_string(),
+                    unit.unit.serialize(bytecode_version),
+                ),
+                CompiledUnit::Module(module) => (
+                    module.name.to_string(),
+                    unit.unit.serialize(bytecode_version),
+                ),
             })
             .collect();
         let abi_options = AbigenOptions {


### PR DESCRIPTION
## Motivation
This PR adds a generic representation of metadata into the file format.

This is a breaking change. While it is downwards compatible, it is not upwards compatible. That is, old code cannot read the new file format. This is unfortunate as in cases like this we could have upwards compatibility, but the current code is not setup for this. Therefore we want to do this as soon as possible and before more Move code hits mainnet.

Metadata can be used for multiple things:

Attaching attributes so a custom verifier can see them in the bytecode (e.g. for verifying which structs are allowed on transactions)
Representing extended analysis results, e.g. read-write sets.
Representing source line info for stack traces (as solidity does)
etc.
The design is rather simple: metadata is represented as a vector of pairs of a key and a value, both byte blobs. A convention to organize keys is to be defined outside of the file format, one approach is to make them 32 byte hashes over a naming scheme. For comparison, in EVM bytecode there is only a single byte blob for metadata. The keys we have allow to search the metadata for a specific value without the need of decoding it all.

## Test Plan
CI/CD tests are covered. 
