### PR TITLE
[Move] Added Move analyzer's support for multi-root workspaces #220_122

### DIFF
--- a/language/move-analyzer/src/bin/move-analyzer.rs
+++ b/language/move-analyzer/src/bin/move-analyzer.rs
@@ -112,14 +112,13 @@ fn main() {
     let (diag_sender, diag_receiver) = bounded::<Result<BTreeMap<Symbol, Vec<Diagnostic>>>>(0);
     let mut symbolicator_runner = symbols::SymbolicatorRunner::idle();
     if symbols::DEFS_AND_REFS_SUPPORT {
+        symbolicator_runner =
+            symbols::SymbolicatorRunner::new(context.symbols.clone(), diag_sender);
         if let Some(uri) = initialize_params.root_uri {
-            symbolicator_runner =
-                symbols::SymbolicatorRunner::new(&uri, context.symbols.clone(), diag_sender);
-            symbolicator_runner.run();
+            symbolicator_runner.run(uri.path());
         }
     };
 
-    let mut missing_manifest_reported = false;
     loop {
         select! {
             recv(diag_receiver) -> message => {
@@ -142,23 +141,17 @@ fn main() {
                             Err(err) => {
                                 let typ = lsp_types::MessageType::Error;
                                 let message = format!("{err}");
-                                let missing_manifest = message.starts_with("Unable to find package manifest");
-                                if !missing_manifest || !missing_manifest_reported {
                                     // report missing manifest only once to avoid re-generating
                                     // user-visible error in cases when the developer decides to
                                     // keep editing a file that does not belong to a packages
                                     let params = lsp_types::ShowMessageParams { typ, message };
-                                    let notification = Notification::new(lsp_types::notification::ShowMessage::METHOD.to_string(), params);
-                                    if let Err(err) = context
-                                        .connection
-                                        .sender
-                                        .send(lsp_server::Message::Notification(notification)) {
-                                            eprintln!("could not send compiler error response: {:?}", err);
-                                        };
-                                }
-                                if missing_manifest {
-                                    missing_manifest_reported = true;
-                                }
+                                let notification = Notification::new(lsp_types::notification::ShowMessage::METHOD.to_string(), params);
+                                if let Err(err) = context
+                                    .connection
+                                    .sender
+                                    .send(lsp_server::Message::Notification(notification)) {
+                                        eprintln!("could not send compiler error response: {:?}", err);
+                                    };
                             },
                         }
                     },

--- a/language/move-analyzer/src/symbols.rs
+++ b/language/move-analyzer/src/symbols.rs
@@ -51,7 +51,7 @@ use crate::{
     diagnostics::{lsp_diagnostics, lsp_empty_diagnostics},
     utils::get_loc,
 };
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use codespan_reporting::files::SimpleFiles;
 use crossbeam::channel::Sender;
 use im::ordmap::OrdMap;
@@ -200,9 +200,9 @@ pub struct Symbols {
     file_name_mapping: BTreeMap<FileHash, Symbol>,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Copy)]
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
 enum RunnerState {
-    Run,
+    Run(PathBuf),
     Wait,
     Quit,
 }
@@ -326,52 +326,75 @@ impl SymbolicatorRunner {
 
     /// Create a new runner
     pub fn new(
-        uri: &Url,
         symbols: Arc<Mutex<Symbols>>,
         sender: Sender<Result<BTreeMap<Symbol, Vec<Diagnostic>>>>,
     ) -> Self {
         let mtx_cvar = Arc::new((Mutex::new(RunnerState::Wait), Condvar::new()));
         let thread_mtx_cvar = mtx_cvar.clone();
-        let pkg_path = uri.to_file_path().unwrap();
+        let runner = SymbolicatorRunner { mtx_cvar };
 
         thread::spawn(move || {
             let (mtx, cvar) = &*thread_mtx_cvar;
+            // Locations opened in the IDE (files or directories) for which manifest file is missing
+            let mut missing_manifests = BTreeSet::new();
             // infinite loop to wait for symbolication requests
+            eprintln!("starting symbolicator runner loop");
             loop {
-                let get_symbols = {
+                let starting_path_opt = {
                     // hold the lock only as long as it takes to get the data, rather than through
                     // the whole symbolication process (hence a separate scope here)
                     let mut symbolicate = mtx.lock().unwrap();
-                    match *symbolicate {
+                    match symbolicate.clone() {
                         RunnerState::Quit => break,
-                        RunnerState::Run => {
+                        RunnerState::Run(root_dir) => {
                             *symbolicate = RunnerState::Wait;
-                            true
+                            Some(root_dir)
                         }
                         RunnerState::Wait => {
                             // wait for next request
                             symbolicate = cvar.wait(symbolicate).unwrap();
-                            match *symbolicate {
+                            match symbolicate.clone() {
                                 RunnerState::Quit => break,
-                                RunnerState::Run => {
+                                RunnerState::Run(root_dir) => {
                                     *symbolicate = RunnerState::Wait;
-                                    true
+                                    Some(root_dir)
                                 }
-                                RunnerState::Wait => false,
+                                RunnerState::Wait => None,
                             }
                         }
                     }
                 };
-                if get_symbols {
+                if let Some(starting_path) = starting_path_opt {
+                    let root_dir = Self::root_dir(&starting_path);
+                    if root_dir.is_none() && !missing_manifests.contains(&starting_path) {
+                        eprintln!("reporting missing manifest");
+
+                        // report missing manifest file only once to avoid cluttering IDE's UI in
+                        // cases when developer indeed intended to open a standalone file that was
+                        // not meant to compile
+                        missing_manifests.insert(starting_path);
+                        if let Err(err) =
+                            sender.send(Err(anyhow!("Unable to find package manifest")))
+                        {
+                            eprintln!("could not pass missing manifest error: {:?}", err);
+                        }
+                        continue;
+                    }
                     eprintln!("symbolication started");
-                    match Symbolicator::get_symbols(&pkg_path) {
+                    match Symbolicator::get_symbols(root_dir.unwrap().as_path()) {
                         Ok((symbols_opt, lsp_diagnostics)) => {
                             eprintln!("symbolication finished");
                             if let Some(new_symbols) = symbols_opt {
-                                // replace symbols only if they have been actually recomputed,
-                                // otherwise keep the old (possibly out-dated) symbolication info
+                                // merge the new symbols with the old ones to support a
+                                // (potentially) new project/package that symbolication information
+                                // was built for
+                                //
+                                // TODO: we may consider "unloading" symbolication information when
+                                // files/directories are being closed but as with other performance
+                                // optimizations (e.g. incrementalizatino of the vfs), let's wait
+                                // until we know we actually need it
                                 let mut old_symbols = symbols.lock().unwrap();
-                                *old_symbols = new_symbols;
+                                (*old_symbols).merge(new_symbols);
                             }
                             // set/reset (previous) diagnostics
                             if let Err(err) = sender.send(Ok(lsp_diagnostics)) {
@@ -381,7 +404,7 @@ impl SymbolicatorRunner {
                         Err(err) => {
                             eprintln!("symbolication failed: {:?}", err);
                             if let Err(err) = sender.send(Err(err)) {
-                                eprintln!("could not compiler error: {:?}", err);
+                                eprintln!("could not pass compiler error: {:?}", err);
                             }
                         }
                     }
@@ -389,14 +412,14 @@ impl SymbolicatorRunner {
             }
         });
 
-        SymbolicatorRunner { mtx_cvar }
+        runner
     }
 
-    pub fn run(&self) {
-        eprintln!("scheduling run");
+    pub fn run(&self, starting_path: &str) {
+        eprintln!("scheduling run for {}", starting_path);
         let (mtx, cvar) = &*self.mtx_cvar;
         let mut symbolicate = mtx.lock().unwrap();
-        *symbolicate = RunnerState::Run;
+        *symbolicate = RunnerState::Run(PathBuf::from(starting_path));
         cvar.notify_one();
         eprintln!("scheduled run");
     }
@@ -406,6 +429,19 @@ impl SymbolicatorRunner {
         let mut symbolicate = mtx.lock().unwrap();
         *symbolicate = RunnerState::Quit;
         cvar.notify_one();
+    }
+
+    fn root_dir(starting_path: &Path) -> Option<PathBuf> {
+        let mut current_path_opt = Some(starting_path);
+        while current_path_opt.is_some() {
+            let current_path = current_path_opt.unwrap();
+            let manifest_path = current_path.join("Move.toml");
+            if manifest_path.is_file() {
+                return Some(current_path.to_path_buf());
+            }
+            current_path_opt = current_path.parent();
+        }
+        None
     }
 }
 
@@ -482,6 +518,19 @@ impl UseDefMap {
 
     fn extend(&mut self, use_defs: BTreeMap<u32, BTreeSet<UseDef>>) {
         self.0.extend(use_defs);
+    }
+}
+
+impl Symbols {
+    fn merge(&mut self, other: Self) {
+        for (k, v) in other.references {
+            self.references
+                .entry(k)
+                .or_insert_with(BTreeSet::new)
+                .extend(v);
+        }
+        self.file_use_defs.extend(other.file_use_defs);
+        self.file_name_mapping.extend(other.file_name_mapping);
     }
 }
 

--- a/language/move-analyzer/src/vfs.rs
+++ b/language/move-analyzer/src/vfs.rs
@@ -63,6 +63,7 @@ pub fn on_text_document_sync_notification(
                 parameters.text_document.uri.path(),
                 &parameters.text_document.text,
             );
+            symbolicator_runner.run(parameters.text_document.uri.path());
         }
         lsp_types::notification::DidChangeTextDocument::METHOD => {
             let parameters =
@@ -81,7 +82,7 @@ pub fn on_text_document_sync_notification(
                 parameters.text_document.uri.path(),
                 &parameters.text.unwrap(),
             );
-            symbolicator_runner.run();
+            symbolicator_runner.run(parameters.text_document.uri.path());
         }
         lsp_types::notification::DidCloseTextDocument::METHOD => {
             let parameters =


### PR DESCRIPTION
## Motivation

This is another language server enhancement, this time related to supporting multi-root workspaces. This PR not only adds support for opening multiple directories within a workspace but also adds support for manifest file searching in case a single Move source file is open.

The implementation is fairly straightforward - instead of replacing existing symbolication information, augment it with additional symbols coming from additional files/directories being opened.

This PR also implements discovery of manifest files in case a Move source file is opened rather than a package directory. Previously, if the former has happened, the new features would not be available as the language server did not know where to find Move.toml file needed for compilation.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes