### PR TITLE
Aw/missing manifest fix #232_127

### DIFF
--- a/language/move-analyzer/src/bin/move-analyzer.rs
+++ b/language/move-analyzer/src/bin/move-analyzer.rs
@@ -101,22 +101,16 @@ fn main() {
     })
     .expect("could not serialize server capabilities");
 
-    let client_response: serde_json::Value = context
+    context
         .connection
         .initialize(capabilities)
         .expect("could not initialize the connection");
-
-    let initialize_params: lsp_types::InitializeParams =
-        serde_json::from_value(client_response).expect("could not deserialize client capabilities");
 
     let (diag_sender, diag_receiver) = bounded::<Result<BTreeMap<Symbol, Vec<Diagnostic>>>>(0);
     let mut symbolicator_runner = symbols::SymbolicatorRunner::idle();
     if symbols::DEFS_AND_REFS_SUPPORT {
         symbolicator_runner =
             symbols::SymbolicatorRunner::new(context.symbols.clone(), diag_sender);
-        if let Some(uri) = initialize_params.root_uri {
-            symbolicator_runner.run(uri.path());
-        }
     };
 
     loop {

--- a/language/move-analyzer/src/symbols.rs
+++ b/language/move-analyzer/src/symbols.rs
@@ -431,6 +431,7 @@ impl SymbolicatorRunner {
         cvar.notify_one();
     }
 
+    /// Finds manifest file in a subdirectory of a Move source file passed as argument
     fn root_dir(starting_path: &Path) -> Option<PathBuf> {
         let mut current_path_opt = Some(starting_path);
         while current_path_opt.is_some() {


### PR DESCRIPTION
## Motivation

This PR modifies the time when a manifest file is being located by the language server. Previously finding manifest file was attempted at upon two different events:

- when the first root directory was opened in the IDE
- when a Move source file was opened in the IDE

The first one is not only redundant (as opening a directory without opening a Move source file is basically a no-op) but also may lead to a confusion - for example if a user opens a root directory of a repo containing multiple Move packages/projects, they will get an error as the manifest file in this case will not be found in a parent directory of the repository root (and even if some manifest file is found, it will be most likely an incorrect one)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

CI/CD tests are covered.