### PR TITLE
[move-vm] Fix compatibility issues for new entry modifier #190_96

### DIFF
--- a/language/move-binary-format/src/compatibility.rs
+++ b/language/move-binary-format/src/compatibility.rs
@@ -3,6 +3,7 @@
 
 use crate::{
     file_format::{AbilitySet, StructTypeParameter, Visibility},
+    file_format_common::VERSION_5,
     normalized::Module,
 };
 use std::collections::BTreeSet;
@@ -13,6 +14,7 @@ use std::collections::BTreeSet;
 /// `{ struct_and_function_linking: true, struct_layout: false }`: Dependent modules that reference functions or types in this module may not link. However, fixing, recompiling, and redeploying all dependent modules will work--no data migration needed.
 /// `{ type_and_function_linking: true, struct_layout: false }`: Attempting to read structs published by this module will now fail at runtime. However, dependent modules will continue to link. Requires data migration, but no changes to dependent modules.
 /// `{ type_and_function_linking: false, struct_layout: false }`: Everything is broken. Need both a data migration and changes to dependent modules.
+#[derive(PartialEq, Eq, Debug, Clone, Copy)]
 pub struct Compatibility {
     /// If false, dependent modules that reference functions or structs in this module may not link
     pub struct_and_function_linking: bool,
@@ -107,16 +109,27 @@ impl Compatibility {
                 }
             };
             let is_vis_compatible = match (old_func.visibility, new_func.visibility) {
+                // public must remain public
                 (Visibility::Public, Visibility::Public) => true,
                 (Visibility::Public, _) => false,
+                // friend can become public or remain friend
                 (Visibility::Friend, Visibility::Public)
                 | (Visibility::Friend, Visibility::Friend) => true,
                 (Visibility::Friend, _) => false,
+                // private can become public or friend, or stay private
                 (Visibility::Private, _) => true,
             };
-            // If it was an entry function, it must remain one.
-            // If it was not an entry function, it is allowed to become one.
-            let is_entry_compatible = !old_func.is_entry || new_func.is_entry;
+            let is_entry_compatible = if old_module.file_format_version < VERSION_5
+                && new_module.file_format_version < VERSION_5
+            {
+                // if it was public(script), it must remain pubic(script)
+                // if it was not public(script), it _cannot_ become public(script)
+                old_func.is_entry == new_func.is_entry
+            } else {
+                // If it was an entry function, it must remain one.
+                // If it was not an entry function, it is allowed to become one.
+                !old_func.is_entry || new_func.is_entry
+            };
             if !is_vis_compatible
                 || !is_entry_compatible
                 || old_func.parameters != new_func.parameters

