### PR TITLE
[move-cli] sandbox publishing with multiple modules and optionally, all modules in a package #261_153

### DIFF
--- a/language/tools/move-cli/src/sandbox/cli.rs
+++ b/language/tools/move-cli/src/sandbox/cli.rs
@@ -34,6 +34,14 @@ pub enum SandboxCommand {
         /// Set this flag to ignore breaking changes checks and publish anyway.
         #[clap(long = "ignore-breaking-changes")]
         ignore_breaking_changes: bool,
+        /// If set, publish not only the modules in this package but also
+        /// modules in all its dependencies.
+        #[clap(long = "with-deps")]
+        with_deps: bool,
+        /// If set, all modules at once as a bundle. The default is to publish
+        /// modules sequentially.
+        #[clap(long = "bundle")]
+        bundle: bool,
         /// Manually specify the publishing order of modules.
         #[clap(
             long = "override-ordering",
@@ -182,6 +190,8 @@ impl SandboxCommand {
             SandboxCommand::Publish {
                 no_republish,
                 ignore_breaking_changes,
+                with_deps,
+                bundle,
                 override_ordering,
             } => {
                 let context =
@@ -194,6 +204,8 @@ impl SandboxCommand {
                     context.package(),
                     *no_republish,
                     *ignore_breaking_changes,
+                    *with_deps,
+                    *bundle,
                     override_ordering.as_ref().map(|o| o.as_slice()),
                     move_args.verbose,
                 )

--- a/language/tools/move-cli/src/sandbox/commands/publish.rs
+++ b/language/tools/move-cli/src/sandbox/commands/publish.rs
@@ -22,19 +22,46 @@ pub fn publish(
     package: &CompiledPackage,
     no_republish: bool,
     ignore_breaking_changes: bool,
+    with_deps: bool,
+    bundle: bool,
     override_ordering: Option<&[String]>,
     verbose: bool,
 ) -> Result<()> {
+    // collect all modules compiled
+    let compiled_modules = if with_deps {
+        package.all_modules().collect::<Vec<_>>()
+    } else {
+        package.root_modules().collect::<Vec<_>>()
+    };
     if verbose {
-        println!(
-            "Found {} modules",
-            package.root_modules().collect::<Vec<_>>().len()
-        );
+        println!("Found {} modules", compiled_modules.len());
     }
 
+    // order the modules for publishing
+    let modules_to_publish = match override_ordering {
+        Some(ordering) => {
+            let module_map: BTreeMap<_, _> = compiled_modules
+                .into_iter()
+                .map(|unit| (unit.unit.name().to_string(), unit))
+                .collect();
+
+            let mut ordered_modules = vec![];
+            for name in ordering {
+                match module_map.get(name) {
+                    None => bail!("Invalid module name in publish ordering: {}", name),
+                    Some(unit) => {
+                        ordered_modules.push(*unit);
+                    }
+                }
+            }
+            ordered_modules
+        }
+        None => compiled_modules,
+    };
+
     if no_republish {
-        let republished = package
-            .root_modules()
+        let republished = modules_to_publish
+            .iter()
             .filter_map(|unit| {
                 let id = module(&unit.unit).ok()?.self_id();
                 if state.has_module(&id) {
@@ -59,59 +86,52 @@ pub fn publish(
         let vm = MoveVM::new(natives).unwrap();
         let mut gas_status = get_gas_status(cost_table, None)?;
         let mut session = vm.new_session(state);
-
         let mut has_error = false;
-        match override_ordering {
-            None => {
-                for unit in package.root_modules() {
-                    let module_bytes = unit.unit.serialize(bytecode_version);
-                    let id = module(&unit.unit)?.self_id();
-                    let sender = *id.address();
 
-                    let res = session.publish_module(module_bytes, sender, &mut gas_status);
-                    if let Err(err) = res {
-                        explain_publish_error(err, state, unit)?;
-                        has_error = true;
-                        break;
+        if bundle {
+            // publish all modules together as a bundle
+            let mut sender_opt = None;
+            let mut module_bytes_vec = vec![];
+            for unit in &modules_to_publish {
+                let module_bytes = unit.unit.serialize(bytecode_version);
+                module_bytes_vec.push(module_bytes);
+
+                let module_address = *module(&unit.unit)?.self_id().address();
+                match &sender_opt {
+                    None => {
+                        sender_opt = Some(module_address);
+                    }
+                    Some(val) => {
+                        if val != &module_address {
+                            bail!("All modules in the bundle must share the same address");
+                        }
                     }
                 }
             }
-            Some(ordering) => {
-                let module_map: BTreeMap<_, _> = package
-                    .root_modules()
-                    .into_iter()
-                    .map(|unit| (unit.unit.name().to_string(), unit))
-                    .collect();
-
-                let mut sender_opt = None;
-                let mut module_bytes_vec = vec![];
-                for name in ordering {
-                    match module_map.get(name) {
-                        None => bail!("Invalid module name in publish ordering: {}", name),
-                        Some(unit) => {
-                            let module_bytes = unit.unit.serialize(bytecode_version);
-                            module_bytes_vec.push(module_bytes);
-                            if sender_opt.is_none() {
-                                sender_opt = Some(*module(&unit.unit)?.self_id().address());
-                            }
-                        }
+            match sender_opt {
+                None => bail!("No modules to publish"),
+                Some(sender) => {
+                    let res =
+                        session.publish_module_bundle(module_bytes_vec, sender, &mut gas_status);
+                    if let Err(err) = res {
+                        // TODO (mengxu): explain publish errors in multi-module publishing
+                        println!("Invalid multi-module publishing: {}", err);
+                        has_error = true;
                     }
                 }
+            }
+        } else {
+            // publish modules sequentially, one module at a time
+            for unit in &modules_to_publish {
+                let module_bytes = unit.unit.serialize(bytecode_version);
+                let id = module(&unit.unit)?.self_id();
+                let sender = *id.address();
 
-                match sender_opt {
-                    None => bail!("No modules to publish"),
-                    Some(sender) => {
-                        let res = session.publish_module_bundle(
-                            module_bytes_vec,
-                            sender,
-                            &mut gas_status,
-                        );
-                        if let Err(err) = res {
-                            // TODO (mengxu): explain publish errors in multi-module publishing
-                            println!("Invalid multi-module publishing: {}", err);
-                            has_error = true;
-                        }
-                    }
+                let res = session.publish_module(module_bytes, sender, &mut gas_status);
+                if let Err(err) = res {
+                    explain_publish_error(err, state, unit)?;
+                    has_error = true;
+                    break;
                 }
             }
         }
@@ -133,7 +153,7 @@ pub fn publish(
         // backward incompatible changes, as as result, if this flag is set, we skip the VM process
         // and force the CLI to override the on-disk state directly
         let mut serialized_modules = vec![];
-        for unit in package.all_modules() {
+        for unit in modules_to_publish {
             let id = module(&unit.unit)?.self_id();
             let module_bytes = unit.unit.serialize(bytecode_version);
             serialized_modules.push((id, module_bytes));

--- a/language/tools/move-cli/tests/sandbox_tests/cyclic_multi_module_publish/args.exp
+++ b/language/tools/move-cli/tests/sandbox_tests/cyclic_multi_module_publish/args.exp
@@ -1,8 +1,8 @@
-Command `-p p1 sandbox publish --override-ordering A --override-ordering B -v`:
+Command `-p p1 sandbox publish --bundle --override-ordering A --override-ordering B -v`:
 Found 2 modules
 Publishing a new module 00000000000000000000000000000003::A (wrote 82 bytes)
 Publishing a new module 00000000000000000000000000000003::B (wrote 93 bytes)
 Wrote 175 bytes of module ID's and code
-Command `-p p2 sandbox publish --override-ordering A --override-ordering C -v`:
+Command `-p p2 sandbox publish --bundle --override-ordering A --override-ordering C -v`:
 Found 3 modules
 Invalid multi-module publishing: VMError with status INVALID_FRIEND_DECL_WITH_MODULES_IN_DEPENDENCIES at location Module ModuleId { address: 00000000000000000000000000000003, name: Identifier("C") } and message At least one module, 00000000000000000000000000000003::A, appears in both the dependency set and the friend set

--- a/language/tools/move-cli/tests/sandbox_tests/cyclic_multi_module_publish/args.txt
+++ b/language/tools/move-cli/tests/sandbox_tests/cyclic_multi_module_publish/args.txt
@@ -1,2 +1,2 @@
--p p1 sandbox publish --override-ordering A --override-ordering B -v
--p p2 sandbox publish --override-ordering A --override-ordering C -v
+-p p1 sandbox publish --bundle --override-ordering A --override-ordering B -v
+-p p2 sandbox publish --bundle --override-ordering A --override-ordering C -v

--- a/language/tools/move-cli/tests/sandbox_tests/multi_module_publish/args.exp
+++ b/language/tools/move-cli/tests/sandbox_tests/multi_module_publish/args.exp
@@ -1,13 +1,13 @@
-Command `sandbox publish --override-ordering A -v`:
+Command `sandbox publish --bundle --override-ordering A -v`:
 Found 2 modules
 Invalid multi-module publishing: VMError with status LINKER_ERROR at location UNDEFINED and message Cannot find ModuleId { address: 00000000000000000000000000000002, name: Identifier("B") } in data cache
-Command `sandbox publish --override-ordering B -v`:
+Command `sandbox publish --bundle --override-ordering B -v`:
 Found 2 modules
 Invalid multi-module publishing: VMError with status LINKER_ERROR at location UNDEFINED and message Cannot find ModuleId { address: 00000000000000000000000000000002, name: Identifier("A") } in data cache
-Command `sandbox publish --override-ordering B --override-ordering A -v`:
+Command `sandbox publish --bundle --override-ordering B --override-ordering A -v`:
 Found 2 modules
 Invalid multi-module publishing: VMError with status LINKER_ERROR at location UNDEFINED and message Cannot find ModuleId { address: 00000000000000000000000000000002, name: Identifier("A") } in data cache
-Command `sandbox publish --override-ordering A --override-ordering B -v`:
+Command `sandbox publish --bundle --override-ordering A --override-ordering B -v`:
 Found 2 modules
 Publishing a new module 00000000000000000000000000000002::A (wrote 89 bytes)
 Publishing a new module 00000000000000000000000000000002::B (wrote 97 bytes)

--- a/language/tools/move-cli/tests/sandbox_tests/multi_module_publish/args.txt
+++ b/language/tools/move-cli/tests/sandbox_tests/multi_module_publish/args.txt
@@ -1,14 +1,14 @@
 # expect failure as A friends B and B is missing in the bundle
-sandbox publish --override-ordering A -v
+sandbox publish --bundle --override-ordering A -v
 
 # expect failure as B depends on A and A is missing in the bundle
-sandbox publish --override-ordering B -v
+sandbox publish --bundle --override-ordering B -v
 
 # expect failure as B depends on A but A appears after B in the bundle
-sandbox publish --override-ordering B --override-ordering A -v
+sandbox publish --bundle --override-ordering B --override-ordering A -v
 
 # expect success: this is the correct order of publishing A and B
 # with friend relationship
-sandbox publish --override-ordering A --override-ordering B -v
+sandbox publish --bundle --override-ordering A --override-ordering B -v
 sandbox view storage/0x00000000000000000000000000000002/modules/A.mv
 sandbox view storage/0x00000000000000000000000000000002/modules/B.mv


### PR DESCRIPTION
## Motivation

This PR contains two changes to the move-cli sandbox publish interface:

-  [move-cli] add --with-deps option to the publish command

The default scenario is to publish the modules within the package only,
excluding the modules compiled from its dependency packages. This
--with-deps flag, when set, will allow modules in the deps packages
to be published as well, together with the package root modules.

-  [move-cli] allow multi-module publishing in Move CLI with --bundle

The current default mode of publishing in Move CLI is sequential,
i.e., one-module-at-a-time. This means that modules that are cyclic
dependent cannot be published all at once (e.g., the DPN in the
documentation/examples directory).

To show this issue, run:

```
cd language/documentation/examples/diem-framework/move-packages/DPN
cargo run -p df-cli -- sandbox publish
An error message of "unexpected LINK_ERROR" will appear.
```

This commit fixes this issue and allows all modules in the package to be
published at once by specifying the --bundle flag, as in
sandbox publish --bundle.

The whole DPN can be published with

`cargo run -p df-cli --sandbox publish --bundle`
Two move-cli sandbox tests on multiple-module publishing are updated with the --bundle flag accordingly.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

CI/CD tests are covered.