### PR TITLE
[vm] Allow access to native extensions via the session. #293_162

### DIFF
--- a/language/move-vm/runtime/src/session.rs
+++ b/language/move-vm/runtime/src/session.rs
@@ -262,7 +262,7 @@ impl<'r, 'l, S: MoveResolver> Session<'r, 'l, S> {
         self.runtime.loader().get_struct_type(index)
     }
 
-    // Get the abilities for this type, at it's particular instantiation
+    /// Gets the abilities for this type, at it's particular instantiation
     pub fn get_type_abilities(&self, ty: &Type) -> VMResult<AbilitySet> {
         self.runtime
             .loader()
@@ -270,8 +270,14 @@ impl<'r, 'l, S: MoveResolver> Session<'r, 'l, S> {
             .map_err(|e| e.finish(Location::Undefined))
     }
 
+    /// Gets the underlying data store
     pub fn get_data_store(&mut self) -> &mut dyn DataStore {
         &mut self.data_cache
+    }
+
+    /// Gets the underlying native extensions.
+    pub fn get_native_extensions(&mut self) -> &mut NativeContextExtensions<'r> {
+        &mut self.native_extensions
     }
 }
 


### PR DESCRIPTION
## Motivation

Until now this have been hidden inside the session and only accessible from within native functions. This makes them also accessible outside so we can work with them on session level (e.g. for lazy code loading).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes