### PR TITLE
[move-analyzer] Automatically upload the move binary program after the Release is generated #208_104

### DIFF
--- a/.github/workflows/release_asset.yml
+++ b/.github/workflows/release_asset.yml
@@ -1,0 +1,48 @@
+# When the release is published, this workflow is automatically triggered,
+# the move-related binaries are automatically packaged, and uploaded to
+# the release's Assets
+
+name: Release asset bot
+
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+jobs:
+  build:
+    name: Build release asset
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - ubuntu-latest
+          - ubuntu-18.04
+          - macos-latest
+          - windows-latest
+    runs-on: ${{matrix.platform}}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: install rust toolchain
+        uses: actions-rs/toolchain@v1
+      - name: build for ${{ matrix.platform }}
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release
+
+      - name: package move asset
+        run: ./scripts/package_asset.sh ${{ matrix.platform }}
+
+      - name: upload move asset
+        if: ${{ github.event_name == 'release'}}
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ./move-${{ matrix.platform }}.zip
+          asset_name: move-${{ matrix.platform }}.zip
+          asset_content_type: application/zip

--- a/scripts/package_asset.sh
+++ b/scripts/package_asset.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Copyright (c) The Diem Core Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# A script to package the move binary into a zip package.
+
+rm -rf move-artifacts/*
+mkdir -p move-artifacts/
+BINS="move move-analyzer move-bytecode-viewer move-disassembler move-prover move-to-yul prover-lab"
+
+for BIN in $BINS; do
+  cp -v target/release/$BIN move-artifacts/
+done
+
+cp -v README.md move-artifacts/
+
+if [ "$1" == "windows-latest" ]; then
+  7z a -r move-$1.zip move-artifacts
+else
+  zip -r move-$1.zip move-artifacts
+fi


### PR DESCRIPTION
## Motivation

[move-analyzer] Automatically upload the move binary program after the Release is generated

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan
CI/CD tests are covered.