### PR TITLE
abi-metadata and conversion to ethabi.contract (#193)_97

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -246,10 +246,10 @@ version = "0.19.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55f93d0ef3363c364d5976646a38f04cf67cfe1d4c8d160cdea02cab2c116b33"
 dependencies = [
- "funty",
+ "funty 1.1.0",
  "radium 0.5.3",
  "tap",
- "wyz",
+ "wyz 0.2.0",
 ]
 
 [[package]]
@@ -258,10 +258,22 @@ version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7774144344a4faa177370406a7ff5f1da24303817368584c6206c8303eb07848"
 dependencies = [
- "funty",
+ "funty 1.1.0",
  "radium 0.6.2",
  "tap",
- "wyz",
+ "wyz 0.2.0",
+]
+
+[[package]]
+name = "bitvec"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1489fcb93a5bb47da0462ca93ad252ad6af2145cce58d10d46a83931ba9f016b"
+dependencies = [
+ "funty 2.0.0",
+ "radium 0.7.0",
+ "tap",
+ "wyz 0.5.0",
 ]
 
 [[package]]
@@ -294,6 +306,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
  "block-padding 0.2.1",
+ "generic-array 0.14.4",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf7fe51849ea569fd452f37822f606a5cabb684dc918707a0193fd4664ff324"
+dependencies = [
  "generic-array 0.14.4",
 ]
 
@@ -829,6 +850,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
+name = "crypto-common"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57952ca27b5e3606ff4dd79b0020231aaf9d6aa76dc05fd30137538c50bd3ce8"
+dependencies = [
+ "generic-array 0.14.4",
+ "typenum",
+]
+
+[[package]]
 name = "crypto-mac"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1064,6 +1095,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "digest"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
+dependencies = [
+ "block-buffer 0.10.2",
+ "crypto-common",
+]
+
+[[package]]
 name = "dir-diff"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1205,6 +1246,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68b91989ae21441195d7d9b9993a2f9295c7e1a8c96255d8b729accddc124797"
 
 [[package]]
+name = "ethabi"
+version = "17.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b69517146dfab88e9238c00c724fd8e277951c3cc6f22b016d72f422a832213e"
+dependencies = [
+ "ethereum-types 0.13.1",
+ "hex",
+ "once_cell",
+ "regex",
+ "serde 1.0.130",
+ "serde_json",
+ "sha3 0.10.1",
+ "thiserror",
+ "uint",
+]
+
+[[package]]
 name = "ethbloom"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1212,9 +1270,22 @@ checksum = "bfb684ac8fa8f6c5759f788862bb22ec6fe3cb392f6bfd08e3c64b603661e3f8"
 dependencies = [
  "crunchy",
  "fixed-hash",
- "impl-codec",
+ "impl-codec 0.5.1",
  "impl-rlp",
  "scale-info",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "ethbloom"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11da94e443c60508eb62cf256243a64da87304c2802ac2528847f79d750007ef"
+dependencies = [
+ "crunchy",
+ "fixed-hash",
+ "impl-rlp",
+ "impl-serde",
  "tiny-keccak",
 ]
 
@@ -1225,10 +1296,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34c90e0a755da706ce0970ec0fa8cc48aabcc8e8efa1245336acf718dab06ffe"
 dependencies = [
  "bytes",
- "ethereum-types",
+ "ethereum-types 0.12.1",
  "hash-db",
  "hash256-std-hasher",
- "parity-scale-codec",
+ "parity-scale-codec 2.3.1",
  "rlp",
  "rlp-derive",
  "scale-info",
@@ -1243,12 +1314,26 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05136f7057fe789f06e6d41d07b34e6f70d8c86e5693b60f97aaa6553553bdaf"
 dependencies = [
- "ethbloom",
+ "ethbloom 0.11.1",
  "fixed-hash",
- "impl-codec",
+ "impl-codec 0.5.1",
  "impl-rlp",
- "primitive-types",
+ "primitive-types 0.10.1",
  "scale-info",
+ "uint",
+]
+
+[[package]]
+name = "ethereum-types"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2827b94c556145446fcce834ca86b7abf0c39a805883fe20e72c5bfdb5a0dc6"
+dependencies = [
+ "ethbloom 0.12.1",
+ "fixed-hash",
+ "impl-rlp",
+ "impl-serde",
+ "primitive-types 0.11.1",
  "uint",
 ]
 
@@ -1271,8 +1356,8 @@ dependencies = [
  "evm-gasometer",
  "evm-runtime",
  "log",
- "parity-scale-codec",
- "primitive-types",
+ "parity-scale-codec 2.3.1",
+ "primitive-types 0.10.1",
  "rlp",
  "scale-info",
  "serde 1.0.130",
@@ -1285,9 +1370,9 @@ version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dfe4f2a56c4c05a8107b8596380e2332fc2019ffcf56b8f2d01971393a30c4d"
 dependencies = [
- "funty",
- "parity-scale-codec",
- "primitive-types",
+ "funty 1.1.0",
+ "parity-scale-codec 2.3.1",
+ "primitive-types 0.10.1",
  "scale-info",
  "serde 1.0.130",
 ]
@@ -1301,7 +1386,7 @@ dependencies = [
  "evm-runtime",
  "hex",
  "move-command-line-common",
- "primitive-types",
+ "primitive-types 0.10.1",
  "sha3 0.9.1",
  "tempfile",
 ]
@@ -1315,7 +1400,7 @@ dependencies = [
  "environmental",
  "evm-core",
  "evm-runtime",
- "primitive-types",
+ "primitive-types 0.10.1",
 ]
 
 [[package]]
@@ -1326,8 +1411,27 @@ checksum = "419e8434ac6e850a8a4bc09a19406264582d1940913b2920be2af948f4ffc49b"
 dependencies = [
  "environmental",
  "evm-core",
- "primitive-types",
+ "primitive-types 0.10.1",
  "sha3 0.8.2",
+]
+
+[[package]]
+name = "extract-ethereum-abi"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "atty",
+ "clap 3.1.8",
+ "codespan",
+ "codespan-reporting",
+ "ethabi",
+ "move-core-types",
+ "move-ethereum-abi",
+ "move-to-yul",
+ "once_cell",
+ "regex",
+ "serde 1.0.130",
+ "serde_json",
 ]
 
 [[package]]
@@ -1410,6 +1514,12 @@ name = "funty"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
@@ -1791,7 +1901,16 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "161ebdfec3c8e3b52bf61c4f3550a1eea4f9579d10dc1b936f3171ebdcd6c443"
 dependencies = [
- "parity-scale-codec",
+ "parity-scale-codec 2.3.1",
+]
+
+[[package]]
+name = "impl-codec"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba6a270039626615617f3f36d15fc827041df3b78c439da2cadfa47455a77f2f"
+dependencies = [
+ "parity-scale-codec 3.1.2",
 ]
 
 [[package]]
@@ -1801,6 +1920,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f28220f89297a075ddc7245cd538076ee98b01f2a9c23a53a4f1105d5a322808"
 dependencies = [
  "rlp",
+]
+
+[[package]]
+name = "impl-serde"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4551f042f3438e64dbd6226b20527fc84a6e1fe65688b58746a2f53623f25f5c"
+dependencies = [
+ "serde 1.0.130",
 ]
 
 [[package]]
@@ -2430,6 +2558,10 @@ dependencies = [
 name = "move-ethereum-abi"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
+ "ethabi",
+ "once_cell",
+ "regex",
  "serde 1.0.130",
  "serde_json",
 ]
@@ -2816,7 +2948,7 @@ dependencies = [
  "num 0.4.0",
  "once_cell",
  "pretty",
- "primitive-types",
+ "primitive-types 0.10.1",
  "rand 0.8.4",
  "regex",
  "serde 1.0.130",
@@ -2890,7 +3022,7 @@ dependencies = [
  "move-vm-test-utils",
  "move-vm-types",
  "once_cell",
- "primitive-types",
+ "primitive-types 0.10.1",
  "rayon",
  "regex",
 ]
@@ -3207,9 +3339,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.8.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
+checksum = "7709cef83f0c1f58f666e746a08b21e0085f7440fa6a29cc194d68aac97a4225"
 
 [[package]]
 name = "oorandom"
@@ -3296,7 +3428,21 @@ dependencies = [
  "bitvec 0.20.4",
  "byte-slice-cast",
  "impl-trait-for-tuples",
- "parity-scale-codec-derive",
+ "parity-scale-codec-derive 2.3.1",
+ "serde 1.0.130",
+]
+
+[[package]]
+name = "parity-scale-codec"
+version = "3.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8b44461635bbb1a0300f100a841e571e7d919c81c73075ef5d152ffdb521066"
+dependencies = [
+ "arrayvec 0.7.2",
+ "bitvec 1.0.0",
+ "byte-slice-cast",
+ "impl-trait-for-tuples",
+ "parity-scale-codec-derive 3.1.2",
  "serde 1.0.130",
 ]
 
@@ -3305,6 +3451,18 @@ name = "parity-scale-codec-derive"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1557010476e0595c9b568d16dcfb81b93cdeb157612726f5170d31aa707bed27"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2 1.0.28",
+ "quote 1.0.9",
+ "syn 1.0.74",
+]
+
+[[package]]
+name = "parity-scale-codec-derive"
+version = "3.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c45ed1f39709f5a89338fab50e59816b2e8815f5bb58276e7ddf9afd495f73f8"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.28",
@@ -3573,9 +3731,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05e4722c697a58a99d5d06a08c30821d7c082a4632198de1eaa5a6c22ef42373"
 dependencies = [
  "fixed-hash",
- "impl-codec",
+ "impl-codec 0.5.1",
  "impl-rlp",
  "scale-info",
+ "uint",
+]
+
+[[package]]
+name = "primitive-types"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e28720988bff275df1f51b171e1b2a18c30d194c4d2b61defdacecd625a5d94a"
+dependencies = [
+ "fixed-hash",
+ "impl-codec 0.6.0",
+ "impl-rlp",
+ "impl-serde",
  "uint",
 ]
 
@@ -3795,6 +3966,12 @@ name = "radium"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -4138,7 +4315,7 @@ dependencies = [
  "bitvec 0.20.4",
  "cfg-if 1.0.0",
  "derive_more",
- "parity-scale-codec",
+ "parity-scale-codec 2.3.1",
  "scale-info-derive",
 ]
 
@@ -4363,6 +4540,16 @@ dependencies = [
  "digest 0.9.0",
  "keccak",
  "opaque-debug 0.3.0",
+]
+
+[[package]]
+name = "sha3"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "881bf8156c87b6301fc5ca6b27f11eeb2761224c7081e69b409d5a1951a70c86"
+dependencies = [
+ "digest 0.10.3",
+ "keccak",
 ]
 
 [[package]]
@@ -4982,9 +5169,9 @@ checksum = "0685c84d5d54d1c26f7d3eb96cd41550adb97baed141a761cf335d3d33bcd0ae"
 
 [[package]]
 name = "typenum"
-version = "1.12.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
+checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
 name = "ucd-trie"
@@ -5312,6 +5499,15 @@ name = "wyz"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
+
+[[package]]
+name = "wyz"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b31594f29d27036c383b53b59ed3476874d518f0efb151b27a4c275141390e"
+dependencies = [
+ "tap",
+]
 
 [[package]]
 name = "x"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "language/documentation/examples/diem-framework/crates/crypto-derive",
     "language/documentation/examples/diem-framework/crates/natives",
     "language/evm/exec-utils",
+    "language/evm/extract-ethereum-abi",
     "language/evm/move-ethereum-abi",
     "language/evm/move-to-yul",
     "language/extensions/async/move-async-vm",
@@ -77,6 +78,7 @@ members = [
 #
 # For more, see the "Conditional compilation for tests" section in documentation/coding_guidelines.md.
 default-members = [
+    "language/evm/extract-ethereum-abi",
     "language/evm/move-to-yul",
     "language/move-analyzer",
     "language/move-ir-compiler",

--- a/language/evm/extract-ethereum-abi/Cargo.toml
+++ b/language/evm/extract-ethereum-abi/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "extract-ethereum-abi"
+version = "0.1.0"
+authors = ["Diem Association <opensource@diem.com>"]
+description = "Extract Etherem ABI"
+publish = false
+edition = "2018"
+license = "Apache-2.0"
+
+[dependencies]
+# move dependencies
+move-ethereum-abi = { path = "../move-ethereum-abi" }
+move-to-yul = { path = "../move-to-yul" }
+move-core-types = { path = "../../move-core/types" }
+
+# external dependencies
+anyhow = "1.0.38"
+atty = "0.2.14"
+codespan = "0.11.1"
+codespan-reporting = "0.11.1"
+ethabi = "17.0.0"
+serde = { version = "1.0.124", features = ["derive"] }
+serde_json = "1.0.64"
+regex = "1.4.3"
+once_cell = "1.7.2"
+clap = { version = "3", features = ["derive", "env"] }

--- a/language/evm/extract-ethereum-abi/src/main.rs
+++ b/language/evm/extract-ethereum-abi/src/main.rs
@@ -1,0 +1,38 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#![forbid(unsafe_code)]
+
+use clap::Parser;
+use codespan_reporting::term::termcolor::{ColorChoice, StandardStream};
+use move_to_yul::{options::Options, parse_metadata_to_move_sig, run_to_abi_metadata};
+
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        let mut c = e.source();
+        while let Some(s) = c {
+            eprintln!("caused by: {}", s);
+            c = s.source();
+        }
+        std::process::exit(1)
+    }
+}
+
+fn run() -> anyhow::Result<()> {
+    let options = Options::parse();
+    let color = if atty::is(atty::Stream::Stderr) && atty::is(atty::Stream::Stdout) {
+        ColorChoice::Auto
+    } else {
+        ColorChoice::Never
+    };
+    let mut error_writer = StandardStream::stderr(color);
+    let metadata_vec = run_to_abi_metadata(&mut error_writer, options).unwrap();
+    for metadata in metadata_vec {
+        let move_sig_opt = parse_metadata_to_move_sig(&metadata);
+        if let Some(move_sig) = move_sig_opt {
+            println!("{}", serde_json::to_string_pretty(&move_sig).unwrap());
+        }
+    }
+    Ok(())
+}

--- a/language/evm/move-ethereum-abi/Cargo.toml
+++ b/language/evm/move-ethereum-abi/Cargo.toml
@@ -9,8 +9,12 @@ license = "Apache-2.0"
 
 [dependencies]
 # external dependencies
+anyhow = "1.0.38"
+ethabi = "17.0.0"
 serde = { version = "1.0.124", features = ["derive"] }
 serde_json = "1.0.64"
+regex = "1.4.3"
+once_cell = "1.7.2"
 
 [lib]
 doctest = false

--- a/language/evm/move-ethereum-abi/src/abi_move_type.rs
+++ b/language/evm/move-ethereum-abi/src/abi_move_type.rs
@@ -1,19 +1,299 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use ethabi::Contract;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
 use crate::abi_signature_type::ABIJsonSignature;
 
 /// Key for metadata
-const _ABI_ETHER_MOVE_KEY: &str = "abi_ethereum_move";
+pub const ABI_ETHER_MOVE_KEY: &str = "abi_ethereum_move";
 
 #[derive(Serialize, Deserialize)]
 pub struct ABIMoveSignature {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub constructor: Option<ABIJsonSignature>,
     // Move type -> Ethereum event abi
     pub event_map: BTreeMap<String, ABIJsonSignature>,
-
     // Move function -> Ethereum pub function abi
     pub func_map: BTreeMap<String, ABIJsonSignature>,
+    // Indicate whether a receive function is defined in the contract
+    pub receive: bool,
+    // Indicate whether a fallback function is defined in the contract
+    pub fallback: bool,
+}
+
+impl ABIMoveSignature {
+    fn _convert_to_contract(&self) -> Result<Contract, ethabi::Error> {
+        let contract_str = self._generate_abi_string();
+        Contract::load(contract_str.as_bytes())
+    }
+
+    fn _generate_abi_string(&self) -> String {
+        let mut res = vec![];
+        if let Some(cons) = &self.constructor {
+            res.push(serde_json::to_string_pretty(&cons).unwrap());
+        }
+        for (_, ev_sig) in self.event_map.iter() {
+            res.push(serde_json::to_string_pretty(&ev_sig).unwrap());
+        }
+        for (_, fn_sig) in self.func_map.iter() {
+            res.push(serde_json::to_string_pretty(&fn_sig).unwrap());
+        }
+        if self.receive {
+            res.push("{ \"type\": \"receive\" }\n".to_string());
+        }
+        if self.fallback {
+            res.push("{ \"type\": \"fallback\" }\n".to_string());
+        }
+        format!(
+            "[\n{}\n]",
+            res.iter()
+                .map(|t| t.to_string())
+                .collect::<Vec<_>>()
+                .join(",\n")
+        )
+    }
+}
+
+#[cfg(test)]
+#[allow(deprecated)]
+mod tests {
+    use super::*;
+    use ethabi::{
+        Constructor, Contract, Event, EventParam, Function, Param, ParamType, StateMutability,
+    };
+    use std::iter::FromIterator;
+
+    #[test]
+    fn test_fallback_receive_only() {
+        let json = r#"{
+            "event_map": {},
+            "func_map": {},
+            "receive": true,
+            "fallback": true
+          }"#;
+        let deserialized_json_sig: ABIMoveSignature = serde_json::from_str(json).unwrap();
+        let contract = deserialized_json_sig._convert_to_contract().unwrap();
+        assert_eq!(
+            contract,
+            Contract {
+                constructor: None,
+                functions: BTreeMap::new(),
+                events: BTreeMap::new(),
+                errors: BTreeMap::new(),
+                receive: true,
+                fallback: true,
+            }
+        );
+    }
+
+    #[test]
+    fn test_constructor() {
+        let json = r#"{
+            "constructor": {
+              "name": "init",
+              "type": "constructor",
+              "inputs": [
+                {
+                  "type": "uint64",
+                  "name": "value"
+                },
+                {
+                  "type": "uint64",
+                  "name": "value2"
+                }
+              ],
+              "outputs": [],
+              "stateMutability": "nonpayable"
+            },
+            "event_map": {},
+            "func_map": {},
+            "receive": false,
+            "fallback": false
+          }"#;
+        let mut const_inputs = vec![];
+        let param_uint64 = ParamType::Uint(64);
+        let name_1 = "value";
+        let name_2 = "value2";
+        let para1 = Param {
+            name: name_1.to_string(),
+            kind: param_uint64.clone(),
+            internal_type: None,
+        };
+        let para2 = Param {
+            name: name_2.to_string(),
+            kind: param_uint64,
+            internal_type: None,
+        };
+        const_inputs.push(para1);
+        const_inputs.push(para2);
+        let constructor = Constructor {
+            inputs: const_inputs,
+        };
+        let deserialized_json_sig: ABIMoveSignature = serde_json::from_str(json).unwrap();
+        let contract = deserialized_json_sig._convert_to_contract().unwrap();
+        assert_eq!(
+            contract,
+            Contract {
+                constructor: Some(constructor),
+                functions: BTreeMap::new(),
+                events: BTreeMap::new(),
+                errors: BTreeMap::new(),
+                receive: false,
+                fallback: false,
+            }
+        );
+    }
+
+    #[test]
+    fn test_events() {
+        let json = r#"{
+            "event_map": {
+                "ev1": {
+					"type": "event",
+					"name": "ev1",
+					"inputs": [
+						{
+							"name":"a",
+							"type":"bytes",
+                            "indexed": true
+						}
+					],
+					"anonymous": false
+				},
+				"ev2": {
+					"type": "event",
+					"name": "ev2",
+					"inputs": [
+						{
+							"name":"b",
+							"type":"address[]"
+						}
+					],
+					"anonymous": false
+				}
+            },
+            "func_map": {},
+            "receive": true,
+            "fallback": false
+          }"#;
+        let deserialized_json_sig: ABIMoveSignature = serde_json::from_str(json).unwrap();
+        let contract = deserialized_json_sig._convert_to_contract().unwrap();
+        assert_eq!(
+            contract,
+            Contract {
+                constructor: None,
+                functions: BTreeMap::new(),
+                events: BTreeMap::from_iter(vec![
+                    (
+                        "ev1".to_string(),
+                        vec![Event {
+                            name: "ev1".to_string(),
+                            inputs: vec![EventParam {
+                                name: "a".to_string(),
+                                kind: ParamType::Bytes,
+                                indexed: true,
+                            }],
+                            anonymous: false,
+                        }]
+                    ),
+                    (
+                        "ev2".to_string(),
+                        vec![Event {
+                            name: "ev2".to_string(),
+                            inputs: vec![EventParam {
+                                name: "b".to_string(),
+                                kind: ParamType::Array(Box::new(ParamType::Address)),
+                                indexed: false
+                            }],
+                            anonymous: false,
+                        }]
+                    ),
+                ]),
+                errors: BTreeMap::new(),
+                receive: true,
+                fallback: false,
+            }
+        );
+    }
+
+    #[test]
+    fn test_functions() {
+        let json = r#"{
+            "event_map": {},
+            "func_map": {
+                "fn1": {
+                "type": "function",
+                "name": "fn1",
+                "inputs": [
+                    {
+                        "name":"arg1",
+                        "type":"address[5]"
+                    }
+                ],
+                "outputs": [
+                    {
+                        "name": "ret1",
+                        "type":"address"
+                    }
+                ],
+                "stateMutability": "nonpayable"
+                },
+                "fn2": {
+                    "type": "function",
+                    "name": "fn2",
+                    "inputs": [],
+                    "outputs": [],
+                    "stateMutability": "pure"
+                }
+            },
+            "receive": true,
+            "fallback": false
+          }"#;
+
+        let deserialized_json_sig: ABIMoveSignature = serde_json::from_str(json).unwrap();
+        let contract = deserialized_json_sig._convert_to_contract().unwrap();
+        assert_eq!(
+            contract,
+            Contract {
+                constructor: None,
+                functions: BTreeMap::from_iter(vec![
+                    (
+                        "fn1".to_string(),
+                        vec![Function {
+                            name: "fn1".to_string(),
+                            inputs: vec![Param {
+                                name: "arg1".to_string(),
+                                kind: ParamType::FixedArray(Box::new(ParamType::Address), 5),
+                                internal_type: None,
+                            }],
+                            outputs: vec![Param {
+                                name: "ret1".to_string(),
+                                kind: ParamType::Address,
+                                internal_type: None,
+                            }],
+                            constant: None,
+                            state_mutability: Default::default(),
+                        }]
+                    ),
+                    (
+                        "fn2".to_string(),
+                        vec![Function {
+                            name: "fn2".to_string(),
+                            inputs: vec![],
+                            outputs: vec![],
+                            constant: None,
+                            state_mutability: StateMutability::Pure,
+                        }]
+                    ),
+                ]),
+                events: BTreeMap::new(),
+                errors: BTreeMap::new(),
+                receive: true,
+                fallback: false,
+            }
+        );
+    }
 }

