### PR TITLE
[move prover] use bytes instead of file path in CustomNativeOptions #253_140

### DIFF
--- a/language/move-prover/boogie-backend/src/lib.rs
+++ b/language/move-prover/boogie-backend/src/lib.rs
@@ -153,12 +153,7 @@ pub fn add_prelude(
     if let Some(custom_native_options) = options.custom_natives.clone() {
         templates.push(templ(
             "custom-natives",
-            &std::fs::read(&custom_native_options.template_path).unwrap_or_else(|_| {
-                panic!(
-                    "cannot read custom template file {}",
-                    &custom_native_options.template_path
-                )
-            }),
+            &custom_native_options.template_bytes,
         ));
         for (module_name, instance_name) in custom_native_options.module_instance_names {
             context.insert(instance_name, &filter_native(&module_name));

--- a/language/move-prover/boogie-backend/src/options.rs
+++ b/language/move-prover/boogie-backend/src/options.rs
@@ -43,8 +43,8 @@ impl VectorTheory {
 /// Options to define custom native functions to include in generated Boogie file.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CustomNativeOptions {
-    /// Path to the custom template file.
-    pub template_path: String,
+    /// Bytes of the custom template.
+    pub template_bytes: Vec<u8>,
     /// List of (module name, module instance key) tuples, used to generate instantiated
     /// versions of generic native functions.
     pub module_instance_names: Vec<(String, String)>,


### PR DESCRIPTION
## Motivation
This PR updates boogie backend options so that we use bytes instead of file path in CustomNativeOptions.