--- a/language/move-binary-format/src/normalized.rs
+++ b/language/move-binary-format/src/normalized.rs
@@ -88,6 +88,7 @@ pub struct Function {
 /// function declarations.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct Module {
+    pub file_format_version: u32,
     pub address: AccountAddress,
     pub name: Identifier,
     pub friends: Vec<ModuleId>,
@@ -117,6 +118,7 @@ impl Module {
             .collect();
 
         Self {
+            file_format_version: m.version(),
             address: *m.address(),
             name: m.name().to_owned(),
             friends,

--- a/language/move-binary-format/src/unit_tests/compatibility_tests.rs
+++ b/language/move-binary-format/src/unit_tests/compatibility_tests.rs
@@ -1,0 +1,134 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use std::convert::TryFrom;
+
+use crate::{compatibility::Compatibility, file_format::*, normalized};
+use move_core_types::{account_address::AccountAddress, identifier::Identifier};
+
+fn mk_module(vis: u8) -> normalized::Module {
+    let (visibility, is_entry) = if vis == Visibility::DEPRECATED_SCRIPT {
+        (Visibility::Public, true)
+    } else {
+        (Visibility::try_from(vis).unwrap(), false)
+    };
+    let m = CompiledModule {
+        version: crate::file_format_common::VERSION_4,
+        module_handles: vec![
+            // only self module
+            ModuleHandle {
+                address: AddressIdentifierIndex(0),
+                name: IdentifierIndex(0),
+            },
+        ],
+        self_module_handle_idx: ModuleHandleIndex(0),
+        identifiers: vec![
+            Identifier::new("M").unwrap(),  // Module name
+            Identifier::new("fn").unwrap(), // Function name
+        ],
+        address_identifiers: vec![
+            AccountAddress::ZERO, // Module address
+        ],
+        function_handles: vec![
+            // fun fn()
+            FunctionHandle {
+                module: ModuleHandleIndex(0),
+                name: IdentifierIndex(1),
+                parameters: SignatureIndex(0),
+                return_: SignatureIndex(0),
+                type_parameters: vec![],
+            },
+        ],
+        function_defs: vec![
+            // public(script) fun fn() { return; }
+            FunctionDefinition {
+                function: FunctionHandleIndex(0),
+                visibility,
+                is_entry,
+                acquires_global_resources: vec![],
+                code: Some(CodeUnit {
+                    locals: SignatureIndex(0),
+                    code: vec![Bytecode::Ret],
+                }),
+            },
+        ],
+        signatures: vec![
+            Signature(vec![]), // void
+        ],
+        struct_defs: vec![],
+        struct_handles: vec![],
+        constant_pool: vec![],
+        metadata: vec![],
+        field_handles: vec![],
+        friend_decls: vec![],
+        struct_def_instantiations: vec![],
+        function_instantiations: vec![],
+        field_instantiations: vec![],
+    };
+    normalized::Module::new(&m)
+}
+
+const NON_COMPATIBLE: Compatibility = Compatibility {
+    struct_and_function_linking: false,
+    struct_layout: true,
+};
+
+const COMPATIBLE: Compatibility = Compatibility {
+    struct_and_function_linking: true,
+    struct_layout: true,
+};
+
+#[test]
+fn deprecated_unchanged_script_visibility() {
+    let script_module = mk_module(Visibility::DEPRECATED_SCRIPT);
+    assert_eq!(
+        Compatibility::check(&script_module, &script_module,),
+        COMPATIBLE
+    );
+}
+
+#[test]
+fn deprecated_remove_script_visibility() {
+    let script_module = mk_module(Visibility::DEPRECATED_SCRIPT);
+    // script -> private, not allowed
+    let private_module = mk_module(Visibility::Private as u8);
+    assert_eq!(
+        Compatibility::check(&script_module, &private_module),
+        NON_COMPATIBLE
+    );
+    // script -> public, not allowed
+    let public_module = mk_module(Visibility::Public as u8);
+    assert_eq!(
+        Compatibility::check(&script_module, &public_module),
+        NON_COMPATIBLE
+    );
+    // script -> friend, not allowed
+    let friend_module = mk_module(Visibility::Friend as u8);
+    assert_eq!(
+        Compatibility::check(&script_module, &friend_module),
+        NON_COMPATIBLE
+    );
+}
+
+#[test]
+fn deprecated_add_script_visibility() {
+    let script_module = mk_module(Visibility::DEPRECATED_SCRIPT);
+    // private -> script, allowed
+    let private_module = mk_module(Visibility::Private as u8);
+    assert_eq!(
+        Compatibility::check(&private_module, &script_module,),
+        COMPATIBLE
+    );
+    // public -> script, not allowed
+    let public_module = mk_module(Visibility::Public as u8);
+    assert_eq!(
+        Compatibility::check(&public_module, &script_module),
+        NON_COMPATIBLE
+    );
+    // friend -> script, not allowed
+    let friend_module = mk_module(Visibility::Friend as u8);
+    assert_eq!(
+        Compatibility::check(&friend_module, &script_module),
+        NON_COMPATIBLE
+    );
+}

--- a/language/move-binary-format/src/unit_tests/mod.rs
+++ b/language/move-binary-format/src/unit_tests/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 mod binary_tests;
+mod compatibility_tests;
 mod deserializer_tests;
 mod number_tests;
 mod signature_token_tests;

--- a/language/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/dependencies_tests.rs
+++ b/language/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/dependencies_tests.rs
@@ -1,0 +1,294 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use move_binary_format::file_format::*;
+use move_bytecode_verifier::dependencies;
+use move_core_types::{
+    account_address::AccountAddress, identifier::Identifier, vm_status::StatusCode,
+};
+
+fn mk_script_function_module() -> CompiledModule {
+    let m = CompiledModule {
+        version: move_binary_format::file_format_common::VERSION_4,
+        module_handles: vec![
+            // only self module
+            ModuleHandle {
+                address: AddressIdentifierIndex(0),
+                name: IdentifierIndex(0),
+            },
+        ],
+        self_module_handle_idx: ModuleHandleIndex(0),
+        identifiers: vec![
+            Identifier::new("M").unwrap(),    // Module name
+            Identifier::new("fn").unwrap(),   // Function name
+            Identifier::new("g_fn").unwrap(), // Generic function name
+        ],
+        address_identifiers: vec![
+            AccountAddress::ZERO, // Module address
+        ],
+        function_handles: vec![
+            // fun fn()
+            FunctionHandle {
+                module: ModuleHandleIndex(0),
+                name: IdentifierIndex(1),
+                parameters: SignatureIndex(0),
+                return_: SignatureIndex(0),
+                type_parameters: vec![],
+            },
+            // fun g_fn<T>()
+            FunctionHandle {
+                module: ModuleHandleIndex(0),
+                name: IdentifierIndex(2),
+                parameters: SignatureIndex(0),
+                return_: SignatureIndex(0),
+                type_parameters: vec![AbilitySet::EMPTY],
+            },
+        ],
+        function_defs: vec![
+            // public(script)  fun fn() { return; }
+            FunctionDefinition {
+                function: FunctionHandleIndex(0),
+                visibility: Visibility::Public,
+                is_entry: true,
+                acquires_global_resources: vec![],
+                code: Some(CodeUnit {
+                    locals: SignatureIndex(0),
+                    code: vec![Bytecode::Ret],
+                }),
+            },
+            // public(script) fun g_fn<T>() { return; }
+            FunctionDefinition {
+                function: FunctionHandleIndex(1),
+                visibility: Visibility::Public,
+                is_entry: true,
+                acquires_global_resources: vec![],
+                code: Some(CodeUnit {
+                    locals: SignatureIndex(0),
+                    code: vec![Bytecode::Ret],
+                }),
+            },
+        ],
+        signatures: vec![
+            Signature(vec![]), // void
+        ],
+        struct_defs: vec![],
+        struct_handles: vec![],
+        constant_pool: vec![],
+        metadata: vec![],
+        field_handles: vec![],
+        friend_decls: vec![],
+        struct_def_instantiations: vec![],
+        function_instantiations: vec![],
+        field_instantiations: vec![],
+    };
+    move_bytecode_verifier::verify_module(&m).unwrap();
+    m
+}
+
+fn mk_invoking_module(use_generic: bool, valid: bool) -> CompiledModule {
+    let call = if use_generic {
+        Bytecode::CallGeneric(FunctionInstantiationIndex(0))
+    } else {
+        Bytecode::Call(FunctionHandleIndex(1))
+    };
+    let m = CompiledModule {
+        version: move_binary_format::file_format_common::VERSION_4,
+        module_handles: vec![
+            // self module
+            ModuleHandle {
+                address: AddressIdentifierIndex(0),
+                name: IdentifierIndex(0),
+            },
+            // other module
+            ModuleHandle {
+                address: AddressIdentifierIndex(0),
+                name: IdentifierIndex(2),
+            },
+        ],
+        self_module_handle_idx: ModuleHandleIndex(0),
+        identifiers: vec![
+            Identifier::new("Test").unwrap(),    // Module name
+            Identifier::new("test_fn").unwrap(), // test name
+            Identifier::new("M").unwrap(),       // Other Module name
+            Identifier::new("fn").unwrap(),      // Other Function name
+            Identifier::new("g_fn").unwrap(),    // Other Generic function name
+        ],
+        address_identifiers: vec![
+            AccountAddress::ZERO, // Module address
+        ],
+        function_handles: vec![
+            // Self::test_fn()
+            FunctionHandle {
+                module: ModuleHandleIndex(0),
+                name: IdentifierIndex(1),
+                parameters: SignatureIndex(0),
+                return_: SignatureIndex(0),
+                type_parameters: vec![],
+            },
+            // 0::M::fn()
+            FunctionHandle {
+                module: ModuleHandleIndex(1),
+                name: IdentifierIndex(3),
+                parameters: SignatureIndex(0),
+                return_: SignatureIndex(0),
+                type_parameters: vec![],
+            },
+            // 0::M::g_fn<T>()
+            FunctionHandle {
+                module: ModuleHandleIndex(1),
+                name: IdentifierIndex(4),
+                parameters: SignatureIndex(0),
+                return_: SignatureIndex(0),
+                type_parameters: vec![AbilitySet::EMPTY],
+            },
+        ],
+        // 0::M::g_fn<u64>()
+        function_instantiations: vec![FunctionInstantiation {
+            handle: FunctionHandleIndex(2),
+            type_parameters: SignatureIndex(1),
+        }],
+        function_defs: vec![
+            // fun fn() { return; }
+            FunctionDefinition {
+                function: FunctionHandleIndex(0),
+                visibility: Visibility::Public,
+                is_entry: valid,
+                acquires_global_resources: vec![],
+                code: Some(CodeUnit {
+                    locals: SignatureIndex(0),
+                    code: vec![call, Bytecode::Ret],
+                }),
+            },
+        ],
+        signatures: vec![
+            Signature(vec![]),                    // void
+            Signature(vec![SignatureToken::U64]), // u64
+        ],
+        struct_defs: vec![],
+        struct_handles: vec![],
+        constant_pool: vec![],
+        metadata: vec![],
+        field_handles: vec![],
+        friend_decls: vec![],
+        struct_def_instantiations: vec![],
+        field_instantiations: vec![],
+    };
+    move_bytecode_verifier::verify_module(&m).unwrap();
+    m
+}
+
+fn mk_invoking_script(use_generic: bool) -> CompiledScript {
+    let call = if use_generic {
+        Bytecode::CallGeneric(FunctionInstantiationIndex(0))
+    } else {
+        Bytecode::Call(FunctionHandleIndex(0))
+    };
+    let s = CompiledScript {
+        version: move_binary_format::file_format_common::VERSION_4,
+        module_handles: vec![
+            // other module
+            ModuleHandle {
+                address: AddressIdentifierIndex(0),
+                name: IdentifierIndex(0),
+            },
+        ],
+        identifiers: vec![
+            Identifier::new("M").unwrap(),    // Other Module name
+            Identifier::new("fn").unwrap(),   // Other Function name
+            Identifier::new("g_fn").unwrap(), // Other Generic function name
+        ],
+        address_identifiers: vec![
+            AccountAddress::ZERO, // Module address
+        ],
+        function_handles: vec![
+            // 0::M::fn()
+            FunctionHandle {
+                module: ModuleHandleIndex(0),
+                name: IdentifierIndex(1),
+                parameters: SignatureIndex(0),
+                return_: SignatureIndex(0),
+                type_parameters: vec![],
+            },
+            // 0::M::g_fn<T>()
+            FunctionHandle {
+                module: ModuleHandleIndex(0),
+                name: IdentifierIndex(2),
+                parameters: SignatureIndex(0),
+                return_: SignatureIndex(0),
+                type_parameters: vec![AbilitySet::EMPTY],
+            },
+        ],
+        // 0::M::g_fn<u64>()
+        function_instantiations: vec![FunctionInstantiation {
+            handle: FunctionHandleIndex(1),
+            type_parameters: SignatureIndex(1),
+        }],
+        type_parameters: vec![],
+        parameters: SignatureIndex(0),
+        code: CodeUnit {
+            locals: SignatureIndex(0),
+            code: vec![call, Bytecode::Ret],
+        },
+        signatures: vec![
+            Signature(vec![]),                    // void
+            Signature(vec![SignatureToken::U64]), // u64
+        ],
+        struct_handles: vec![],
+        constant_pool: vec![],
+        metadata: vec![],
+    };
+    move_bytecode_verifier::verify_script(&s).unwrap();
+    s
+}
+
+#[test]
+
+// tests the deprecated Script visibility logic for < V5
+// tests correct permissible invocation of Script functions
+fn deprecated_script_visibility_checks_valid() {
+    let script_function_module = mk_script_function_module();
+    let deps = &[script_function_module];
+
+    // module uses script functions from script context
+    let is_valid = true;
+    let non_generic_call_mod = mk_invoking_module(false, is_valid);
+    let result = dependencies::verify_module(&non_generic_call_mod, deps);
+    assert!(result.is_ok());
+
+    let generic_call_mod = mk_invoking_module(true, is_valid);
+    let result = dependencies::verify_module(&generic_call_mod, deps);
+    assert!(result.is_ok());
+
+    // script uses script functions
+    let non_generic_call_script = mk_invoking_script(false);
+    let result = dependencies::verify_script(&non_generic_call_script, deps);
+    assert!(result.is_ok());
+
+    let generic_call_script = mk_invoking_script(true);
+    let result = dependencies::verify_script(&generic_call_script, deps);
+    assert!(result.is_ok());
+}
+
+#[test]
+// tests the deprecated Script visibility logic for < V5
+// tests correct non-permissible invocation of Script functions
+fn deprecated_script_visibility_checks_invalid() {
+    let script_function_module = mk_script_function_module();
+    let deps = &[script_function_module];
+
+    // module uses script functions from script context
+    let not_valid = false;
+    let non_generic_call_mod = mk_invoking_module(false, not_valid);
+    let result = dependencies::verify_module(&non_generic_call_mod, deps);
+    assert_eq!(
+        result.unwrap_err().major_status(),
+        StatusCode::CALLED_SCRIPT_VISIBLE_FROM_NON_SCRIPT_VISIBLE,
+    );
+
+    let generic_call_mod = mk_invoking_module(true, not_valid);
+    let result = dependencies::verify_module(&generic_call_mod, deps);
+    assert_eq!(
+        result.unwrap_err().major_status(),
+        StatusCode::CALLED_SCRIPT_VISIBLE_FROM_NON_SCRIPT_VISIBLE,
+    );
+}

--- a/language/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/mod.rs
+++ b/language/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/mod.rs
@@ -6,6 +6,7 @@ pub mod bounds_tests;
 pub mod code_unit_tests;
 pub mod constants_tests;
 pub mod control_flow_tests;
+pub mod dependencies_tests;
 pub mod duplication_tests;
 pub mod generic_ops_tests;
 pub mod multi_pass_tests;

--- a/language/move-bytecode-verifier/src/dependencies.rs
+++ b/language/move-bytecode-verifier/src/dependencies.rs
@@ -3,29 +3,34 @@
 
 //! This module contains verification of usage of dependencies for modules and scripts.
 use move_binary_format::{
-    access::ModuleAccess,
+    access::{ModuleAccess, ScriptAccess},
     binary_views::BinaryIndexedView,
     errors::{verification_error, Location, PartialVMError, PartialVMResult, VMResult},
     file_format::{
-        AbilitySet, CompiledModule, CompiledScript, FunctionHandleIndex, ModuleHandleIndex,
-        SignatureToken, StructHandleIndex, StructTypeParameter, TableIndex, Visibility,
+        AbilitySet, Bytecode, CodeOffset, CompiledModule, CompiledScript, FunctionDefinitionIndex,
+        FunctionHandleIndex, ModuleHandleIndex, SignatureToken, StructHandleIndex,
+        StructTypeParameter, TableIndex, Visibility,
     },
+    file_format_common::VERSION_5,
     IndexKind,
 };
 use move_core_types::{identifier::Identifier, language_storage::ModuleId, vm_status::StatusCode};
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet};
 
 struct Context<'a, 'b> {
     resolver: BinaryIndexedView<'a>,
     // (Module -> CompiledModule) for (at least) all immediate dependencies
     dependency_map: BTreeMap<ModuleId, &'b CompiledModule>,
     // (Module::StructName -> handle) for all types of all dependencies
-    struct_id_to_handle_map: HashMap<(ModuleId, Identifier), StructHandleIndex>,
+    struct_id_to_handle_map: BTreeMap<(ModuleId, Identifier), StructHandleIndex>,
     // (Module::FunctionName -> handle) for all functions that can ever be called by this
     // module/script in all dependencies
-    func_id_to_handle_map: HashMap<(ModuleId, Identifier), FunctionHandleIndex>,
+    func_id_to_handle_map: BTreeMap<(ModuleId, Identifier), FunctionHandleIndex>,
     // (handle -> visibility) for all function handles found in the module being checked
-    function_visibilities: HashMap<FunctionHandleIndex, Visibility>,
+    function_visibilities: BTreeMap<FunctionHandleIndex, Visibility>,
+    // all function handles found in the module being checked that are script functions in <V5
+    // None if the current module/script >= V5
+    script_functions: Option<BTreeSet<FunctionHandleIndex>>,
 }
 
 impl<'a, 'b> Context<'a, 'b> {
@@ -60,15 +65,21 @@ impl<'a, 'b> Context<'a, 'b> {
             .map(|d| (d.self_id(), d))
             .collect();
 
+        let script_functions = if resolver.version() < VERSION_5 {
+            Some(BTreeSet::new())
+        } else {
+            None
+        };
         let mut context = Self {
             resolver,
             dependency_map,
-            struct_id_to_handle_map: HashMap::new(),
-            func_id_to_handle_map: HashMap::new(),
-            function_visibilities: HashMap::new(),
+            struct_id_to_handle_map: BTreeMap::new(),
+            func_id_to_handle_map: BTreeMap::new(),
+            function_visibilities: BTreeMap::new(),
+            script_functions,
         };
 
-        let mut dependency_visibilities = HashMap::new();
+        let mut dependency_visibilities = BTreeMap::new();
         for (module_id, module) in &context.dependency_map {
             let friend_module_ids: BTreeSet<_> = module.immediate_friends().into_iter().collect();
 
@@ -87,7 +98,7 @@ impl<'a, 'b> Context<'a, 'b> {
                 let func_name = module.identifier_at(func_handle.name);
                 dependency_visibilities.insert(
                     (module_id.clone(), func_name.to_owned()),
-                    func_def.visibility,
+                    (func_def.visibility, func_def.is_entry),
                 );
                 let may_be_called = match func_def.visibility {
                     Visibility::Public => true,
@@ -105,29 +116,43 @@ impl<'a, 'b> Context<'a, 'b> {
         }
 
         for function_def in self_function_defs {
-            let visibility = function_def.visibility;
             context
                 .function_visibilities
-                .insert(function_def.function, visibility);
+                .insert(function_def.function, function_def.visibility);
+            if function_def.is_entry {
+                context
+                    .script_functions
+                    .as_mut()
+                    .map(|s| s.insert(function_def.function));
+            }
         }
         for (idx, function_handle) in context.resolver.function_handles().iter().enumerate() {
             if Some(function_handle.module) == self_module_idx {
                 continue;
             }
-            let owner_module_id = context
+            let dep_module_id = context
                 .resolver
                 .module_id_for_handle(context.resolver.module_handle_at(function_handle.module));
             let function_name = context.resolver.identifier_at(function_handle.name);
-            let visibility =
-                match dependency_visibilities.get(&(owner_module_id, function_name.to_owned())) {
-                    // The visibility does not need to be set here. If the function does not
-                    // link, it will be reported by verify_imported_functions
-                    None => continue,
-                    Some(vis) => *vis,
-                };
+            let dep_file_format_version =
+                context.dependency_map.get(&dep_module_id).unwrap().version;
+            let dep_function = (dep_module_id, function_name.to_owned());
+            let (visibility, is_entry) = match dependency_visibilities.get(&dep_function) {
+                // The visibility does not need to be set here. If the function does not
+                // link, it will be reported by verify_imported_functions
+                None => continue,
+                Some(vis_entry) => *vis_entry,
+            };
+            let fhandle_idx = FunctionHandleIndex(idx as TableIndex);
             context
                 .function_visibilities
-                .insert(FunctionHandleIndex(idx as TableIndex), visibility);
+                .insert(fhandle_idx, visibility);
+            if dep_file_format_version < VERSION_5 && is_entry {
+                context
+                    .script_functions
+                    .as_mut()
+                    .map(|s| s.insert(fhandle_idx));
+            }
         }
 
         context
@@ -150,7 +175,8 @@ fn verify_module_impl<'a>(
 
     verify_imported_modules(context)?;
     verify_imported_structs(context)?;
-    verify_imported_functions(context)
+    verify_imported_functions(context)?;
+    verify_all_script_visibility_usage(context)
 }
 
 pub fn verify_script<'a>(
@@ -168,7 +194,8 @@ pub fn verify_script_impl<'a>(
 
     verify_imported_modules(context)?;
     verify_imported_structs(context)?;
-    verify_imported_functions(context)
+    verify_imported_functions(context)?;
+    verify_all_script_visibility_usage(context)
 }
 
 fn verify_imported_modules(context: &Context) -> PartialVMResult<()> {
@@ -471,4 +498,73 @@ fn compare_structs(
     } else {
         Ok(())
     }
+}
+
+fn verify_all_script_visibility_usage(context: &Context) -> PartialVMResult<()> {
+    // script visibility deprecated after V5
+    let script_functions = match &context.script_functions {
+        None => return Ok(()),
+        Some(s) => s,
+    };
+    debug_assert!(context.resolver.version() < VERSION_5);
+    match &context.resolver {
+        BinaryIndexedView::Module(m) => {
+            for (idx, fdef) in m.function_defs().iter().enumerate() {
+                let code = match &fdef.code {
+                    None => continue,
+                    Some(code) => &code.code,
+                };
+                verify_script_visibility_usage(
+                    &context.resolver,
+                    script_functions,
+                    fdef.is_entry,
+                    FunctionDefinitionIndex(idx as TableIndex),
+                    code,
+                )?
+            }
+            Ok(())
+        }
+        BinaryIndexedView::Script(s) => verify_script_visibility_usage(
+            &context.resolver,
+            script_functions,
+            true,
+            FunctionDefinitionIndex(0),
+            &s.code().code,
+        ),
+    }
+}
+
+fn verify_script_visibility_usage(
+    resolver: &BinaryIndexedView,
+    script_functions: &BTreeSet<FunctionHandleIndex>,
+    current_is_entry: bool,
+    fdef_idx: FunctionDefinitionIndex,
+    code: &[Bytecode],
+) -> PartialVMResult<()> {
+    for (idx, instr) in code.iter().enumerate() {
+        let idx = idx as CodeOffset;
+        let fhandle_idx = match instr {
+            Bytecode::Call(fhandle_idx) => fhandle_idx,
+            Bytecode::CallGeneric(finst_idx) => {
+                &resolver.function_instantiation_at(*finst_idx).handle
+            }
+            _ => continue,
+        };
+        match (current_is_entry, script_functions.contains(&fhandle_idx)) {
+            (true, true) => (),
+            (_, true) => {
+                return Err(PartialVMError::new(
+                    StatusCode::CALLED_SCRIPT_VISIBLE_FROM_NON_SCRIPT_VISIBLE,
+                )
+                .at_code_offset(fdef_idx, idx)
+                .with_message(
+                    "script-visible functions can only be called from scripts or other \
+                    script-visible functions"
+                        .to_string(),
+                ));
+            }
+            _ => (),
+        }
+    }
+    Ok(())
 }

--- a/language/move-compiler/src/interface_generator.rs
+++ b/language/move-compiler/src/interface_generator.rs
@@ -219,7 +219,7 @@ fn write_function_def(ctx: &mut Context, fdef: &FunctionDefinition) -> String {
     let return_ = &ctx.module.signature_at(fhandle.return_).0;
     format!(
         "    native {}fun {}{}({}){};",
-        write_visibility(fdef.visibility, fdef.is_entry),
+        write_visibility(fdef.visibility),
         ctx.module.identifier_at(fhandle.name),
         write_fun_type_parameters(&fhandle.type_parameters),
         write_parameters(ctx, parameters),
@@ -227,11 +227,9 @@ fn write_function_def(ctx: &mut Context, fdef: &FunctionDefinition) -> String {
     )
 }
 
-fn write_visibility(visibility: Visibility, is_entry: bool) -> String {
+fn write_visibility(visibility: Visibility) -> String {
     match visibility {
-        Visibility::Public if is_entry => "public(script) ",
         Visibility::Public => "public ",
-        _ if is_entry => panic!("ICE non-public entry functions are not yet supported"),
         Visibility::Friend => "public(friend) ",
         Visibility::Private => "",
     }

--- a/language/move-vm/transactional-tests/tests/module_publishing/republish_module_compatible_add_entry.exp
+++ b/language/move-vm/transactional-tests/tests/module_publishing/republish_module_compatible_add_entry.exp
@@ -1,0 +1,1 @@
+processed 6 tasks

--- a/language/move-vm/transactional-tests/tests/module_publishing/republish_module_compatible_add_entry.mvir
+++ b/language/move-vm/transactional-tests/tests/module_publishing/republish_module_compatible_add_entry.mvir
@@ -1,0 +1,49 @@
+// entry can be added to functions
+
+//# publish
+module 0x42.Priv {
+    foo() {
+    label b0:
+        return;
+    }
+}
+
+//# publish
+module 0x42.Priv {
+    entry foo() {
+    label b0:
+        return;
+    }
+}
+
+//# publish
+module 0x42.Pub {
+    public foo() {
+    label b0:
+        return;
+    }
+}
+
+//# publish
+module 0x42.Pub {
+    public entry foo() {
+    label b0:
+        return;
+    }
+}
+
+//# publish
+module 0x42.Fr {
+    public(friend) foo() {
+    label b0:
+        return;
+    }
+}
+
+//# publish
+module 0x42.Fr {
+    public(friend) entry foo() {
+    label b0:
+        return;
+    }
+}

--- a/language/move-vm/transactional-tests/tests/module_publishing/republish_module_incompatible_entry_removed.exp
+++ b/language/move-vm/transactional-tests/tests/module_publishing/republish_module_incompatible_entry_removed.exp
@@ -1,0 +1,28 @@
+processed 6 tasks
+
+task 1 'publish'. lines 11-17:
+Error: Unable to publish module '00000000000000000000000000000042::Priv'. Got VMError: {
+    major_status: BACKWARD_INCOMPATIBLE_MODULE_UPDATE,
+    sub_status: None,
+    location: undefined,
+    indices: [],
+    offsets: [],
+}
+
+task 3 'publish'. lines 27-33:
+Error: Unable to publish module '00000000000000000000000000000042::Pub'. Got VMError: {
+    major_status: BACKWARD_INCOMPATIBLE_MODULE_UPDATE,
+    sub_status: None,
+    location: undefined,
+    indices: [],
+    offsets: [],
+}
+
+task 5 'publish'. lines 43-49:
+Error: Unable to publish module '00000000000000000000000000000042::Fr'. Got VMError: {
+    major_status: BACKWARD_INCOMPATIBLE_MODULE_UPDATE,
+    sub_status: None,
+    location: undefined,
+    indices: [],
+    offsets: [],
+}

--- a/language/move-vm/transactional-tests/tests/module_publishing/republish_module_incompatible_entry_removed.mvir
+++ b/language/move-vm/transactional-tests/tests/module_publishing/republish_module_incompatible_entry_removed.mvir
@@ -1,0 +1,49 @@
+// entry cannot be removed from functions
+
+//# publish
+module 0x42.Priv {
+    entry foo() {
+    label b0:
+        return;
+    }
+}
+
+//# publish
+module 0x42.Priv {
+    foo() {
+    label b0:
+        return;
+    }
+}
+
+//# publish
+module 0x42.Pub {
+    public entry foo() {
+    label b0:
+        return;
+    }
+}
+
+//# publish
+module 0x42.Pub {
+    public foo() {
+    label b0:
+        return;
+    }
+}
+
+//# publish
+module 0x42.Fr {
+    public(friend) entry foo() {
+    label b0:
+        return;
+    }
+}
+
+//# publish
+module 0x42.Fr {
+    public(friend) foo() {
+    label b0:
+        return;
+    }
+}


### PR DESCRIPTION
## Motivation

- Fix issues where rules were removed for V4
- The changes in https://github.com/diem/move/pull/373 made it so you could get inconsistent results on V4 versions of the file format. Where the old software would say no, and the new software would say yes.

## Test Plan
CI/CD tests were performed