--- a/language/evm/move-to-yul/src/abi_move_metadata.rs
+++ b/language/evm/move-to-yul/src/abi_move_metadata.rs
@@ -1,0 +1,74 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    abi_signature::{from_event_sig, from_solidity_sig},
+    context::Context,
+};
+use move_ethereum_abi::abi_move_type::{ABIMoveSignature, ABI_ETHER_MOVE_KEY};
+
+use itertools::Itertools;
+use move_core_types::metadata::Metadata;
+use std::{collections::BTreeMap, str};
+
+/// Generate Metadata for move signature
+
+pub(crate) fn generate_abi_move_metadata(ctx: &Context, receive: bool, fallback: bool) -> Metadata {
+    let mut event_map = BTreeMap::new();
+    let event_sigs_keys = ctx
+        .event_signature_map
+        .borrow()
+        .keys()
+        .cloned()
+        .collect_vec();
+    for key in &event_sigs_keys {
+        let st_env = ctx.env.get_struct(key.to_qualified_id());
+        event_map.insert(
+            st_env.get_identifier().unwrap().to_string(),
+            from_event_sig(ctx.event_signature_map.borrow().get(&key).unwrap()),
+        );
+    }
+
+    // Callable functions
+    let mut func_map = BTreeMap::new();
+    for (key, (solidity_sig, attr)) in ctx.callable_function_map.borrow().iter() {
+        let fun = ctx.env.get_function(key.to_qualified_id());
+        let abi_sig = from_solidity_sig(&solidity_sig, Some(*attr), "function");
+        func_map.insert(fun.get_identifier().to_string(), abi_sig);
+    }
+
+    let mut constructor = None;
+    let constructor_triple_opt = ctx.constructor_triple.borrow().clone();
+    if let Some((_, solidity_sig, attr)) = constructor_triple_opt {
+        let abi_sig = from_solidity_sig(&solidity_sig, Some(attr), "constructor");
+        constructor = Some(abi_sig);
+    }
+
+    let abi_move = ABIMoveSignature {
+        constructor,
+        event_map,
+        func_map,
+        receive,
+        fallback,
+    };
+
+    let value_blob = serde_json::to_string_pretty(&abi_move)
+        .unwrap()
+        .as_bytes()
+        .to_vec();
+    Metadata {
+        key: ABI_ETHER_MOVE_KEY.as_bytes().to_vec(),
+        value: value_blob,
+    }
+}
+
+/// Parse Metata into ABIMoveSignature
+pub fn parse_metadata_to_move_sig(metadata: &Metadata) -> Option<ABIMoveSignature> {
+    let key = &metadata.key;
+    let value = &metadata.value;
+    let key_str = str::from_utf8(key).unwrap();
+    if key_str == ABI_ETHER_MOVE_KEY {
+        return Some(serde_json::from_str(str::from_utf8(value).unwrap()).unwrap());
+    }
+    None
+}

