### PR TITLE
[vm] Allow native functions to reflect over the stack frame context. #265_147

### DIFF
--- a/language/move-vm/runtime/Cargo.toml
+++ b/language/move-vm/runtime/Cargo.toml
@@ -38,3 +38,4 @@ failpoints = ["fail/failpoints"]
 # Enable tracing and debugging also for release builds. By default, it is only enabled for debug builds.
 debugging = []
 testing = []
+stacktrace = []

--- a/language/move-vm/runtime/src/interpreter.rs
+++ b/language/move-vm/runtime/src/interpreter.rs
@@ -573,6 +573,11 @@ impl Interpreter {
     }
 
     fn get_internal_state(&self) -> ExecutionState {
+        self.get_stack_frames(usize::MAX)
+    }
+
+    /// Get count stack frames starting from the top of the stack.
+    pub(crate) fn get_stack_frames(&self, count: usize) -> ExecutionState {
         // collect frames in the reverse order as this is what is
         // normally expected from the stack trace (outermost frame
         // is the last one)
@@ -581,6 +586,7 @@ impl Interpreter {
             .0
             .iter()
             .rev()
+            .take(count)
             .map(|frame| {
                 (
                     frame.function.module_id().cloned(),
@@ -1042,7 +1048,7 @@ impl Frame {
                                 self.function.pretty_string(),
                                 self.pc,
                             ));
-                        if cfg!(feature = "testing") {
+                        if cfg!(feature = "testing") || cfg!(feature = "stacktrace") {
                             return Err(error.with_exec_state(interpreter.get_internal_state()));
                         } else {
                             return Err(error);

--- a/language/move-vm/runtime/src/native_functions.rs
+++ b/language/move-vm/runtime/src/native_functions.rs
@@ -4,7 +4,7 @@
 use crate::{
     interpreter::Interpreter, loader::Resolver, native_extensions::NativeContextExtensions,
 };
-use move_binary_format::errors::{PartialVMError, PartialVMResult};
+use move_binary_format::errors::{ExecutionState, PartialVMError, PartialVMResult};
 use move_core_types::{
     account_address::AccountAddress,
     gas_schedule::CostTable,
@@ -156,5 +156,11 @@ impl<'a, 'b> NativeContext<'a, 'b> {
 
     pub fn extensions_mut(&mut self) -> &mut NativeContextExtensions<'b> {
         self.extensions
+    }
+
+    /// Get count stack frames, including the one of the called native function. This
+    /// allows a native function to reflect about its caller.
+    pub fn stack_frames(&self, count: usize) -> ExecutionState {
+        self.interpreter.get_stack_frames(count)
     }
 }


### PR DESCRIPTION
## Motivation

- This gives access to ExecutionState (stack frame of calls) to native functions. This is needed e.g. to implement
programmatic access to the address of the calling function.

- Also added another feature stacktrace which allows to enable stack trace capturing and only that in the VM. Currently, this is guarded by a feature testing for UTs which is to general.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

CI/CD tests are covered.