### PR TITLE
[unit-test] Allow extensions used for unit testing to live outside of Move repo #245_135

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2997,6 +2997,7 @@ name = "move-unit-test"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "better_any",
  "clap 3.1.8",
  "codespan-reporting",
  "colored",

--- a/language/tools/move-unit-test/Cargo.toml
+++ b/language/tools/move-unit-test/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0.52"
+better_any = "0.1.1"
 clap = { version = "3.1.8", features = ["derive"] }
 codespan-reporting = "0.11.1"
 colored = "2.0.0"

--- a/language/tools/move-unit-test/src/extensions.rs
+++ b/language/tools/move-unit-test/src/extensions.rs
@@ -6,7 +6,8 @@
 //! to be usable.
 
 use move_vm_runtime::native_extensions::NativeContextExtensions;
-use std::fmt::Write;
+use once_cell::sync::Lazy;
+use std::{fmt::Write, sync::Mutex};
 
 #[cfg(feature = "table-extension")]
 use itertools::Itertools;
@@ -14,13 +15,34 @@ use itertools::Itertools;
 use move_table_extension::NativeTableContext;
 #[cfg(feature = "table-extension")]
 use move_vm_test_utils::BlankStorage;
-#[cfg(feature = "table-extension")]
-use once_cell::sync::Lazy;
+
+static EXTENSION_HOOK: Lazy<
+    Mutex<Option<Box<dyn Fn(&mut NativeContextExtensions<'_>) + Send + Sync>>>,
+> = Lazy::new(|| Mutex::new(None));
+
+/// Sets a hook which is called to populate additional native extensions. This can be used to
+/// get extensions living outside of the Move repo into the unit testing environment.
+///
+/// This need to be called with the extensions of the custom Move environment at two places:
+///
+/// (a) At start of a custom Move CLI, to enable unit testing with the additional
+/// extensions;
+/// (b) Before `cli::run_move_unit_tests` if unit tests are called programmatically from Rust.
+/// You may want to define a new function `my_cli::run_move_unit_tests` which does this.
+///
+/// Note that the table extension is handled already internally, and does not need to added via
+/// this hook.
+pub fn set_extension_hook(p: Box<dyn Fn(&mut NativeContextExtensions<'_>) + Send + Sync>) {
+    *EXTENSION_HOOK.lock().unwrap() = Some(p)
+}
 
 /// Create all available native context extensions.
 #[allow(unused_mut, clippy::let_and_return)]
 pub(crate) fn new_extensions<'a>() -> NativeContextExtensions<'a> {
     let mut e = NativeContextExtensions::default();
+    if let Some(h) = &*EXTENSION_HOOK.lock().unwrap() {
+        (*h)(&mut e)
+    }
     #[cfg(feature = "table-extension")]
     create_table_extension(&mut e);
     e
@@ -72,3 +94,25 @@ fn print_table_extension<W: Write>(w: &mut W, extensions: &mut NativeContextExte
 
 #[cfg(feature = "table-extension")]
 static DUMMY_RESOLVER: Lazy<BlankStorage> = Lazy::new(|| BlankStorage);
+
+#[cfg(test)]
+mod tests {
+    use crate::extensions::{new_extensions, set_extension_hook};
+    use better_any::{Tid, TidAble};
+    use move_vm_runtime::native_extensions::NativeContextExtensions;
+
+    /// A test that extension hooks work as expected.
+    #[test]
+    fn test_extension_hook() {
+        set_extension_hook(Box::new(my_hook));
+        let ext = new_extensions();
+        let _e = ext.get::<TestExtension>();
+    }
+
+    #[derive(Tid)]
+    struct TestExtension();
+
+    fn my_hook(ext: &mut NativeContextExtensions) {
+        ext.add(TestExtension())
+    }
+}

--- a/language/tools/move-unit-test/src/lib.rs
+++ b/language/tools/move-unit-test/src/lib.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod cargo_runner;
-mod extensions;
+pub mod extensions;
 pub mod test_reporter;
 pub mod test_runner;
 


### PR DESCRIPTION
## Motivation

Until now, extensions leveraged by the Move UT infra had to live in the Move repo.

This PR adds a hook which can be used as in move_unit_tests::extensions::set_extension_hook(fun),
where fun is populating a NativeContextExtensions for the according custom environment. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes