### PR TITLE
fix the wrong logic in VMStatus::status_code() #197_99

### DIFF
--- a/language/move-core/types/src/unit_tests/mod.rs
+++ b/language/move-core/types/src/unit_tests/mod.rs
@@ -4,3 +4,4 @@
 mod identifier_test;
 mod language_storage_test;
 mod value_test;
+mod vm_status_test;

--- a/language/move-core/types/src/unit_tests/vm_status_test.rs
+++ b/language/move-core/types/src/unit_tests/vm_status_test.rs
@@ -1,0 +1,11 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::vm_status::{StatusCode, VMStatus};
+
+#[test]
+fn test_stats_code() {
+    let vm_status = VMStatus::Error(StatusCode::OUT_OF_GAS);
+    let code = vm_status.status_code();
+    assert_eq!(code, StatusCode::OUT_OF_GAS);
+}

--- a/language/move-core/types/src/vm_status.rs
+++ b/language/move-core/types/src/vm_status.rs
@@ -129,7 +129,9 @@ impl VMStatus {
                 let code = *code;
                 debug_assert!(code != StatusCode::EXECUTED);
                 debug_assert!(code != StatusCode::ABORTED);
-                debug_assert!(code.status_type() != StatusType::Execution);
+                debug_assert!(
+                    code.status_type() != StatusType::Execution || code == StatusCode::OUT_OF_GAS
+                );
                 code
             }
         }


### PR DESCRIPTION
## Motivation

fix the wrong logic in VMStatus::status_code()

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

CI/CD tests are covered.