### PR TITLE
[move-cli] Adds "--only-deps" argument to the move package build to allow skipping… #104_94

### DIFF
--- a/language/tools/move-cli/tests/build_tests/only_deps/Move.toml
+++ b/language/tools/move-cli/tests/build_tests/only_deps/Move.toml
@@ -1,0 +1,10 @@
+[package]
+name = "OnlyDeps"
+version = "0.0.0"
+
+
+[addresses]
+Std = "0x1"
+
+[dependencies]
+MoveStdlib = { local = "../../../../../move-stdlib" }

--- a/language/tools/move-cli/tests/build_tests/only_deps/args.exp
+++ b/language/tools/move-cli/tests/build_tests/only_deps/args.exp
@@ -1,0 +1,7 @@
+Command `package build -v --only-deps`:
+INCLUDING DEPENDENCY MoveStdlib
+BUILDING OnlyDeps
+External Command `cat build/OnlyDeps/sources/A.move`:
+cat: build/OnlyDeps/sources/A.move: No such file or directory
+External Command `ls build/OnlyDeps/sources/dependencies`:
+MoveStdlib

--- a/language/tools/move-cli/tests/build_tests/only_deps/args.txt
+++ b/language/tools/move-cli/tests/build_tests/only_deps/args.txt
@@ -1,0 +1,3 @@
+package build -v --only-deps
+> cat build/OnlyDeps/sources/A.move
+> ls build/OnlyDeps/sources/dependencies

--- a/language/tools/move-cli/tests/build_tests/only_deps/sources/A.move
+++ b/language/tools/move-cli/tests/build_tests/only_deps/sources/A.move
@@ -1,0 +1,2 @@
+A specially made mistake
+module 0x1::A {}

--- a/language/tools/move-package/src/compilation/compiled_package.rs
+++ b/language/tools/move-package/src/compilation/compiled_package.rs
@@ -535,7 +535,10 @@ impl CompiledPackage {
         // invoke the compiler
         let paths = {
             let mut v = deps_package_paths.clone();
-            v.push(sources_package_paths.clone());
+            // Skip project files in the compilation process. Used in external IDE integrations.
+            if !resolution_graph.build_options.only_deps {
+                v.push(sources_package_paths.clone());
+            }
             v
         };
         let compiler = Compiler::from_package_paths(paths, vec![]).set_flags(flags);

--- a/language/tools/move-package/src/lib.rs
+++ b/language/tools/move-package/src/lib.rs
@@ -124,6 +124,10 @@ pub struct BuildConfig {
 
     #[clap(long = "arch", global = true, parse(try_from_str = Architecture::try_parse_from_str))]
     pub architecture: Option<Architecture>,
+
+    /// Only compile dependencies
+    #[clap(long = "only-deps", global = true)]
+    pub only_deps: bool,
 }
 
 impl Default for BuildConfig {
@@ -137,6 +141,7 @@ impl Default for BuildConfig {
             force_recompilation: false,
             additional_named_addresses: BTreeMap::new(),
             architecture: None,
+            only_deps: false,
         }
     }
 }

--- a/language/tools/move-package/tests/test_sources/compilation/basic_no_deps/Move.exp
+++ b/language/tools/move-package/tests/test_sources/compilation/basic_no_deps/Move.exp
@@ -15,5 +15,6 @@ CompiledPackageInfo {
         force_recompilation: false,
         additional_named_addresses: {},
         architecture: None,
+        only_deps: false,
     },
 }

--- a/language/tools/move-package/tests/test_sources/compilation/basic_no_deps_address_assigned/Move.exp
+++ b/language/tools/move-package/tests/test_sources/compilation/basic_no_deps_address_assigned/Move.exp
@@ -17,5 +17,6 @@ CompiledPackageInfo {
         force_recompilation: false,
         additional_named_addresses: {},
         architecture: None,
+        only_deps: false,
     },
 }

--- a/language/tools/move-package/tests/test_sources/compilation/basic_no_deps_address_not_assigned_with_dev_assignment/Move.exp
+++ b/language/tools/move-package/tests/test_sources/compilation/basic_no_deps_address_not_assigned_with_dev_assignment/Move.exp
@@ -17,5 +17,6 @@ CompiledPackageInfo {
         force_recompilation: false,
         additional_named_addresses: {},
         architecture: None,
+        only_deps: false,
     },
 }

--- a/language/tools/move-package/tests/test_sources/compilation/basic_no_deps_test_mode/Move.exp
+++ b/language/tools/move-package/tests/test_sources/compilation/basic_no_deps_test_mode/Move.exp
@@ -17,5 +17,6 @@ CompiledPackageInfo {
         force_recompilation: false,
         additional_named_addresses: {},
         architecture: None,
+        only_deps: false,
     },
 }

--- a/language/tools/move-package/tests/test_sources/compilation/diamond_problem_backflow_resolution/Move.exp
+++ b/language/tools/move-package/tests/test_sources/compilation/diamond_problem_backflow_resolution/Move.exp
@@ -18,5 +18,6 @@ CompiledPackageInfo {
         force_recompilation: false,
         additional_named_addresses: {},
         architecture: None,
+        only_deps: false,
     },
 }

--- a/language/tools/move-package/tests/test_sources/compilation/diamond_problem_no_conflict/Move.exp
+++ b/language/tools/move-package/tests/test_sources/compilation/diamond_problem_no_conflict/Move.exp
@@ -18,5 +18,6 @@ CompiledPackageInfo {
         force_recompilation: false,
         additional_named_addresses: {},
         architecture: None,
+        only_deps: false,
     },
 }

--- a/language/tools/move-package/tests/test_sources/compilation/multiple_deps_rename/Move.exp
+++ b/language/tools/move-package/tests/test_sources/compilation/multiple_deps_rename/Move.exp
@@ -19,5 +19,6 @@ CompiledPackageInfo {
         force_recompilation: false,
         additional_named_addresses: {},
         architecture: None,
+        only_deps: false,
     },
 }

--- a/language/tools/move-package/tests/test_sources/compilation/multiple_deps_rename_one/Move.exp
+++ b/language/tools/move-package/tests/test_sources/compilation/multiple_deps_rename_one/Move.exp
@@ -19,5 +19,6 @@ CompiledPackageInfo {
         force_recompilation: false,
         additional_named_addresses: {},
         architecture: None,
+        only_deps: false,
     },
 }

--- a/language/tools/move-package/tests/test_sources/compilation/one_dep/Move.exp
+++ b/language/tools/move-package/tests/test_sources/compilation/one_dep/Move.exp
@@ -17,5 +17,6 @@ CompiledPackageInfo {
         force_recompilation: false,
         additional_named_addresses: {},
         architecture: None,
+        only_deps: false,
     },
 }

--- a/language/tools/move-package/tests/test_sources/compilation/one_dep_assigned_address/Move.exp
+++ b/language/tools/move-package/tests/test_sources/compilation/one_dep_assigned_address/Move.exp
@@ -17,5 +17,6 @@ CompiledPackageInfo {
         force_recompilation: false,
         additional_named_addresses: {},
         architecture: None,
+        only_deps: false,
     },
 }

--- a/language/tools/move-package/tests/test_sources/compilation/one_dep_renamed/Move.exp
+++ b/language/tools/move-package/tests/test_sources/compilation/one_dep_renamed/Move.exp
@@ -17,5 +17,6 @@ CompiledPackageInfo {
         force_recompilation: false,
         additional_named_addresses: {},
         architecture: None,
+        only_deps: false,
     },
 }

--- a/language/tools/move-package/tests/test_sources/compilation/one_dep_with_scripts/Move.exp
+++ b/language/tools/move-package/tests/test_sources/compilation/one_dep_with_scripts/Move.exp
@@ -17,5 +17,6 @@ CompiledPackageInfo {
         force_recompilation: false,
         additional_named_addresses: {},
         architecture: None,
+        only_deps: false,
     },
 }

--- a/language/tools/move-package/tests/test_sources/compilation/test_symlinks/Move.exp
+++ b/language/tools/move-package/tests/test_sources/compilation/test_symlinks/Move.exp
@@ -17,5 +17,6 @@ CompiledPackageInfo {
         force_recompilation: false,
         additional_named_addresses: {},
         architecture: None,
+        only_deps: false,
     },
 }

--- a/language/tools/move-package/tests/test_sources/parsing/invalid_identifier_package_name/Move.exp
+++ b/language/tools/move-package/tests/test_sources/parsing/invalid_identifier_package_name/Move.exp
@@ -11,6 +11,7 @@ ResolutionGraph {
         force_recompilation: false,
         additional_named_addresses: {},
         architecture: None,
+        only_deps: false,
     },
     root_package: SourceManifest {
         package: PackageInfo {

--- a/language/tools/move-package/tests/test_sources/parsing/minimal_manifest/Move.exp
+++ b/language/tools/move-package/tests/test_sources/parsing/minimal_manifest/Move.exp
@@ -11,6 +11,7 @@ ResolutionGraph {
         force_recompilation: false,
         additional_named_addresses: {},
         architecture: None,
+        only_deps: false,
     },
     root_package: SourceManifest {
         package: PackageInfo {

--- a/language/tools/move-package/tests/test_sources/resolution/basic_no_deps/Move.exp
+++ b/language/tools/move-package/tests/test_sources/resolution/basic_no_deps/Move.exp
@@ -11,6 +11,7 @@ ResolutionGraph {
         force_recompilation: false,
         additional_named_addresses: {},
         architecture: None,
+        only_deps: false,
     },
     root_package: SourceManifest {
         package: PackageInfo {

--- a/language/tools/move-package/tests/test_sources/resolution/basic_no_deps_address_assigned/Move.exp
+++ b/language/tools/move-package/tests/test_sources/resolution/basic_no_deps_address_assigned/Move.exp
@@ -11,6 +11,7 @@ ResolutionGraph {
         force_recompilation: false,
         additional_named_addresses: {},
         architecture: None,
+        only_deps: false,
     },
     root_package: SourceManifest {
         package: PackageInfo {

--- a/language/tools/move-package/tests/test_sources/resolution/basic_no_deps_address_not_assigned_with_dev_assignment/Move.exp
+++ b/language/tools/move-package/tests/test_sources/resolution/basic_no_deps_address_not_assigned_with_dev_assignment/Move.exp
@@ -11,6 +11,7 @@ ResolutionGraph {
         force_recompilation: false,
         additional_named_addresses: {},
         architecture: None,
+        only_deps: false,
     },
     root_package: SourceManifest {
         package: PackageInfo {

--- a/language/tools/move-package/tests/test_sources/resolution/dep_good_digest/Move.exp
+++ b/language/tools/move-package/tests/test_sources/resolution/dep_good_digest/Move.exp
@@ -11,6 +11,7 @@ ResolutionGraph {
         force_recompilation: false,
         additional_named_addresses: {},
         architecture: None,
+        only_deps: false,
     },
     root_package: SourceManifest {
         package: PackageInfo {

--- a/language/tools/move-package/tests/test_sources/resolution/diamond_problem_backflow_resolution/Move.exp
+++ b/language/tools/move-package/tests/test_sources/resolution/diamond_problem_backflow_resolution/Move.exp
@@ -11,6 +11,7 @@ ResolutionGraph {
         force_recompilation: false,
         additional_named_addresses: {},
         architecture: None,
+        only_deps: false,
     },
     root_package: SourceManifest {
         package: PackageInfo {

--- a/language/tools/move-package/tests/test_sources/resolution/diamond_problem_no_conflict/Move.exp
+++ b/language/tools/move-package/tests/test_sources/resolution/diamond_problem_no_conflict/Move.exp
@@ -11,6 +11,7 @@ ResolutionGraph {
         force_recompilation: false,
         additional_named_addresses: {},
         architecture: None,
+        only_deps: false,
     },
     root_package: SourceManifest {
         package: PackageInfo {

--- a/language/tools/move-package/tests/test_sources/resolution/multiple_deps_rename/Move.exp
+++ b/language/tools/move-package/tests/test_sources/resolution/multiple_deps_rename/Move.exp
@@ -11,6 +11,7 @@ ResolutionGraph {
         force_recompilation: false,
         additional_named_addresses: {},
         architecture: None,
+        only_deps: false,
     },
     root_package: SourceManifest {
         package: PackageInfo {

--- a/language/tools/move-package/tests/test_sources/resolution/one_dep/Move.exp
+++ b/language/tools/move-package/tests/test_sources/resolution/one_dep/Move.exp
@@ -11,6 +11,7 @@ ResolutionGraph {
         force_recompilation: false,
         additional_named_addresses: {},
         architecture: None,
+        only_deps: false,
     },
     root_package: SourceManifest {
         package: PackageInfo {

--- a/language/tools/move-package/tests/test_sources/resolution/one_dep_assigned_address/Move.exp
+++ b/language/tools/move-package/tests/test_sources/resolution/one_dep_assigned_address/Move.exp
@@ -11,6 +11,7 @@ ResolutionGraph {
         force_recompilation: false,
         additional_named_addresses: {},
         architecture: None,
+        only_deps: false,
     },
     root_package: SourceManifest {
         package: PackageInfo {

--- a/language/tools/move-package/tests/test_sources/resolution/one_dep_multiple_of_same_name/Move.exp
+++ b/language/tools/move-package/tests/test_sources/resolution/one_dep_multiple_of_same_name/Move.exp
@@ -11,6 +11,7 @@ ResolutionGraph {
         force_recompilation: false,
         additional_named_addresses: {},
         architecture: None,
+        only_deps: false,
     },
     root_package: SourceManifest {
         package: PackageInfo {

--- a/language/tools/move-package/tests/test_sources/resolution/one_dep_reassigned_address/Move.exp
+++ b/language/tools/move-package/tests/test_sources/resolution/one_dep_reassigned_address/Move.exp
@@ -11,6 +11,7 @@ ResolutionGraph {
         force_recompilation: false,
         additional_named_addresses: {},
         architecture: None,
+        only_deps: false,
     },
     root_package: SourceManifest {
         package: PackageInfo {

--- a/language/tools/move-package/tests/test_sources/resolution/one_dep_unification_across_local_renamings/Move.exp
+++ b/language/tools/move-package/tests/test_sources/resolution/one_dep_unification_across_local_renamings/Move.exp
@@ -11,6 +11,7 @@ ResolutionGraph {
         force_recompilation: false,
         additional_named_addresses: {},
         architecture: None,
+        only_deps: false,
     },
     root_package: SourceManifest {
         package: PackageInfo {


### PR DESCRIPTION
## Motivation

Adds --only-deps argument to the move package build to allow skipping project source files in the compilation process.
This parameter will be used for autocomplete in IDE. It allows you to upload all dependencies to the build folder, even if there are errors in project.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

CI/CD tests are covered.