### PR TITLE
[stdlib] Bump the version of stdlib to 0.1.1 #205_105

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2730,7 +2730,7 @@ dependencies = [
 
 [[package]]
 name = "move-stdlib"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "dir-diff",
  "file_diff",

--- a/language/move-analyzer/editors/code/.vscodeignore
+++ b/language/move-analyzer/editors/code/.vscodeignore
@@ -4,7 +4,8 @@
 # https://code.visualstudio.com/api/working-with-extensions/publishing-extension#.vscodeignore
 
 **/*
-out/src/**/*
+!out/src/*
+!node_modules/**/*
 !language-configuration.json
 !move.tmLanguage.json
 !package-lock.json

--- a/language/move-analyzer/editors/code/package.json
+++ b/language/move-analyzer/editors/code/package.json
@@ -4,7 +4,7 @@
     "description": "A language server and basic grammar for the Move programming language.",
     "publisher": "move",
     "license": "Apache-2.0",
-    "version": "0.0.5",
+    "version": "0.0.7",
     "preview": true,
     "homepage": "https://developers.diem.com",
     "repository": {

--- a/language/move-stdlib/Cargo.toml
+++ b/language/move-stdlib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "move-stdlib"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2018"
 authors = ["Diem Association <opensource@diem.com>"]
 description = "Diem stdlib"


### PR DESCRIPTION
## Motivation

Increment the version number of stdlib to `0.1.1`. This is needed because in a recent change to stdlib, the name of some move files are changed from upper case to lower case. This could incur some unexpected issues on some file systems that don't distinguish between upper case and lower case. Bumping the version will fix this issue partially: for those who uses cargo to bring in dependency, the file path will contain the new ```0.1.1``` version and would thus be able to distinguish between `move-stdlib-0.1.0/docs/BCS.md` and `move-stdlib-0.1.1/docs/bcs.md`, whereas in the previous case it is not possible for the system to distinguish between `move-stdlib-0.1.0/docs/BCS.md` and `move-stdlib-0.1.0/docs/bcs.md`.

## Test Plan
CI/CD Tests were covered