### PR TITLE
[Move] Added JavaScript files to the VSCode extension to integrate with the language server #202_102

### DIFF
--- a/language/move-analyzer/editors/code/.vscodeignore
+++ b/language/move-analyzer/editors/code/.vscodeignore
@@ -4,7 +4,8 @@
 # https://code.visualstudio.com/api/working-with-extensions/publishing-extension#.vscodeignore
 
 **/*
-out/src/**/*
+!out/src/*
+!node_modules/**/*
 !language-configuration.json
 !move.tmLanguage.json
 !package-lock.json

--- a/language/move-analyzer/editors/code/package.json
+++ b/language/move-analyzer/editors/code/package.json
@@ -4,7 +4,7 @@
     "description": "A language server and basic grammar for the Move programming language.",
     "publisher": "move",
     "license": "Apache-2.0",
-    "version": "0.0.5",
+    "version": "0.0.7",
     "preview": true,
     "homepage": "https://developers.diem.com",
     "repository": {


### PR DESCRIPTION
## Motivation
Currently published version of the extension doesn't really integrate with the language server as its current distribution is missing all JavaScript files that are responsible for handling LSP (Language Server Protocol):
```
unzip -l move.move-analyzer-0.0.6.vsix 
Archive:  move.move-analyzer-0.0.6.vsix
  Length      Date    Time    Name
---------  ---------- -----   ----
     2129  04-22-2022 22:58   extension.vsixmanifest
      296  04-22-2022 22:58   [Content_Types].xml
      970  04-01-2022 18:53   extension/language-configuration.json
    20704  04-01-2022 18:53   extension/move.tmLanguage.json
   137022  04-22-2022 14:53   extension/package-lock.json
     4104  04-22-2022 15:23   extension/package.json
     4583  04-22-2022 22:58   extension/README.md
---------                     -------
   169808                     7 files
```
This PR fixes this by including all the necessary files.

## Test Plan
CI/CD Tests were performed