### PR TITLE
[move-compiler] Allow 'vector' as a module name #151_79

### DIFF
--- a/language/move-compiler/src/expansion/translate.rs
+++ b/language/move-compiler/src/expansion/translate.rs
@@ -402,7 +402,7 @@ fn module_(
     assert!(context.address == None);
     assert!(address == None);
     set_sender_address(context, &name, module_address);
-    let _ = check_restricted_name_all_cases(context, "module", &name.0);
+    let _ = check_restricted_name_all_cases(context, NameCase::Module, &name.0);
     if name.value().starts_with(|c| c == '_') {
         let msg = format!(
             "Invalid module name '{}'. Module names cannot start with '_'",
@@ -868,7 +868,8 @@ fn use_(context: &mut Context, acc: &mut AliasMapBuilder, u: P::UseDecl) {
     macro_rules! add_module_alias {
         ($ident:expr, $alias_opt:expr) => {{
             let alias: Name = $alias_opt.unwrap_or_else(|| $ident.value.module.0.clone());
-            if let Err(()) = check_restricted_name_all_cases(context, "module alias", &alias) {
+            if let Err(()) = check_restricted_name_all_cases(context, NameCase::ModuleAlias, &alias)
+            {
                 return;
             }
 
@@ -2436,7 +2437,7 @@ fn check_valid_address_name_(
     use P::LeadingNameAccess_ as LN;
     match ln_ {
         LN::AnonymousAddress(_) => Ok(()),
-        LN::Name(n) => check_restricted_name_all_cases_(env, "address", n),
+        LN::Name(n) => check_restricted_name_all_cases_(env, NameCase::Address, n),
     }
 }
 
@@ -2454,7 +2455,7 @@ fn check_valid_local_name(context: &mut Context, v: &Var) {
             .env
             .add_diag(diag!(Declarations::InvalidName, (v.loc(), msg)));
     }
-    let _ = check_restricted_name_all_cases(context, "variable", &v.0);
+    let _ = check_restricted_name_all_cases(context, NameCase::Variable, &v.0);
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -2466,12 +2467,44 @@ enum ModuleMemberKind {
 }
 
 impl ModuleMemberKind {
-    pub fn case(&self) -> &'static str {
+    fn case(self) -> NameCase {
         match self {
-            ModuleMemberKind::Function => "function",
-            ModuleMemberKind::Constant => "constant",
-            ModuleMemberKind::Struct => "struct",
-            ModuleMemberKind::Schema => "schema",
+            ModuleMemberKind::Constant => NameCase::Constant,
+            ModuleMemberKind::Function => NameCase::Function,
+            ModuleMemberKind::Struct => NameCase::Struct,
+            ModuleMemberKind::Schema => NameCase::Schema,
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+enum NameCase {
+    Constant,
+    Function,
+    Struct,
+    Schema,
+    Module,
+    ModuleMemberAlias(ModuleMemberKind),
+    ModuleAlias,
+    Variable,
+    Address,
+}
+
+impl NameCase {
+    const fn name(&self) -> &'static str {
+        match self {
+            NameCase::Constant => "constant",
+            NameCase::Function => "function",
+            NameCase::Struct => "struct",
+            NameCase::Schema => "schema",
+            NameCase::Module => "module",
+            NameCase::ModuleMemberAlias(ModuleMemberKind::Function) => "function alias",
+            NameCase::ModuleMemberAlias(ModuleMemberKind::Constant) => "constant alias",
+            NameCase::ModuleMemberAlias(ModuleMemberKind::Struct) => "struct alias",
+            NameCase::ModuleMemberAlias(ModuleMemberKind::Schema) => "schema alias",
+            NameCase::ModuleAlias => "module alias",
+            NameCase::Variable => "variable",
+            NameCase::Address => "address",
         }
     }
 }
@@ -2496,7 +2529,7 @@ fn check_valid_module_member_alias(
         context,
         member,
         &alias,
-        &format!("{} alias", member.case()),
+        NameCase::ModuleMemberAlias(member),
     ) {
         Err(()) => None,
         Ok(()) => Some(alias),
@@ -2507,7 +2540,7 @@ fn check_valid_module_member_name_impl(
     context: &mut Context,
     member: ModuleMemberKind,
     n: &Name,
-    case: &str,
+    case: NameCase,
 ) -> Result<(), ()> {
     use ModuleMemberKind as M;
     fn upper_first_letter(s: &str) -> String {
@@ -2517,15 +2550,14 @@ fn check_valid_module_member_name_impl(
             Some(c) => c.to_uppercase().collect::<String>() + chars.as_str(),
         }
     }
-    let lcase = case;
     match member {
         M::Function => {
             if n.value.starts_with(|c| c == '_') {
                 let msg = format!(
                     "Invalid {} name '{}'. {} names cannot start with '_'",
-                    lcase,
+                    case.name(),
                     n,
-                    upper_first_letter(case),
+                    upper_first_letter(case.name()),
                 );
                 context
                     .env
@@ -2537,9 +2569,9 @@ fn check_valid_module_member_name_impl(
             if !is_valid_struct_constant_or_schema_name(&n.value) {
                 let msg = format!(
                     "Invalid {} name '{}'. {} names must start with 'A'..'Z'",
-                    lcase,
+                    case.name(),
                     n,
-                    upper_first_letter(case),
+                    upper_first_letter(case.name()),
                 );
                 context
                     .env
@@ -2552,20 +2584,20 @@ fn check_valid_module_member_name_impl(
     // TODO move these names to a more central place?
     check_restricted_names(
         context,
-        lcase,
+        case,
         n,
         crate::naming::ast::BuiltinFunction_::all_names(),
     )?;
     check_restricted_names(
         context,
-        lcase,
+        case,
         n,
         crate::naming::ast::BuiltinTypeName_::all_names(),
     )?;
 
     // Restricting Self for now in the case where we ever have impls
     // Otherwise, we could allow it
-    check_restricted_name_all_cases(context, lcase, n)?;
+    check_restricted_name_all_cases(context, case, n)?;
 
     Ok(())
 }
@@ -2576,17 +2608,24 @@ pub fn is_valid_struct_constant_or_schema_name(s: &str) -> bool {
 
 // Checks for a restricted name in any decl case
 // Self and vector are not allowed
-fn check_restricted_name_all_cases(context: &mut Context, case: &str, n: &Name) -> Result<(), ()> {
+fn check_restricted_name_all_cases(
+    context: &mut Context,
+    case: NameCase,
+    n: &Name,
+) -> Result<(), ()> {
     check_restricted_name_all_cases_(context.env, case, n)
 }
 
 fn check_restricted_name_all_cases_(
     env: &mut CompilationEnv,
-    case: &str,
+    case: NameCase,
     n: &Name,
 ) -> Result<(), ()> {
     let n_str = n.value.as_str();
-    if n_str == ModuleName::SELF_NAME || n_str == crate::naming::ast::BuiltinTypeName_::VECTOR {
+    let can_be_vector = matches!(case, NameCase::Module | NameCase::ModuleAlias);
+    if n_str == ModuleName::SELF_NAME
+        || (!can_be_vector && n_str == crate::naming::ast::BuiltinTypeName_::VECTOR)
+    {
         env.add_diag(restricted_name_error(case, n.loc, n_str));
         Err(())
     } else {
@@ -2596,7 +2635,7 @@ fn check_restricted_name_all_cases_(
 
 fn check_restricted_names(
     context: &mut Context,
-    case: &str,
+    case: NameCase,
     sp!(loc, n_): &Name,
     all_names: &BTreeSet<Symbol>,
 ) -> Result<(), ()> {
@@ -2608,8 +2647,8 @@ fn check_restricted_names(
     }
 }
 
-fn restricted_name_error(case: &str, loc: Loc, restricted: &str) -> Diagnostic {
-    let a_or_an = match case.chars().next().unwrap() {
+fn restricted_name_error(case: NameCase, loc: Loc, restricted: &str) -> Diagnostic {
+    let a_or_an = match case.name().chars().next().unwrap() {
         // TODO this is not exhaustive to the indefinite article rules in English
         // but 'case' is never user generated, so it should be okay for a while/forever...
         'a' | 'e' | 'i' | 'o' | 'u' => "an",
@@ -2619,7 +2658,7 @@ fn restricted_name_error(case: &str, loc: Loc, restricted: &str) -> Diagnostic {
         "Invalid {case} name '{restricted}'. '{restricted}' is restricted and cannot be used to \
          name {a_or_an} {case}",
         a_or_an = a_or_an,
-        case = case,
+        case = case.name(),
         restricted = restricted,
     );
     diag!(NameResolution::ReservedName, (loc, msg))

--- a/language/move-compiler/src/parser/syntax.rs
+++ b/language/move-compiler/src/parser/syntax.rs
@@ -883,7 +883,10 @@ fn parse_term(context: &mut Context) -> Result<Exp, Diagnostic> {
             Exp_::Continue
         }
 
-        Tok::Identifier if context.tokens.content() == VECTOR_IDENT => {
+        Tok::Identifier
+            if context.tokens.content() == VECTOR_IDENT
+                && matches!(context.tokens.lookahead(), Ok(Tok::Less | Tok::LBracket)) =>
+        {
             consume_identifier(context.tokens, VECTOR_IDENT)?;
             let vec_end_loc = context.tokens.previous_end_loc();
             let vec_loc = make_loc(context.tokens.file_hash(), start_loc, vec_end_loc);

--- a/language/move-compiler/tests/move_check/expansion/restricted_module_alias_names.exp
+++ b/language/move-compiler/tests/move_check/expansion/restricted_module_alias_names.exp
@@ -1,12 +1,12 @@
 error[E03011]: invalid use of reserved name
-  ┌─ tests/move_check/expansion/restricted_module_alias_names.move:2:20
-  │
-2 │     use 0x42::M as Self;
-  │                    ^^^^ Invalid module alias name 'Self'. 'Self' is restricted and cannot be used to name a module alias
-
-error[E03011]: invalid use of reserved name
   ┌─ tests/move_check/expansion/restricted_module_alias_names.move:3:20
   │
-3 │     use 0x42::M as vector;
-  │                    ^^^^^^ Invalid module alias name 'vector'. 'vector' is restricted and cannot be used to name a module alias
+3 │     use 0x42::M as Self;
+  │                    ^^^^ Invalid module alias name 'Self'. 'Self' is restricted and cannot be used to name a module alias
+
+warning[W09001]: unused alias
+  ┌─ tests/move_check/expansion/restricted_module_alias_names.move:5:20
+  │
+5 │     use 0x42::M as vector;
+  │                    ^^^^^^ Unused 'use' of alias 'vector'. Consider removing it
 

--- a/language/move-compiler/tests/move_check/expansion/restricted_module_alias_names.move
+++ b/language/move-compiler/tests/move_check/expansion/restricted_module_alias_names.move
@@ -1,4 +1,6 @@
 module 0x42::M {
+    // not allowed
     use 0x42::M as Self;
+    // now allowed
     use 0x42::M as vector;
 }

--- a/language/move-compiler/tests/move_check/expansion/restricted_module_names.exp
+++ b/language/move-compiler/tests/move_check/expansion/restricted_module_names.exp
@@ -1,12 +1,6 @@
 error[E03011]: invalid use of reserved name
-  ┌─ tests/move_check/expansion/restricted_module_names.move:1:14
-  │
-1 │ module 0x42::Self {}
-  │              ^^^^ Invalid module name 'Self'. 'Self' is restricted and cannot be used to name a module
-
-error[E03011]: invalid use of reserved name
   ┌─ tests/move_check/expansion/restricted_module_names.move:2:14
   │
-2 │ module 0x42::vector {}
-  │              ^^^^^^ Invalid module name 'vector'. 'vector' is restricted and cannot be used to name a module
+2 │ module 0x42::Self {}
+  │              ^^^^ Invalid module name 'Self'. 'Self' is restricted and cannot be used to name a module
 

--- a/language/move-compiler/tests/move_check/expansion/restricted_module_names.move
+++ b/language/move-compiler/tests/move_check/expansion/restricted_module_names.move
@@ -1,2 +1,4 @@
+// not allowed
 module 0x42::Self {}
+// now allowed
 module 0x42::vector {}


### PR DESCRIPTION
## Motivation
[move-compiler] Allow 'vector' as a module name


## Test Plan
CI/CD Tests were covered