### PR TITLE
[scripts] Git installation in dev_setup.sh (#164)_84

### DIFF
--- a/docker/move-cli/Dockerfile
+++ b/docker/move-cli/Dockerfile
@@ -20,8 +20,7 @@ ENV PATH "/opt/cargo/bin:/usr/lib/golang/bin:/opt/bin:${DOTNET_ROOT}:${DOTNET_RO
 RUN mkdir -p /github/home && \
     mkdir -p /opt/cargo/ && \
     mkdir -p /opt/git/ && \
-    /move/scripts/dev_setup.sh -t -b -p -y -d -n && \
-    apt-get install -y git && \
+    /move/scripts/dev_setup.sh -t -b -p -y -d -g -n && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/scripts/dev_setup.sh
+++ b/scripts/dev_setup.sh
@@ -36,6 +36,7 @@ function usage {
   echo "-t install build tools"
   echo "-y installs or updates Move prover tools: z3, cvc5, dotnet, boogie"
   echo "-d installs the solidity compiler"
+  echo "-g installs Git (required by the Move CLI)"
   echo "-v verbose mode"
   echo "-i installs an individual tool by name"
   echo "-n will target the /opt/ dir rather than the $HOME dir.  /opt/bin/, /opt/rustup/, and /opt/dotnet/ rather than $HOME/bin/, $HOME/.rustup/, and $HOME/.dotnet/"
@@ -462,6 +463,13 @@ Solidity compiler (since -d was provided):
 EOF
   fi
 
+  if [[ "$INSTALL_GIT" == "true" ]]; then
+    cat <<EOF
+Version control system (since -g was provided):
+  * git
+EOF
+  fi
+
   if [[ "$INSTALL_PROFILE" == "true" ]]; then
     cat <<EOF
 Moreover, ~/.profile will be updated (since -p was provided).
@@ -480,44 +488,48 @@ INSTALL_BUILD_TOOLS=false
 INSTALL_PROFILE=false
 INSTALL_PROVER=false
 INSTALL_SOLIDITY=false
+INSTALL_GIT=false
 INSTALL_INDIVIDUAL=false
 INSTALL_PACKAGES=()
 INSTALL_DIR="${HOME}/bin/"
 OPT_DIR="false"
 
 #parse args
-while getopts "btpvydh:i:n" arg; do
+while getopts "btpvydgh:i:n" arg; do
   case "$arg" in
-  b)
-    BATCH_MODE="true"
-    ;;
-  t)
-    INSTALL_BUILD_TOOLS="true"
-    ;;
-  p)
-    INSTALL_PROFILE="true"
-    ;;
-  v)
-    VERBOSE=true
-    ;;
-  y)
-    INSTALL_PROVER="true"
-    ;;
-  d)
-    INSTALL_SOLIDITY="true"
-    ;;
-  i)
-    INSTALL_INDIVIDUAL="true"
-    echo "$OPTARG"
-    INSTALL_PACKAGES+=("$OPTARG")
-    ;;
-  n)
-    OPT_DIR="true"
-    ;;
-  *)
-    usage
-    exit 0
-    ;;
+    b)
+      BATCH_MODE="true"
+      ;;
+    t)
+      INSTALL_BUILD_TOOLS="true"
+      ;;
+    p)
+      INSTALL_PROFILE="true"
+      ;;
+    v)
+      VERBOSE="true"
+      ;;
+    y)
+      INSTALL_PROVER="true"
+      ;;
+    d)
+      INSTALL_SOLIDITY="true"
+      ;;
+    g)
+      INSTALL_GIT="true"
+      ;;
+    i)
+      INSTALL_INDIVIDUAL="true"
+      echo "$OPTARG"
+      INSTALL_PACKAGES+=("$OPTARG")
+      ;;
+    n)
+      OPT_DIR="true"
+      ;;
+    *)
+      usage
+      exit 0
+      ;;
   esac
 done
 
@@ -525,10 +537,11 @@ if [[ "$VERBOSE" == "true" ]]; then
   set -x
 fi
 
-if [[ "$INSTALL_BUILD_TOOLS" == "false" ]] &&
-  [[ "$INSTALL_PROFILE" == "false" ]] &&
-  [[ "$INSTALL_PROVER" == "false" ]] &&
-  [[ "$INSTALL_SOLIDITY" == "false" ]] &&
+if [[ "$INSTALL_BUILD_TOOLS" == "false" ]] && \
+  [[ "$INSTALL_PROFILE" == "false" ]] && \
+  [[ "$INSTALL_PROVER" == "false" ]] && \
+  [[ "$INSTALL_SOLIDITY" == "false" ]] && \
+  [[ "$INSTALL_GIT" == "false" ]] && \
   [[ "$INSTALL_INDIVIDUAL" == "false" ]]; then
   INSTALL_BUILD_TOOLS="true"
 fi
@@ -673,6 +686,10 @@ fi
 
 if [[ "$INSTALL_SOLIDITY" == "true" ]]; then
   install_solidity
+fi
+
+if [[ "$INSTALL_GIT" == "true" ]]; then
+  install_pkg git "$PACKAGE_MANAGER"
 fi
 
 if [[ "${BATCH_MODE}" == "false" ]]; then


### PR DESCRIPTION
## Motivation

Although most of the development setups have Git installed (since development happens in a Git repository), this assumption does not hold for all the cases: for example in the case of Docker's ADD . where local files are copied into a container without Git.

However, Git is required by the Move CLI (when using packages with Git dependencies), although this is undocumented.

Hence, the development setup script should have an option for installing it (although it's disabled by default).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

CI/CD tests are covered.