### PR TITLE
[move-lang] Fix ControlFlowGraph trait (#195)_98

### DIFF
--- a/language/move-binary-format/src/control_flow_graph.rs
+++ b/language/move-binary-format/src/control_flow_graph.rs
@@ -22,7 +22,8 @@ pub trait ControlFlowGraph {
     /// Successors of the block ID in the bytecode vector
     fn successors(&self, block_id: BlockId) -> &Vec<BlockId>;
 
-    fn next_block(&self, block_id: BlockId) -> Option<CodeOffset>;
+    /// Return the next block in traversal order
+    fn next_block(&self, block_id: BlockId) -> Option<BlockId>;
 
     /// Iterator over the indexes of instructions in this block
     fn instr_indexes(&self, block_id: BlockId) -> Box<dyn Iterator<Item = CodeOffset>>;


### PR DESCRIPTION
## Motivation

- Fix the signature of next_block and add documentation.
- The next_block method returns the block id of the next block to traverse. The current return type however is CodeOffset, which is rather confusing.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Since `pub type BlockId = CodeOffset`;, this change won't affect execution.