### PR TITLE
[move-prover] test quantifier evaluation in the stackless vm (#219)_120

### DIFF
--- a/language/move-prover/interpreter-testsuite/tests/concrete_check/property/arithmetics.exp
+++ b/language/move-prover/interpreter-testsuite/tests/concrete_check/property/arithmetics.exp
@@ -8,7 +8,7 @@ Test failures:
 Failures in 0x2::A:
 
 ┌── check_arithmetics_div0 ──────
-│ error: failed to evaluate expression
+│ error: failed to evaluate expression: unexpected error code
 │    ┌─ tests/concrete_check/property/arithmetics.move:17:20
 │    │
 │ 17 │             assert 5 / 0 == 1;
@@ -19,7 +19,7 @@ Failures in 0x2::A:
 
 
 ┌── check_arithmetics_mod0 ──────
-│ error: failed to evaluate expression
+│ error: failed to evaluate expression: unexpected error code
 │    ┌─ tests/concrete_check/property/arithmetics.move:24:20
 │    │
 │ 24 │             assert 5 % 0 == 1;

--- a/language/move-prover/interpreter-testsuite/tests/concrete_check/property/global_basics.exp
+++ b/language/move-prover/interpreter-testsuite/tests/concrete_check/property/global_basics.exp
@@ -7,7 +7,7 @@ Test failures:
 Failures in 0x2::A:
 
 ┌── check_global_basics_fail ──────
-│ error: failed to evaluate expression
+│ error: failed to evaluate expression: unexpected error code
 │    ┌─ tests/concrete_check/property/global_basics.move:28:20
 │    │
 │ 28 │             assert global<R>(a).f2 == 42;

--- a/language/move-prover/interpreter-testsuite/tests/concrete_check/quantifier.exp
+++ b/language/move-prover/interpreter-testsuite/tests/concrete_check/quantifier.exp
@@ -1,0 +1,50 @@
+Running Move unit tests
+[ FAIL    ] 0x2::A::init_vector_failure
+[ PASS    ] 0x2::A::init_vector_success
+[ PASS    ] 0x2::A::move_to_test
+
+Test failures:
+
+Failures in 0x2::A:
+
+┌── init_vector_failure ──────
+│ error: failed to evaluate expression: enumeration of a non-address type domain is not supported
+│    ┌─ tests/concrete_check/quantifier.move:43:27
+│    │
+│ 43 │         ensures exists i: u64 where (i == len(result) - 1): result[i] == 1;
+│    │                           ^^^
+│
+│ error: failed to evaluate expression: unexpected error code
+│    ┌─ tests/concrete_check/quantifier.move:43:17
+│    │
+│ 43 │         ensures exists i: u64 where (i == len(result) - 1): result[i] == 1;
+│    │                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+│
+│ error: failed to evaluate expression: enumeration of a non-address type domain is not supported
+│    ┌─ tests/concrete_check/quantifier.move:44:27
+│    │
+│ 44 │         ensures exists i: u64: (i == len(result) - 1) ==> result[i] == 1;
+│    │                           ^^^
+│
+│ error: failed to evaluate expression: unexpected error code
+│    ┌─ tests/concrete_check/quantifier.move:44:17
+│    │
+│ 44 │         ensures exists i: u64: (i == len(result) - 1) ==> result[i] == 1;
+│    │                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+│
+│ error: failed to evaluate expression: enumeration of a non-address type domain is not supported
+│    ┌─ tests/concrete_check/quantifier.move:45:27
+│    │
+│ 45 │         ensures exists i: u64: result[i] == 1;
+│    │                           ^^^
+│
+│ error: failed to evaluate expression: unexpected error code
+│    ┌─ tests/concrete_check/quantifier.move:45:17
+│    │
+│ 45 │         ensures exists i: u64: result[i] == 1;
+│    │                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+│
+│
+└──────────────────
+
+Test result: FAILED. Total tests: 3; passed: 2; failed: 1

--- a/language/move-prover/interpreter-testsuite/tests/concrete_check/quantifier.move
+++ b/language/move-prover/interpreter-testsuite/tests/concrete_check/quantifier.move
@@ -1,0 +1,47 @@
+module 0x2::A {
+    use std::vector;
+
+    struct R has key { i: u64 }
+
+    struct S has key { i: u64 }
+
+    #[test(a=@0x2)]
+    public fun move_to_test(a: &signer) {
+        let r = R {i: 1};
+        let s = S {i: 1};
+        move_to(a, r);
+        move_to(a, s);
+
+        spec {
+            assert forall a: address where exists<R>(a): exists<S>(a);
+        };
+    }
+
+    #[test]
+    public fun init_vector_success(): vector<u64> {
+        let v = vector::empty<u64>();
+        vector::push_back(&mut v, 1);
+        vector::push_back(&mut v, 2);
+        v
+    }
+
+    spec init_vector_success {
+        ensures forall num in result: num > 0;
+        ensures exists num in result: num == 2;
+        ensures exists i in 0..len(result): result[i] == 1;
+    }
+
+    #[test, expected_failure]
+    public fun init_vector_failure(): vector<u64> {
+        let v = vector::empty<u64>();
+        vector::push_back(&mut v, 1);
+        vector::push_back(&mut v, 2);
+        v
+    }
+
+    spec init_vector_failure {
+        ensures exists i: u64 where (i == len(result) - 1): result[i] == 1;
+        ensures exists i: u64: (i == len(result) - 1) ==> result[i] == 1;
+        ensures exists i: u64: result[i] == 1;
+    }
+}

--- a/language/move-prover/interpreter/src/concrete/player.rs
+++ b/language/move-prover/interpreter/src/concrete/player.rs
@@ -1099,7 +1099,7 @@ impl<'env> FunctionContext<'env> {
         let env = self.target.global_env();
         let inst = convert_model_struct_type(env, module_id, struct_id, ty_args, &self.ty_args);
         let addr = op_addr.into_address();
-        match global_state.get_resource(None, addr, inst) {
+        match global_state.get_resource_for_code(None, addr, inst) {
             None => Err(self.sys_abort(StatusCode::MISSING_DATA)),
             Some(object) => Ok(object),
         }
@@ -1117,7 +1117,7 @@ impl<'env> FunctionContext<'env> {
         let env = self.target.global_env();
         let inst = convert_model_struct_type(env, module_id, struct_id, ty_args, &self.ty_args);
         let addr = op_addr.into_address();
-        match global_state.get_resource(Some(is_mut), addr, inst) {
+        match global_state.get_resource_for_code(Some(is_mut), addr, inst) {
             None => Err(self.sys_abort(StatusCode::MISSING_DATA)),
             Some(object) => Ok(object),
         }

--- a/language/move-prover/interpreter/src/concrete/value.rs
+++ b/language/move-prover/interpreter/src/concrete/value.rs
@@ -1007,11 +1007,12 @@ impl AccountState {
 pub struct GlobalState {
     accounts: BTreeMap<AccountAddress, AccountState>,
     events: BTreeMap<Vec<u8>, BTreeMap<u64, TypedValue>>,
+    touched_addresses: BTreeSet<AccountAddress>,
 }
 
 impl GlobalState {
-    /// Get a reference to a resource from the address, return None of the resource does not exist
-    pub fn get_resource(
+    /// Get a reference to a resource from the address, return None if the resource does not exist
+    pub fn get_resource_for_spec(
         &self,
         is_mut_opt: Option<bool>,
         addr: AccountAddress,
@@ -1032,12 +1033,25 @@ impl GlobalState {
         })
     }
 
+    /// Get a reference to a resource from the address, return None if the resource does not exist
+    /// otherwise, update the set of addresses touched by the bytecode
+    pub fn get_resource_for_code(
+        &mut self,
+        is_mut_opt: Option<bool>,
+        addr: AccountAddress,
+        key: StructInstantiation,
+    ) -> Option<TypedValue> {
+        self.touched_addresses.insert(addr);
+        self.get_resource_for_spec(is_mut_opt, addr, key)
+    }
+
     /// Remove a resource from the address, return the old resource (as struct) if exists
     pub fn del_resource(
         &mut self,
         addr: AccountAddress,
         key: StructInstantiation,
     ) -> Option<TypedValue> {
+        self.touched_addresses.insert(addr);
         self.accounts.get_mut(&addr).and_then(|account| {
             account.del_resource(&key).map(|val| TypedValue {
                 ty: Type::mk_struct(key),
@@ -1057,6 +1071,7 @@ impl GlobalState {
         if cfg!(debug_assertions) {
             assert_eq!(key, object.ty.into_struct_inst());
         }
+        self.touched_addresses.insert(addr);
         self.accounts
             .entry(addr)
             .or_insert_with(AccountState::default)
@@ -1085,6 +1100,11 @@ impl GlobalState {
         if cfg!(debug_assertions) {
             assert!(res.is_none());
         }
+    }
+
+    /// Output all the addresses that are touched by the bytecode so far
+    pub fn get_touched_addresses(&self) -> &BTreeSet<AccountAddress> {
+        &self.touched_addresses
     }
 
     /// Calculate the delta (i.e., a ChangeSet) against the old state


### PR DESCRIPTION
## Motivation

- Record all the addresses touched by bytecode in a set and use it when unrolling address domain when determining the range of quantifiers
- Instead of aborting at unreachable, log error message on the console when the range is non-address type

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

CI/CD tests are covered.