--- a/language/evm/move-to-yul/src/context.rs
+++ b/language/evm/move-to-yul/src/context.rs
@@ -10,7 +10,7 @@ use crate::{
     events::EventSignature,
     evm_transformation::EvmTransformationProcessor,
     native_functions::NativeFunctions,
-    solidity_ty::SolidityType,
+    solidity_ty::{SoliditySignature, SolidityType},
     yul_functions,
     yul_functions::YulFunction,
     Options,
@@ -70,6 +70,18 @@ pub(crate) struct Context<'a> {
     pub(crate) abi_struct_signature_map: RefCell<BTreeMap<QualifiedInstId<StructId>, SolidityType>>,
     /// Mapping of abi structs names to abi structs
     pub(crate) abi_struct_name_map: RefCell<BTreeMap<String, QualifiedInstId<StructId>>>,
+    /// Solidity signature for callable functions
+    pub(crate) callable_function_map: RefCell<
+        BTreeMap<QualifiedInstId<FunId>, (SoliditySignature, attributes::FunctionAttribute)>,
+    >,
+    /// Solidity signature for the constructor function
+    pub(crate) constructor_triple: RefCell<
+        Option<(
+            QualifiedInstId<FunId>,
+            SoliditySignature,
+            attributes::FunctionAttribute,
+        )>,
+    >,
     /// A code writer where we emit JSON-ABI.
     pub abi_writer: CodeWriter,
 }
