### PR TITLE
move-bytecode-verifier: remove the Clone bound for the error type in the TransferFunctions trait#199_100

### DIFF
--- a/language/move-bytecode-verifier/src/absint.rs
+++ b/language/move-bytecode-verifier/src/absint.rs
@@ -49,7 +49,7 @@ pub type InvariantMap<State, AnalysisError> =
 /// Auxiliary data can be stored in self.
 pub trait TransferFunctions {
     type State: AbstractDomain;
-    type AnalysisError: Clone;
+    type AnalysisError;
 
     /// Execute local@instr found at index local@index in the current basic block from pre-state
     /// local@pre.


### PR DESCRIPTION
## Motivation

move-bytecode-verifier: remove the Clone bound for the error type in the TransferFunctions trait

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

CI/CD tests are covered.
