### PR TITLE
[Move analyzer] Added support for building and running on Windows #292_161

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1190,6 +1190,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "453440c271cf5577fd2a40e4942540cb7d0d2f85e27c8d07dd0023c925a67541"
+
+[[package]]
 name = "ed25519"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2261,6 +2267,7 @@ dependencies = [
  "clap 3.1.8",
  "codespan-reporting",
  "crossbeam",
+ "dunce",
  "im",
  "lsp-server",
  "lsp-types",

--- a/language/move-analyzer/Cargo.toml
+++ b/language/move-analyzer/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0.52"
 codespan-reporting = "0.11.1"
+dunce = "1.0.2"
 im = "15.1.0"
 lsp-server = "0.5.1"
 lsp-types = "0.90.1"

--- a/language/move-analyzer/src/bin/move-analyzer.rs
+++ b/language/move-analyzer/src/bin/move-analyzer.rs
@@ -123,7 +123,7 @@ fn main() {
         // main reason for this is to enable unit tests that rely on the symbolication information
         // to be available right after the client is initialized.
         if let Some(uri) = initialize_params.root_uri {
-            if let Some(p) = symbols::SymbolicatorRunner::root_dir(Path::new(uri.path())) {
+            if let Some(p) = symbols::SymbolicatorRunner::root_dir(&uri.to_file_path().unwrap()) {
                 if let Ok((Some(new_symbols), _)) = symbols::Symbolicator::get_symbols(p.as_path())
                 {
                     let mut old_symbols = context.symbols.lock().unwrap();

--- a/language/move-analyzer/src/completion.rs
+++ b/language/move-analyzer/src/completion.rs
@@ -126,10 +126,18 @@ pub fn on_completion_request(context: &Context, request: &Request) {
     let parameters = serde_json::from_value::<CompletionParams>(request.params.clone())
         .expect("could not deserialize completion request");
 
-    let path = parameters.text_document_position.text_document.uri.path();
-    let buffer = context.files.get(path);
+    let path = parameters
+        .text_document_position
+        .text_document
+        .uri
+        .to_file_path()
+        .unwrap();
+    let buffer = context.files.get(&path);
     if buffer.is_none() {
-        eprintln!("Could not read '{}' when handling completion request", path);
+        eprintln!(
+            "Could not read '{:?}' when handling completion request",
+            path
+        );
     }
 
     // The completion items we provide depend upon where the user's cursor is positioned.

--- a/language/move-analyzer/src/symbols.rs
+++ b/language/move-analyzer/src/symbols.rs
@@ -63,7 +63,7 @@ use lsp_types::{
 use std::{
     cmp,
     collections::{BTreeMap, BTreeSet, HashMap},
-    fmt, fs,
+    fmt,
     path::{Path, PathBuf},
     sync::{Arc, Condvar, Mutex},
     thread,
@@ -333,95 +333,98 @@ impl SymbolicatorRunner {
         let thread_mtx_cvar = mtx_cvar.clone();
         let runner = SymbolicatorRunner { mtx_cvar };
 
-        thread::spawn(move || {
-            let (mtx, cvar) = &*thread_mtx_cvar;
-            // Locations opened in the IDE (files or directories) for which manifest file is missing
-            let mut missing_manifests = BTreeSet::new();
-            // infinite loop to wait for symbolication requests
-            eprintln!("starting symbolicator runner loop");
-            loop {
-                let starting_path_opt = {
-                    // hold the lock only as long as it takes to get the data, rather than through
-                    // the whole symbolication process (hence a separate scope here)
-                    let mut symbolicate = mtx.lock().unwrap();
-                    match symbolicate.clone() {
-                        RunnerState::Quit => break,
-                        RunnerState::Run(root_dir) => {
-                            *symbolicate = RunnerState::Wait;
-                            Some(root_dir)
-                        }
-                        RunnerState::Wait => {
-                            // wait for next request
-                            symbolicate = cvar.wait(symbolicate).unwrap();
-                            match symbolicate.clone() {
-                                RunnerState::Quit => break,
-                                RunnerState::Run(root_dir) => {
-                                    *symbolicate = RunnerState::Wait;
-                                    Some(root_dir)
+        thread::Builder::new()
+            .stack_size(16 * 1024 * 1024) // building Move code requires a larger stack size on Windows
+            .spawn(move || {
+                let (mtx, cvar) = &*thread_mtx_cvar;
+                // Locations opened in the IDE (files or directories) for which manifest file is missing
+                let mut missing_manifests = BTreeSet::new();
+                // infinite loop to wait for symbolication requests
+                eprintln!("starting symbolicator runner loop");
+                loop {
+                    let starting_path_opt = {
+                        // hold the lock only as long as it takes to get the data, rather than through
+                        // the whole symbolication process (hence a separate scope here)
+                        let mut symbolicate = mtx.lock().unwrap();
+                        match symbolicate.clone() {
+                            RunnerState::Quit => break,
+                            RunnerState::Run(root_dir) => {
+                                *symbolicate = RunnerState::Wait;
+                                Some(root_dir)
+                            }
+                            RunnerState::Wait => {
+                                // wait for next request
+                                symbolicate = cvar.wait(symbolicate).unwrap();
+                                match symbolicate.clone() {
+                                    RunnerState::Quit => break,
+                                    RunnerState::Run(root_dir) => {
+                                        *symbolicate = RunnerState::Wait;
+                                        Some(root_dir)
+                                    }
+                                    RunnerState::Wait => None,
                                 }
-                                RunnerState::Wait => None,
                             }
                         }
-                    }
-                };
-                if let Some(starting_path) = starting_path_opt {
-                    let root_dir = Self::root_dir(&starting_path);
-                    if root_dir.is_none() && !missing_manifests.contains(&starting_path) {
-                        eprintln!("reporting missing manifest");
+                    };
+                    if let Some(starting_path) = starting_path_opt {
+                        let root_dir = Self::root_dir(&starting_path);
+                        if root_dir.is_none() && !missing_manifests.contains(&starting_path) {
+                            eprintln!("reporting missing manifest");
 
-                        // report missing manifest file only once to avoid cluttering IDE's UI in
-                        // cases when developer indeed intended to open a standalone file that was
-                        // not meant to compile
-                        missing_manifests.insert(starting_path);
-                        if let Err(err) = sender.send(Err(anyhow!(
-                            "Unable to find package manifest. Make sure that
+                            // report missing manifest file only once to avoid cluttering IDE's UI in
+                            // cases when developer indeed intended to open a standalone file that was
+                            // not meant to compile
+                            missing_manifests.insert(starting_path);
+                            if let Err(err) = sender.send(Err(anyhow!(
+                                "Unable to find package manifest. Make sure that
                             the source files are located in a sub-directory of a package containing
                             a Move.toml file. "
-                        ))) {
-                            eprintln!("could not pass missing manifest error: {:?}", err);
-                        }
-                        continue;
-                    }
-                    eprintln!("symbolication started");
-                    match Symbolicator::get_symbols(root_dir.unwrap().as_path()) {
-                        Ok((symbols_opt, lsp_diagnostics)) => {
-                            eprintln!("symbolication finished");
-                            if let Some(new_symbols) = symbols_opt {
-                                // merge the new symbols with the old ones to support a
-                                // (potentially) new project/package that symbolication information
-                                // was built for
-                                //
-                                // TODO: we may consider "unloading" symbolication information when
-                                // files/directories are being closed but as with other performance
-                                // optimizations (e.g. incrementalizatino of the vfs), let's wait
-                                // until we know we actually need it
-                                let mut old_symbols = symbols.lock().unwrap();
-                                (*old_symbols).merge(new_symbols);
+                            ))) {
+                                eprintln!("could not pass missing manifest error: {:?}", err);
                             }
-                            // set/reset (previous) diagnostics
-                            if let Err(err) = sender.send(Ok(lsp_diagnostics)) {
-                                eprintln!("could not pass diagnostics: {:?}", err);
-                            }
+                            continue;
                         }
-                        Err(err) => {
-                            eprintln!("symbolication failed: {:?}", err);
-                            if let Err(err) = sender.send(Err(err)) {
-                                eprintln!("could not pass compiler error: {:?}", err);
+                        eprintln!("symbolication started");
+                        match Symbolicator::get_symbols(root_dir.unwrap().as_path()) {
+                            Ok((symbols_opt, lsp_diagnostics)) => {
+                                eprintln!("symbolication finished");
+                                if let Some(new_symbols) = symbols_opt {
+                                    // merge the new symbols with the old ones to support a
+                                    // (potentially) new project/package that symbolication information
+                                    // was built for
+                                    //
+                                    // TODO: we may consider "unloading" symbolication information when
+                                    // files/directories are being closed but as with other performance
+                                    // optimizations (e.g. incrementalizatino of the vfs), let's wait
+                                    // until we know we actually need it
+                                    let mut old_symbols = symbols.lock().unwrap();
+                                    (*old_symbols).merge(new_symbols);
+                                }
+                                // set/reset (previous) diagnostics
+                                if let Err(err) = sender.send(Ok(lsp_diagnostics)) {
+                                    eprintln!("could not pass diagnostics: {:?}", err);
+                                }
+                            }
+                            Err(err) => {
+                                eprintln!("symbolication failed: {:?}", err);
+                                if let Err(err) = sender.send(Err(err)) {
+                                    eprintln!("could not pass compiler error: {:?}", err);
+                                }
                             }
                         }
                     }
                 }
-            }
-        });
+            })
+            .unwrap();
 
         runner
     }
 
-    pub fn run(&self, starting_path: &str) {
-        eprintln!("scheduling run for {}", starting_path);
+    pub fn run(&self, starting_path: PathBuf) {
+        eprintln!("scheduling run for {:?}", starting_path);
         let (mtx, cvar) = &*self.mtx_cvar;
         let mut symbolicate = mtx.lock().unwrap();
-        *symbolicate = RunnerState::Run(PathBuf::from(starting_path));
+        *symbolicate = RunnerState::Run(starting_path);
         cvar.notify_one();
         eprintln!("scheduled run");
     }
@@ -658,7 +661,7 @@ impl Symbolicator {
 
             file_use_defs
                 .entry(
-                    fs::canonicalize(fpath.as_str())
+                    dunce::canonicalize(fpath.as_str())
                         .unwrap_or_else(|_| PathBuf::from(fpath.as_str())),
                 )
                 .or_insert_with(UseDefMap::new)
@@ -1788,7 +1791,8 @@ pub fn on_go_to_def_request(context: &Context, request: &Request, symbols: &Symb
         .text_document_position_params
         .text_document
         .uri
-        .path();
+        .to_file_path()
+        .unwrap();
     let loc = parameters.text_document_position_params.position;
     let line = loc.line;
     let col = loc.character;
@@ -1796,7 +1800,7 @@ pub fn on_go_to_def_request(context: &Context, request: &Request, symbols: &Symb
     on_use_request(
         context,
         symbols,
-        fpath,
+        &fpath,
         line,
         col,
         request.id.clone(),
@@ -1827,7 +1831,8 @@ pub fn on_go_to_type_def_request(context: &Context, request: &Request, symbols: 
         .text_document_position_params
         .text_document
         .uri
-        .path();
+        .to_file_path()
+        .unwrap();
     let loc = parameters.text_document_position_params.position;
     let line = loc.line;
     let col = loc.character;
@@ -1835,7 +1840,7 @@ pub fn on_go_to_type_def_request(context: &Context, request: &Request, symbols: 
     on_use_request(
         context,
         symbols,
-        fpath,
+        &fpath,
         line,
         col,
         request.id.clone(),
@@ -1862,7 +1867,12 @@ pub fn on_references_request(context: &Context, request: &Request, symbols: &Sym
     let parameters = serde_json::from_value::<ReferenceParams>(request.params.clone())
         .expect("could not deserialize references request");
 
-    let fpath = parameters.text_document_position.text_document.uri.path();
+    let fpath = parameters
+        .text_document_position
+        .text_document
+        .uri
+        .to_file_path()
+        .unwrap();
     let loc = parameters.text_document_position.position;
     let line = loc.line;
     let col = loc.character;
@@ -1871,7 +1881,7 @@ pub fn on_references_request(context: &Context, request: &Request, symbols: &Sym
     on_use_request(
         context,
         symbols,
-        fpath,
+        &fpath,
         line,
         col,
         request.id.clone(),
@@ -1917,7 +1927,8 @@ pub fn on_hover_request(context: &Context, request: &Request, symbols: &Symbols)
         .text_document_position_params
         .text_document
         .uri
-        .path();
+        .to_file_path()
+        .unwrap();
     let loc = parameters.text_document_position_params.position;
     let line = loc.line;
     let col = loc.character;
@@ -1925,7 +1936,7 @@ pub fn on_hover_request(context: &Context, request: &Request, symbols: &Symbols)
     on_use_request(
         context,
         symbols,
-        fpath,
+        &fpath,
         line,
         col,
         request.id.clone(),
@@ -1945,7 +1956,7 @@ pub fn on_hover_request(context: &Context, request: &Request, symbols: &Symbols)
 pub fn on_use_request(
     context: &Context,
     symbols: &Symbols,
-    use_fpath: &str,
+    use_fpath: &PathBuf,
     use_line: u32,
     use_col: u32,
     id: RequestId,
@@ -1954,7 +1965,7 @@ pub fn on_use_request(
     let mut result = None;
 
     let mut use_def_found = false;
-    if let Some(mod_symbols) = symbols.file_use_defs.get(&PathBuf::from(use_fpath)) {
+    if let Some(mod_symbols) = symbols.file_use_defs.get(use_fpath) {
         if let Some(uses) = mod_symbols.get(use_line) {
             for u in uses {
                 if use_col >= u.col_start && use_col <= u.col_end {
@@ -2034,7 +2045,7 @@ fn symbols_test() {
 
     let mut fpath = path.clone();
     fpath.push("sources/M1.move");
-    let cpath = fs::canonicalize(&fpath).unwrap();
+    let cpath = dunce::canonicalize(&fpath).unwrap();
 
     let mod_symbols = symbols.file_use_defs.get(&cpath).unwrap();
 
@@ -2717,7 +2728,7 @@ fn symbols_test() {
 
     let mut fpath = path.clone();
     fpath.push("sources/M3.move");
-    let cpath = fs::canonicalize(&fpath).unwrap();
+    let cpath = dunce::canonicalize(&fpath).unwrap();
 
     let mod_symbols = symbols.file_use_defs.get(&cpath).unwrap();
 
@@ -2867,7 +2878,7 @@ fn symbols_test() {
 
     let mut fpath = path.clone();
     fpath.push("sources/M4.move");
-    let cpath = fs::canonicalize(&fpath).unwrap();
+    let cpath = dunce::canonicalize(&fpath).unwrap();
 
     let mod_symbols = symbols.file_use_defs.get(&cpath).unwrap();
 

--- a/language/move-analyzer/src/vfs.rs
+++ b/language/move-analyzer/src/vfs.rs
@@ -9,24 +9,24 @@
 //! basically just a mapping from file identifier (this could be the file's path were it to be
 //! saved) to its textual contents.
 
+use crate::symbols;
 use lsp_server::Notification;
 use lsp_types::{
     notification::Notification as _, DidChangeTextDocumentParams, DidCloseTextDocumentParams,
     DidOpenTextDocumentParams, DidSaveTextDocumentParams,
 };
-
-use crate::symbols;
+use std::path::PathBuf;
 
 /// A mapping from identifiers (file names, potentially, but not necessarily) to their contents.
 #[derive(Debug, Default)]
 pub struct VirtualFileSystem {
-    files: std::collections::HashMap<String, String>,
+    files: std::collections::HashMap<PathBuf, String>,
 }
 
 impl VirtualFileSystem {
     /// Returns a reference to the buffer corresponding to the given identifier, or `None` if it
     /// is not present in the system.
-    pub fn get(&self, identifier: &str) -> Option<&str> {
+    pub fn get(&self, identifier: &PathBuf) -> Option<&str> {
         self.files.get(identifier).map(|s| s.as_str())
     }
 
@@ -36,13 +36,12 @@ impl VirtualFileSystem {
     /// from the client, instead of completely replacing them each time. The rust-analyzer has a
     /// 'vfs' module that is capable of doing just that, but it is not published on crates.io. If
     /// we could help get it published, we could use it here.
-    pub fn update(&mut self, identifier: &str, content: &str) {
-        self.files
-            .insert(identifier.to_string(), content.to_string());
+    pub fn update(&mut self, identifier: PathBuf, content: &str) {
+        self.files.insert(identifier, content.to_string());
     }
 
     /// Removes the buffer and its identifier from the system.
-    pub fn remove(&mut self, identifier: &str) {
+    pub fn remove(&mut self, identifier: &PathBuf) {
         self.files.remove(identifier);
     }
 }
@@ -60,17 +59,17 @@ pub fn on_text_document_sync_notification(
                 serde_json::from_value::<DidOpenTextDocumentParams>(notification.params.clone())
                     .expect("could not deserialize notification");
             files.update(
-                parameters.text_document.uri.path(),
+                parameters.text_document.uri.to_file_path().unwrap(),
                 &parameters.text_document.text,
             );
-            symbolicator_runner.run(parameters.text_document.uri.path());
+            symbolicator_runner.run(parameters.text_document.uri.to_file_path().unwrap());
         }
         lsp_types::notification::DidChangeTextDocument::METHOD => {
             let parameters =
                 serde_json::from_value::<DidChangeTextDocumentParams>(notification.params.clone())
                     .expect("could not deserialize notification");
             files.update(
-                parameters.text_document.uri.path(),
+                parameters.text_document.uri.to_file_path().unwrap(),
                 &parameters.content_changes.last().unwrap().text,
             );
         }
@@ -79,16 +78,16 @@ pub fn on_text_document_sync_notification(
                 serde_json::from_value::<DidSaveTextDocumentParams>(notification.params.clone())
                     .expect("could not deserialize notification");
             files.update(
-                parameters.text_document.uri.path(),
+                parameters.text_document.uri.to_file_path().unwrap(),
                 &parameters.text.unwrap(),
             );
-            symbolicator_runner.run(parameters.text_document.uri.path());
+            symbolicator_runner.run(parameters.text_document.uri.to_file_path().unwrap());
         }
         lsp_types::notification::DidCloseTextDocument::METHOD => {
             let parameters =
                 serde_json::from_value::<DidCloseTextDocumentParams>(notification.params.clone())
                     .expect("could not deserialize notification");
-            files.remove(parameters.text_document.uri.path());
+            files.remove(&parameters.text_document.uri.to_file_path().unwrap());
         }
         _ => eprintln!("invalid notification '{}'", notification.method),
     }


### PR DESCRIPTION
## Motivation
This PR adds additional support for the Move analyzer to correctly build and run on Windows. In particular the "standard" version of path canonicalization produces non-standard output on Windows (so called UNC format).

