### PR TITLE
[tutorials] remove depreciated std::errors in tutorial #248_138

### DIFF
--- a/language/documentation/tutorial/step_4/BasicCoin/sources/BasicCoin.move
+++ b/language/documentation/tutorial/step_4/BasicCoin/sources/BasicCoin.move
@@ -1,6 +1,5 @@
 /// This module defines a minimal Coin and Balance.
 module NamedAddr::BasicCoin {
-    use std::errors;
     use std::signer;
 
     /// Address of the owner of this module
@@ -31,7 +30,7 @@ module NamedAddr::BasicCoin {
     /// Initialize this module.
     public fun mint(module_owner: &signer, mint_addr: address, amount: u64) {
         // Only the owner of the module can initialize this module
-        assert!(signer::address_of(module_owner) == MODULE_OWNER, errors::requires_address(ENOT_MODULE_OWNER));
+        assert!(signer::address_of(module_owner) == MODULE_OWNER, ENOT_MODULE_OWNER);
 
         // Deposit `amount` of tokens to `mint_addr`'s balance
         deposit(mint_addr, Coin { value: amount });
@@ -52,7 +51,7 @@ module NamedAddr::BasicCoin {
     fun withdraw(addr: address, amount: u64) : Coin acquires Balance {
         let balance = balance_of(addr);
         // balance must be greater than the withdraw amount
-        assert!(balance >= amount, errors::limit_exceeded(EINSUFFICIENT_BALANCE));
+        assert!(balance >= amount, EINSUFFICIENT_BALANCE);
         let balance_ref = &mut borrow_global_mut<Balance>(addr).coin.value;
         *balance_ref = balance - amount;
         Coin { value: amount }

--- a/language/documentation/tutorial/step_4_sol/BasicCoin/sources/BasicCoin.move
+++ b/language/documentation/tutorial/step_4_sol/BasicCoin/sources/BasicCoin.move
@@ -1,6 +1,5 @@
 /// This module defines a minimal Coin and Balance.
 module NamedAddr::BasicCoin {
-    use std::errors;
     use std::signer;
 
     /// Address of the owner of this module
@@ -24,14 +23,14 @@ module NamedAddr::BasicCoin {
     /// minting or transferring to the account.
     public fun publish_balance(account: &signer) {
         let empty_coin = Coin { value: 0 };
-        assert!(!exists<Balance>(signer::address_of(account)), errors::already_published(EALREADY_HAS_BALANCE));
+        assert!(!exists<Balance>(signer::address_of(account)), EALREADY_HAS_BALANCE);
         move_to(account, Balance { coin: empty_coin });
     }
 
     /// Mint `amount` tokens to `mint_addr`. Mint must be approved by the module owner.
     public fun mint(module_owner: &signer, mint_addr: address, amount: u64) acquires Balance {
         // Only the owner of the module can initialize this module
-        assert!(signer::address_of(module_owner) == MODULE_OWNER, errors::requires_address(ENOT_MODULE_OWNER));
+        assert!(signer::address_of(module_owner) == MODULE_OWNER, ENOT_MODULE_OWNER);
 
         // Deposit `amount` of tokens to `mint_addr`'s balance
         deposit(mint_addr, Coin { value: amount });
@@ -52,7 +51,7 @@ module NamedAddr::BasicCoin {
     fun withdraw(addr: address, amount: u64) : Coin acquires Balance {
         let balance = balance_of(addr);
         // balance must be greater than the withdraw amount
-        assert!(balance >= amount, errors::limit_exceeded(EINSUFFICIENT_BALANCE));
+        assert!(balance >= amount, EINSUFFICIENT_BALANCE);
         let balance_ref = &mut borrow_global_mut<Balance>(addr).coin.value;
         *balance_ref = balance - amount;
         Coin { value: amount }

--- a/language/documentation/tutorial/step_5/BasicCoin/sources/BasicCoin.move
+++ b/language/documentation/tutorial/step_5/BasicCoin/sources/BasicCoin.move
@@ -1,6 +1,5 @@
 /// This module defines a minimal Coin and Balance.
 module NamedAddr::BasicCoin {
-    use std::errors;
     use std::signer;
 
     /// Address of the owner of this module
@@ -24,14 +23,14 @@ module NamedAddr::BasicCoin {
     /// minting or transferring to the account.
     public fun publish_balance(account: &signer) {
         let empty_coin = Coin { value: 0 };
-        assert!(!exists<Balance>(signer::address_of(account)), errors::already_published(EALREADY_HAS_BALANCE));
+        assert!(!exists<Balance>(signer::address_of(account)), EALREADY_HAS_BALANCE);
         move_to(account, Balance { coin: empty_coin });
     }
 
     /// Mint `amount` tokens to `mint_addr`. Mint must be approved by the module owner.
     public fun mint(module_owner: &signer, mint_addr: address, amount: u64) acquires Balance {
         // Only the owner of the module can initialize this module
-        assert!(signer::address_of(module_owner) == MODULE_OWNER, errors::requires_address(ENOT_MODULE_OWNER));
+        assert!(signer::address_of(module_owner) == MODULE_OWNER, ENOT_MODULE_OWNER);
 
         // Deposit `amount` of tokens to `mint_addr`'s balance
         deposit(mint_addr, Coin { value: amount });
@@ -52,7 +51,7 @@ module NamedAddr::BasicCoin {
     fun withdraw(addr: address, amount: u64) : Coin acquires Balance {
         let balance = balance_of(addr);
         // balance must be greater than the withdraw amount
-        assert!(balance >= amount, errors::limit_exceeded(EINSUFFICIENT_BALANCE));
+        assert!(balance >= amount, EINSUFFICIENT_BALANCE);
         let balance_ref = &mut borrow_global_mut<Balance>(addr).coin.value;
         *balance_ref = balance - amount;
         Coin { value: amount }

--- a/language/documentation/tutorial/step_5_sol/BasicCoin/sources/BasicCoin.move
+++ b/language/documentation/tutorial/step_5_sol/BasicCoin/sources/BasicCoin.move
@@ -1,6 +1,5 @@
 /// This module defines a minimal Coin and Balance.
 module NamedAddr::BasicCoin {
-    use std::errors;
     use std::signer;
 
     /// Address of the owner of this module
@@ -24,14 +23,14 @@ module NamedAddr::BasicCoin {
     /// minting or transferring to the account.
     public fun publish_balance(account: &signer) {
         let empty_coin = Coin { value: 0 };
-        assert!(!exists<Balance>(signer::address_of(account)), errors::already_published(EALREADY_HAS_BALANCE));
+        assert!(!exists<Balance>(signer::address_of(account)), EALREADY_HAS_BALANCE);
         move_to(account, Balance { coin:  empty_coin });
     }
 
     /// Mint `amount` tokens to `mint_addr`. Mint must be approved by the module owner.
     public fun mint(module_owner: &signer, mint_addr: address, amount: u64) acquires Balance {
         // Only the owner of the module can initialize this module
-        assert!(signer::address_of(module_owner) == MODULE_OWNER, errors::requires_address(ENOT_MODULE_OWNER));
+        assert!(signer::address_of(module_owner) == MODULE_OWNER, ENOT_MODULE_OWNER);
 
         // Deposit `amount` of tokens to `mint_addr`'s balance
         deposit(mint_addr, Coin { value: amount });
@@ -52,7 +51,7 @@ module NamedAddr::BasicCoin {
     fun withdraw(addr: address, amount: u64) : Coin acquires Balance {
         let balance = balance_of(addr);
         // balance must be greater than the withdraw amount
-        assert!(balance >= amount, errors::limit_exceeded(EINSUFFICIENT_BALANCE));
+        assert!(balance >= amount, EINSUFFICIENT_BALANCE);
         let balance_ref = &mut borrow_global_mut<Balance>(addr).coin.value;
         *balance_ref = balance - amount;
         Coin { value: amount }

--- a/language/documentation/tutorial/step_6/BasicCoin/sources/BasicCoin.move
+++ b/language/documentation/tutorial/step_6/BasicCoin/sources/BasicCoin.move
@@ -1,6 +1,5 @@
 /// This module defines a minimal and generic Coin and Balance.
 module NamedAddr::BasicCoin {
-    use std::errors;
     use std::signer;
 
     /// Error codes
@@ -20,7 +19,7 @@ module NamedAddr::BasicCoin {
     /// minting or transferring to the account.
     public fun publish_balance<CoinType>(account: &signer) {
         let empty_coin = Coin<CoinType> { value: 0 };
-        assert!(!exists<Balance<CoinType>>(signer::address_of(account)), errors::already_published(EALREADY_HAS_BALANCE));
+        assert!(!exists<Balance<CoinType>>(signer::address_of(account)), EALREADY_HAS_BALANCE);
         move_to(account, Balance<CoinType> { coin:  empty_coin });
     }
 

--- a/language/documentation/tutorial/step_7/BasicCoin/sources/BasicCoin.move
+++ b/language/documentation/tutorial/step_7/BasicCoin/sources/BasicCoin.move
@@ -1,6 +1,5 @@
 /// This module defines a minimal and generic Coin and Balance.
 module NamedAddr::BasicCoin {
-    use std::errors;
     use std::signer;
 
     /// Error codes
@@ -20,7 +19,7 @@ module NamedAddr::BasicCoin {
     /// minting or transferring to the account.
     public fun publish_balance<CoinType>(account: &signer) {
         let empty_coin = Coin<CoinType> { value: 0 };
-        assert!(!exists<Balance<CoinType>>(signer::address_of(account)), errors::already_published(EALREADY_HAS_BALANCE));
+        assert!(!exists<Balance<CoinType>>(signer::address_of(account)), EALREADY_HAS_BALANCE);
         move_to(account, Balance<CoinType> { coin: empty_coin });
     }
 

--- a/language/documentation/tutorial/step_8/BasicCoin/sources/BasicCoin.move
+++ b/language/documentation/tutorial/step_8/BasicCoin/sources/BasicCoin.move
@@ -1,6 +1,5 @@
 /// This module defines a minimal and generic Coin and Balance.
 module NamedAddr::BasicCoin {
-    use std::errors;
     use std::signer;
 
     /// Error codes
@@ -21,7 +20,7 @@ module NamedAddr::BasicCoin {
     /// minting or transferring to the account.
     public fun publish_balance<CoinType>(account: &signer) {
         let empty_coin = Coin<CoinType> { value: 0 };
-        assert!(!exists<Balance<CoinType>>(signer::address_of(account)), errors::already_published(EALREADY_HAS_BALANCE));
+        assert!(!exists<Balance<CoinType>>(signer::address_of(account)), EALREADY_HAS_BALANCE);
         move_to(account, Balance<CoinType> { coin: empty_coin });
     }
 

--- a/language/documentation/tutorial/step_8_sol/BasicCoin/sources/BasicCoin.move
+++ b/language/documentation/tutorial/step_8_sol/BasicCoin/sources/BasicCoin.move
@@ -1,6 +1,5 @@
 /// This module defines a minimal and generic Coin and Balance.
 module NamedAddr::BasicCoin {
-    use std::errors;
     use std::signer;
 
     /// Error codes
@@ -20,7 +19,7 @@ module NamedAddr::BasicCoin {
 
     public fun publish_balance<CoinType>(account: &signer) {
         let empty_coin = Coin<CoinType> { value: 0 };
-        assert!(!exists<Balance<CoinType>>(signer::address_of(account)), errors::already_published(EALREADY_HAS_BALANCE));
+        assert!(!exists<Balance<CoinType>>(signer::address_of(account)), EALREADY_HAS_BALANCE);
         move_to(account, Balance<CoinType> { coin: empty_coin });
     }
 


### PR DESCRIPTION
## Motivation 
Fixed the errors that were found in the tutorials. 

## Test Plan
Only documents are changed. No test plans