### PR TITLE
[gas_schedule] remove legacy assert (#169)_85

### DIFF
--- a/language/move-vm/types/src/gas_schedule.rs
+++ b/language/move-vm/types/src/gas_schedule.rs
@@ -18,7 +18,7 @@ use move_binary_format::{
 use move_core_types::{
     gas_schedule::{
         AbstractMemorySize, CostTable, GasAlgebra, GasCarrier, GasConstants, GasCost, GasUnits,
-        InternalGasUnits, MAX_TRANSACTION_SIZE_IN_BYTES,
+        InternalGasUnits,
     },
     vm_status::StatusCode,
 };
@@ -450,7 +450,6 @@ pub fn calculate_intrinsic_gas(
     transaction_size: AbstractMemorySize<GasCarrier>,
     gas_constants: &GasConstants,
 ) -> InternalGasUnits<GasCarrier> {
-    debug_assert!(transaction_size.get() <= MAX_TRANSACTION_SIZE_IN_BYTES as GasCarrier);
     let min_transaction_fee = gas_constants.min_transaction_gas_units;
 
     if transaction_size.get() > gas_constants.large_transaction_cutoff.get() {


### PR DESCRIPTION
## Motivation

- This is the default gas schedule, having the assert there is harmful
since it causes issues for testing larger transaction sizes.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes
