### PR TITLE
[language server] Added support for passing compilation errors back to the IDE #167_93

### DIFF
--- a/language/move-analyzer/src/bin/move-analyzer.rs
+++ b/language/move-analyzer/src/bin/move-analyzer.rs
@@ -1,6 +1,7 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use anyhow::Result;
 use clap::Parser;
 use crossbeam::channel::{bounded, select};
 use lsp_server::{Connection, Message, Notification, Request, Response};
@@ -105,7 +106,7 @@ fn main() {
     let initialize_params: lsp_types::InitializeParams =
         serde_json::from_value(client_response).expect("could not deserialize client capabilities");
 
-    let (diag_sender, diag_receiver) = bounded::<BTreeMap<Symbol, Vec<Diagnostic>>>(0);
+    let (diag_sender, diag_receiver) = bounded::<Result<BTreeMap<Symbol, Vec<Diagnostic>>>>(0);
     let mut symbolicator_runner = symbols::SymbolicatorRunner::idle();
     if symbols::DEFS_AND_REFS_SUPPORT {
         if let Some(uri) = initialize_params.root_uri {
@@ -115,22 +116,47 @@ fn main() {
         }
     };
 
+    let mut missing_manifest_reported = false;
     loop {
         select! {
             recv(diag_receiver) -> message => {
                 match message {
-                    Ok(diags) => {
-                        for (k, v) in diags {
-                            let url = Url::from_file_path(Path::new(&k.to_string())).unwrap();
-                            let params = lsp_types::PublishDiagnosticsParams::new(url, v, None);
-                            let notification = Notification::new(lsp_types::notification::PublishDiagnostics::METHOD.to_string(), params);
-                            if let Err(err) = context
-                                .connection
-                                .sender
-                                .send(lsp_server::Message::Notification(notification)) {
-                                    eprintln!("could not send completion response: {:?}", err);
+                    Ok(result) => {
+                        match result {
+                            Ok(diags) => {
+                                for (k, v) in diags {
+                                    let url = Url::from_file_path(Path::new(&k.to_string())).unwrap();
+                                    let params = lsp_types::PublishDiagnosticsParams::new(url, v, None);
+                                    let notification = Notification::new(lsp_types::notification::PublishDiagnostics::METHOD.to_string(), params);
+                                    if let Err(err) = context
+                                        .connection
+                                        .sender
+                                        .send(lsp_server::Message::Notification(notification)) {
+                                            eprintln!("could not send diagnostics response: {:?}", err);
+                                        };
                                 }
-
+                            },
+                            Err(err) => {
+                                let typ = lsp_types::MessageType::Error;
+                                let message = format!("{err}");
+                                let missing_manifest = message.starts_with("Unable to find package manifest");
+                                if !missing_manifest || !missing_manifest_reported {
+                                    // report missing manifest only once to avoid re-generating
+                                    // user-visible error in cases when the developer decides to
+                                    // keep editing a file that does not belong to a packages
+                                    let params = lsp_types::ShowMessageParams { typ, message };
+                                    let notification = Notification::new(lsp_types::notification::ShowMessage::METHOD.to_string(), params);
+                                    if let Err(err) = context
+                                        .connection
+                                        .sender
+                                        .send(lsp_server::Message::Notification(notification)) {
+                                            eprintln!("could not send compiler error response: {:?}", err);
+                                        };
+                                }
+                                if missing_manifest {
+                                    missing_manifest_reported = true;
+                                }
+                            },
                         }
                     },
                     Err(error) => eprintln!("symbolicator message error: {:?}", error),

--- a/language/move-analyzer/src/symbols.rs
+++ b/language/move-analyzer/src/symbols.rs
@@ -86,7 +86,7 @@ use move_symbol_pool::Symbol;
 
 /// Enabling/disabling the language server reporting readiness to support go-to-def and
 /// go-to-references to the IDE.
-pub const DEFS_AND_REFS_SUPPORT: bool = false;
+pub const DEFS_AND_REFS_SUPPORT: bool = true;
 
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Copy)]
 /// Location of a definition's identifier
@@ -202,7 +202,7 @@ impl SymbolicatorRunner {
     pub fn new(
         uri: &Url,
         symbols: Arc<Mutex<Symbols>>,
-        sender: Sender<BTreeMap<Symbol, Vec<Diagnostic>>>,
+        sender: Sender<Result<BTreeMap<Symbol, Vec<Diagnostic>>>>,
     ) -> Self {
         let mtx_cvar = Arc::new((Mutex::new(RunnerState::Wait), Condvar::new()));
         let thread_mtx_cvar = mtx_cvar.clone();
@@ -248,11 +248,16 @@ impl SymbolicatorRunner {
                                 *old_symbols = new_symbols;
                             }
                             // set/reset (previous) diagnostics
-                            if let Err(err) = sender.send(lsp_diagnostics) {
+                            if let Err(err) = sender.send(Ok(lsp_diagnostics)) {
                                 eprintln!("could not pass diagnostics: {:?}", err);
                             }
                         }
-                        Err(err) => eprintln!("symbolication failed: {:?}", err),
+                        Err(err) => {
+                            eprintln!("symbolication failed: {:?}", err);
+                            if let Err(err) = sender.send(Err(err)) {
+                                eprintln!("could not compiler error: {:?}", err);
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Motivation
One more refinement of recently added support for more advanced language server features. This PR is about passing "fatal" compilation errors (i.e., those that do not result in generating diagnostics for the source code) back to IDE so that it's more explicit why more advanced features (i.e., those relying on successful compilation) may not work as expected.

Enabled advanced functionality in the server to simplify deployment, but it's not meant for wider consumption yet as it requires the extension to be re-published for the new functionality to work.

## Test Plan 
CI/CD tests were covered.