@@ -142,6 +154,8 @@ impl<'a> Context<'a> {
             abi_structs: Default::default(),
             abi_struct_signature_map: Default::default(),
             abi_struct_name_map: Default::default(),
+            callable_function_map: Default::default(),
+            constructor_triple: Default::default(),
             abi_writer,
         };
         ctx.native_funs = NativeFunctions::create(&ctx);
@@ -346,6 +360,32 @@ impl<'a> Context<'a> {
 
     // --------------------------------------------------------------------------------------------
     // Signature Event Map
+
+    /// Build the callable signature map
+    pub fn build_callable_signature_map(
+        &self,
+        sig: &SoliditySignature,
+        attr: attributes::FunctionAttribute,
+        fun: &FunctionEnv,
+    ) {
+        let mut callable_signature_map_ref = self.callable_function_map.borrow_mut();
+        let fun_id = fun.get_qualified_id().instantiate(vec![]);
+        if callable_signature_map_ref.get(&fun_id).is_none() {
+            callable_signature_map_ref.insert(fun_id, (sig.clone(), attr));
+        }
+    }
+
+    /// Build the constructor
+    pub fn build_constructor(
+        &self,
+        sig: &SoliditySignature,
+        attr: attributes::FunctionAttribute,
+        fun: &FunctionEnv,
+    ) {
+        let fun_id = fun.get_qualified_id().instantiate(vec![]);
+        self.constructor_triple
+            .replace(Some((fun_id, sig.clone(), attr)));
+    }
 
     /// Build the event signature map
     pub fn build_event_signature_map(&self) {

--- a/language/evm/move-to-yul/src/generator.rs
+++ b/language/evm/move-to-yul/src/generator.rs
@@ -3,7 +3,9 @@
 
 use codespan_reporting::{diagnostic::Severity, term::termcolor::Buffer};
 use itertools::Itertools;
-use move_core_types::{identifier::IdentStr, language_storage::ModuleId, value::MoveValue};
+use move_core_types::{
+    identifier::IdentStr, language_storage::ModuleId, metadata::Metadata, value::MoveValue,
+};
 use std::collections::{BTreeMap, BTreeSet};
 
 use move_model::{
@@ -13,6 +15,7 @@ use move_model::{
 };
 
 use crate::{
+    abi_move_metadata::generate_abi_move_metadata,
     abi_signature::{from_event_sig, from_solidity_sig},
     attributes,
     context::Context,
@@ -133,6 +136,28 @@ impl Generator {
             Ok(ctx.writer.extract_result())
         }
     }
+
+    /// Generate metadata
+    pub(crate) fn generate_abi_metadata(options: &Options, env: &GlobalEnv) -> Vec<Metadata> {
+        let ctx = &Context::new(options, env, false);
+        let mut meta_vec = vec![];
+        for contract in ctx.derive_contracts() {
+            let module = &ctx.env.get_module(contract.module);
+            if !module.is_target() {
+                // Ignore contract from module not target of compilation
+                continue;
+            }
+            let mut gen = Generator::default();
+            gen.compute_ethereum_signatures(ctx, &contract);
+            let metadata = generate_abi_move_metadata(
+                ctx,
+                contract.receive.is_some(),
+                contract.fallback.is_some(),
+            );
+            meta_vec.push(metadata);
+        }
+        meta_vec
+    }
 }
 
 // ================================================================================================
@@ -189,6 +214,44 @@ impl Generator {
         });
         // Generate JSON-ABI
         self.generate_abi_string(ctx);
+    }
+
+    /// Compute ethereum signatures and returns whether
+    pub(crate) fn compute_ethereum_signatures(&mut self, ctx: &Context, contract: &Contract) {
+        let module = &ctx.env.get_module(contract.module);
+        let constructor_opt = contract.constructor.map(|f| module.get_function(f));
+        if let Some(constructor) = constructor_opt {
+            let solidity_sig_constructor = self.get_solidity_signature(ctx, &constructor, false);
+            if let Some(fun_attr_opt) = attributes::construct_fun_attribute(&constructor) {
+                ctx.build_constructor(&solidity_sig_constructor, fun_attr_opt, &constructor);
+            }
+        }
+
+        let callables = contract
+            .callables
+            .iter()
+            .map(|f| module.get_function(*f))
+            .collect_vec();
+
+        for fun in callables {
+            if !self.is_suitable_for_dispatch(ctx, &fun) {
+                ctx.env.diag(
+                    Severity::Warning,
+                    &fun.get_loc(),
+                    "cannot dispatch this function because of unsupported parameter types",
+                );
+                continue;
+            }
+            let sig = self.get_solidity_signature(ctx, &fun, true);
+            if let Some(fun_attr_opt) = attributes::construct_fun_attribute(&fun) {
+                ctx.build_callable_signature_map(&sig, fun_attr_opt, &fun);
+            } else {
+                ctx.env.error(
+                    &fun.get_loc(),
+                    "callable functions can only have one attribute among payable, pure and view",
+                );
+            }
+        }
     }
 
     /// Generate JSON-ABI

