### PR TITLE
[Move] Make compilation kill the process on failure/warning optional #184_103

### DIFF
--- a/language/move-compiler/src/diagnostics/mod.rs
+++ b/language/move-compiler/src/diagnostics/mod.rs
@@ -55,7 +55,8 @@ pub struct Diagnostics {
 //**************************************************************************************************
 
 pub fn report_diagnostics(files: &FilesSourceText, diags: Diagnostics) -> ! {
-    report_diagnostics_impl(files, diags);
+    let should_exit = true;
+    report_diagnostics_impl(files, diags, should_exit);
     std::process::exit(1)
 }
 
@@ -64,10 +65,10 @@ pub fn report_warnings(files: &FilesSourceText, warnings: Diagnostics) {
         return;
     }
     debug_assert!(warnings.max_severity().unwrap() == Severity::Warning);
-    report_diagnostics_impl(files, warnings)
+    report_diagnostics_impl(files, warnings, false)
 }
 
-fn report_diagnostics_impl(files: &FilesSourceText, diags: Diagnostics) {
+fn report_diagnostics_impl(files: &FilesSourceText, diags: Diagnostics, should_exit: bool) {
     let color_choice = match read_env_var(COLOR_MODE_ENV_VAR).as_str() {
         "NONE" => ColorChoice::Never,
         "ANSI" => ColorChoice::AlwaysAnsi,
@@ -76,7 +77,9 @@ fn report_diagnostics_impl(files: &FilesSourceText, diags: Diagnostics) {
     };
     let mut writer = StandardStream::stderr(color_choice);
     output_diagnostics(&mut writer, files, diags);
-    std::process::exit(1)
+    if should_exit {
+        std::process::exit(1);
+    }
 }
 
 pub fn unwrap_or_report_diagnostics<T>(files: &FilesSourceText, res: Result<T, Diagnostics>) -> T {

--- a/language/tools/move-package/src/compilation/build_plan.rs
+++ b/language/tools/move-package/src/compilation/build_plan.rs
@@ -6,7 +6,11 @@ use crate::{
     source_package::parsed_manifest::PackageName,
 };
 use anyhow::Result;
-use move_compiler::{compiled_unit::AnnotatedCompiledUnit, diagnostics::FilesSourceText, Compiler};
+use move_compiler::{
+    compiled_unit::AnnotatedCompiledUnit,
+    diagnostics::{report_diagnostics_to_color_buffer, report_warnings, FilesSourceText},
+    Compiler,
+};
 use petgraph::algo::toposort;
 use std::{collections::BTreeSet, io::Write, path::Path};
 
@@ -97,8 +101,30 @@ impl BuildPlan {
         })
     }
 
+    /// Compilation results in the process exit upon warning/failure
     pub fn compile<W: Write>(&self, writer: &mut W) -> Result<CompiledPackage> {
         self.compile_with_driver(writer, |compiler| compiler.build_and_report())
+    }
+
+    /// Compilation process does not exit even if warnings/failures are encountered
+    pub fn compile_no_exit<W: Write>(&self, writer: &mut W) -> Result<CompiledPackage> {
+        self.compile_with_driver(writer, |compiler| {
+            let (files, units_res) = compiler.build()?;
+            match units_res {
+                Ok((units, warning_diags)) => {
+                    report_warnings(&files, warning_diags);
+                    Ok((files, units))
+                }
+                Err(error_diags) => {
+                    assert!(!error_diags.is_empty());
+                    let diags_buf = report_diagnostics_to_color_buffer(&files, error_diags);
+                    if let Err(err) = std::io::stdout().write_all(&diags_buf) {
+                        anyhow::bail!("Cannot output compiler diagnostics: {}", err);
+                    }
+                    anyhow::bail!("Compilation error");
+                }
+            }
+        })
     }
 
     pub fn compile_with_driver<W: Write>(

--- a/language/tools/move-package/src/lib.rs
+++ b/language/tools/move-package/src/lib.rs
@@ -156,11 +156,26 @@ pub struct ModelConfig {
 }
 
 impl BuildConfig {
-    /// Compile the package at `path` or the containing Move package.
+    /// Compile the package at `path` or the containing Move package. Exit process on warning or
+    /// failure.
     pub fn compile_package<W: Write>(self, path: &Path, writer: &mut W) -> Result<CompiledPackage> {
         let resolved_graph = self.resolution_graph_for_package(path)?;
         let mutx = PackageLock::lock();
         let ret = BuildPlan::create(resolved_graph)?.compile(writer);
+        mutx.unlock();
+        ret
+    }
+
+    /// Compile the package at `path` or the containing Move package. Do not exit process on warning
+    /// or failure.
+    pub fn compile_package_no_exit<W: Write>(
+        self,
+        path: &Path,
+        writer: &mut W,
+    ) -> Result<CompiledPackage> {
+        let resolved_graph = self.resolution_graph_for_package(path)?;
+        let mutx = PackageLock::lock();
+        let ret = BuildPlan::create(resolved_graph)?.compile_no_exit(writer);
         mutx.unlock();
         ret
     }


### PR DESCRIPTION
## Motivation

At this point, building a package containing either errors or just warnings results in the whole process being killed, which makes it impossible for adapters to choose to publish modules with warnings only. This PR addresses the problem by making process exiting upon encountering failure/warning optional.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

CI/CD tests are covered.