### PR TITLE
[async-move] Return extension context in async move execution api. #194_107

### DIFF
--- a/language/extensions/async/move-async-vm/tests/testsuite.rs
+++ b/language/extensions/async/move-async-vm/tests/testsuite.rs
@@ -96,12 +96,12 @@ impl Harness {
                 addr.short_str_lossless(),
                 actor.short_str_lossless()
             ));
-            let result = {
+            {
                 let mut proxy = HarnessProxy { harness: self };
                 let session = self.vm.new_session(addr, 0, &mut proxy);
-                session.new_actor(&actor, addr, &mut gas)
+                let result = session.new_actor(&actor, addr, &mut gas);
+                self.handle_result(&mut mailbox, result);
             };
-            self.handle_result(&mut mailbox, result);
 
             // Put a start message for this actor into the mailbox.
             let entry_point_id = Identifier::from_str("start")?;


### PR DESCRIPTION
## Motivation

Return the native context in async move's api for better composibility. The goal here is to integrate table extension to async move and the current api is not capable of doing that as native context gets consumed.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

CI/CD tests are covered.