--- a/language/evm/move-to-yul/src/lib.rs
+++ b/language/evm/move-to-yul/src/lib.rs
@@ -3,6 +3,8 @@
 
 #![forbid(unsafe_code)]
 
+mod abi_move_metadata;
+pub use abi_move_metadata::parse_metadata_to_move_sig;
 mod abi_native_functions;
 mod abi_signature;
 mod attributes;
@@ -29,6 +31,7 @@ use codespan_reporting::{
     term::termcolor::{ColorChoice, StandardStream, WriteColor},
 };
 use move_compiler::shared::PackagePaths;
+use move_core_types::metadata::Metadata;
 use move_model::{
     model::GlobalEnv, options::ModelBuilderOptions, parse_addresses_from_options,
     run_model_builder_with_options,
@@ -88,6 +91,43 @@ pub fn run_to_yul<W: WriteColor>(error_writer: &mut W, mut options: Options) -> 
         fs::write(options.abi_output, &abi_content)?;
     }
     Ok(())
+}
+
+/// Generate metadata for move-ethereum-abi
+pub fn run_to_abi_metadata<W: WriteColor>(
+    error_writer: &mut W,
+    options: Options,
+) -> anyhow::Result<Vec<Metadata>> {
+    // Run the model builder.
+    let addrs = parse_addresses_from_options(options.named_address_mapping.clone())?;
+    let env = run_model_builder_with_options(
+        vec![PackagePaths {
+            name: None,
+            paths: options.sources.clone(),
+            named_address_map: addrs.clone(),
+        }],
+        vec![PackagePaths {
+            name: None,
+            paths: options.dependencies.clone(),
+            named_address_map: addrs,
+        }],
+        ModelBuilderOptions::default(),
+    )?;
+    // If the model contains any errors, report them now and exit.
+    check_errors(
+        &env,
+        &options,
+        error_writer,
+        "exiting with Move build errors",
+    )?;
+    let metadata_vec = Generator::generate_abi_metadata(&options, &env);
+    check_errors(
+        &env,
+        &options,
+        error_writer,
+        "exiting with Yul generation errors",
+    )?;
+    Ok(metadata_vec)
 }
 
 pub fn check_errors<W: WriteColor>(


### PR DESCRIPTION
## Motivation

1. Add a cli to generate metadata from ABIMoveSignature
2. Convert ABIMoveSignature to ethabi::Contract

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

CI/CD tests are covered.