### PR TITLE
[Move analyzer] Added type-on-hover #189_111

### DIFF
--- a/language/move-analyzer/src/bin/move-analyzer.rs
+++ b/language/move-analyzer/src/bin/move-analyzer.rs
@@ -6,9 +6,9 @@ use clap::Parser;
 use crossbeam::channel::{bounded, select};
 use lsp_server::{Connection, Message, Notification, Request, Response};
 use lsp_types::{
-    notification::Notification as _, request::Request as _, CompletionOptions, Diagnostic, OneOf,
-    SaveOptions, TextDocumentSyncCapability, TextDocumentSyncKind, TextDocumentSyncOptions,
-    WorkDoneProgressOptions,
+    notification::Notification as _, request::Request as _, CompletionOptions, Diagnostic,
+    HoverProviderCapability, OneOf, SaveOptions, TextDocumentSyncCapability, TextDocumentSyncKind,
+    TextDocumentSyncOptions, WorkDoneProgressOptions,
 };
 use std::{
     collections::BTreeMap,
@@ -76,7 +76,7 @@ fn main() {
             },
         )),
         selection_range_provider: None,
-        hover_provider: None,
+        hover_provider: Some(HoverProviderCapability::Simple(true)),
         // The server provides completions as a user is typing.
         completion_provider: Some(CompletionOptions {
             resolve_provider: None,
@@ -196,6 +196,9 @@ fn on_request(context: &Context, request: &Request) {
         }
         lsp_types::request::References::METHOD => {
             symbols::on_references_request(context, request, &context.symbols.lock().unwrap());
+        }
+        lsp_types::request::HoverRequest::METHOD => {
+            symbols::on_hover_request(context, request, &context.symbols.lock().unwrap());
         }
         _ => eprintln!("handle request '{}' from client", request.method),
     }

--- a/language/move-analyzer/tests/symbols/sources/M1.move
+++ b/language/move-analyzer/tests/symbols/sources/M1.move
@@ -59,11 +59,11 @@ module Symbols::M1 {
         tmp
     }
 
-    fun ret(p: bool): u64 {
-        if (p) {
+    fun ret(p1: bool, p2: u64): u64 {
+        if (p1) {
             return SOME_CONST
         };
-        7
+        p2
     }
 
     fun abort_call() {

--- a/language/move-analyzer/tests/symbols/sources/M3.move
+++ b/language/move-analyzer/tests/symbols/sources/M3.move
@@ -4,7 +4,7 @@ module Symbols::M3 {
         some_field: T,
     }
 
-    fun type_param_arg<T>(param: T): T {
+    fun type_param_arg<T: copy + drop>(param: T): T {
         param
     }
 
@@ -20,7 +20,7 @@ module Symbols::M3 {
         param
     }
 
-    struct AnotherParamStruct<T> {
+    struct AnotherParamStruct<T: copy> {
         some_field: ParamStruct<T>,
     }
 

--- a/language/move-compiler/src/naming/ast.rs
+++ b/language/move-compiler/src/naming/ast.rs
@@ -173,7 +173,7 @@ pub struct TParam {
 #[derive(Debug, Hash, Eq, PartialEq, Ord, PartialOrd, Copy, Clone)]
 pub struct TVar(u64);
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, Eq, PartialEq, Clone)]
 #[allow(clippy::large_enum_variant)]
 pub enum Type_ {
     Unit,


### PR DESCRIPTION
## Motivation

This is another refinement for the recently added symbolication support in the language server. This PR adds the type-on-hover functionality.

The basic idea is to store type information with the symbolication data and be able to use it when request for a type of a given identifier is issued.

We cannot use Type for this exclusively as it does not directly represent function signatures, so we special-case the latter. The debugging print for Type wasn't producing the best output for displaying info in the IDE so we implemented the Display trait for Type_ to handle this.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

CI/CD tests are covered.