### PR TITLE
[move-prover] Add missing location line in error trace #297_163

### DIFF
--- a/language/move-prover/boogie-backend/src/bytecode_translator.rs
+++ b/language/move-prover/boogie-backend/src/bytecode_translator.rs
@@ -747,6 +747,11 @@ impl<'env> FunctionTranslator<'env> {
             *last_tracked_loc = None;
         }
         self.track_loc(last_tracked_loc, &loc);
+        if matches!(bytecode, Label(_, _)) {
+            // For labels, retrack the location after the label itself, so
+            // the information will not be missing if we jump to this label
+            *last_tracked_loc = None;
+        }
 
         // Helper function to get a a string for a local
         let str_local = |idx: usize| format!("$t{}", idx);

--- a/language/move-prover/tests/sources/functional/aborts_if_with_code.exp
+++ b/language/move-prover/tests/sources/functional/aborts_if_with_code.exp
@@ -14,6 +14,7 @@ error: abort code not covered by any of the `aborts_if` or `aborts_with` clauses
    =     at tests/sources/functional/aborts_if_with_code.move:69: aborts_if_with_code_mixed_invalid
    =         x = <redacted>
    =     at tests/sources/functional/aborts_if_with_code.move:70: aborts_if_with_code_mixed_invalid
+   =     at tests/sources/functional/aborts_if_with_code.move:73: aborts_if_with_code_mixed_invalid
    =     at tests/sources/functional/aborts_if_with_code.move:74: aborts_if_with_code_mixed_invalid
    =         ABORTED
 
@@ -31,6 +32,7 @@ error: abort code not covered by any of the `aborts_if` or `aborts_with` clauses
     =     at tests/sources/functional/aborts_if_with_code.move:97: aborts_with_invalid
     =         x = <redacted>
     =     at tests/sources/functional/aborts_if_with_code.move:98: aborts_with_invalid
+    =     at tests/sources/functional/aborts_if_with_code.move:101: aborts_with_invalid
     =     at tests/sources/functional/aborts_if_with_code.move:102: aborts_with_invalid
     =         ABORTED
 
@@ -50,6 +52,7 @@ error: abort code not covered by any of the `aborts_if` or `aborts_with` clauses
     =     at tests/sources/functional/aborts_if_with_code.move:123: aborts_with_mixed_invalid
     =         x = <redacted>
     =     at tests/sources/functional/aborts_if_with_code.move:124: aborts_with_mixed_invalid
+    =     at tests/sources/functional/aborts_if_with_code.move:127: aborts_with_mixed_invalid
     =     at tests/sources/functional/aborts_if_with_code.move:128: aborts_with_mixed_invalid
     =         ABORTED
 

--- a/language/move-prover/tests/sources/functional/global_invariants.exp
+++ b/language/move-prover/tests/sources/functional/global_invariants.exp
@@ -26,6 +26,7 @@ error: global memory invariant does not hold
    =     at ../move-stdlib/sources/signer.move:13: address_of
    =         result = <redacted>
    =     at ../move-stdlib/sources/signer.move:14: address_of
+   =     at tests/sources/functional/global_invariants.move:65: remove_R_invalid
    =     at ../move-stdlib/sources/signer.move:12: address_of
    =         s = <redacted>
    =     at ../move-stdlib/sources/signer.move:13: address_of
@@ -50,6 +51,7 @@ error: global memory invariant does not hold
    =     at ../move-stdlib/sources/signer.move:13: address_of
    =         result = <redacted>
    =     at ../move-stdlib/sources/signer.move:14: address_of
+   =     at tests/sources/functional/global_invariants.move:56: remove_S_invalid
    =     at ../move-stdlib/sources/signer.move:12: address_of
    =         s = <redacted>
    =     at ../move-stdlib/sources/signer.move:13: address_of

--- a/language/move-prover/tests/sources/functional/invariants.exp
+++ b/language/move-prover/tests/sources/functional/invariants.exp
@@ -49,8 +49,10 @@ error: data invariant does not hold
     =     at tests/sources/functional/invariants.move:143
     =     at tests/sources/functional/invariants.move:158: lifetime_invalid_S_branching
     =         a = <redacted>
+    =     at tests/sources/functional/invariants.move:158: lifetime_invalid_S_branching
     =         x_ref = <redacted>
     =     at tests/sources/functional/invariants.move:160: lifetime_invalid_S_branching
+    =     at tests/sources/functional/invariants.move:163: lifetime_invalid_S_branching
     =     at tests/sources/functional/invariants.move:143
     =     at tests/sources/functional/invariants.move:163: lifetime_invalid_S_branching
     =         a = <redacted>

--- a/language/move-prover/tests/sources/functional/is_txn_signer.exp
+++ b/language/move-prover/tests/sources/functional/is_txn_signer.exp
@@ -31,6 +31,7 @@ error: unknown assertion failed
    =     at ../move-stdlib/sources/signer.move:13: address_of
    =         result = <redacted>
    =     at ../move-stdlib/sources/signer.move:14: address_of
+   =     at tests/sources/functional/is_txn_signer.move:31: f4_incorrect
 
 error: precondition does not hold at this call
    ┌─ tests/sources/functional/is_txn_signer.move:38:9

--- a/language/move-prover/tests/sources/functional/loops.exp
+++ b/language/move-prover/tests/sources/functional/loops.exp
@@ -80,6 +80,7 @@ error: induction case of the loop invariant does not hold
     =     loop invariant holds at current state
     =     at tests/sources/functional/loops.move:225: loop_invariant_induction_invalid
     =     at tests/sources/functional/loops.move:221: loop_invariant_induction_invalid
+    =     at tests/sources/functional/loops.move:227: loop_invariant_induction_invalid
     =         x = <redacted>
     =     at tests/sources/functional/loops.move:223: loop_invariant_induction_invalid
 
@@ -100,6 +101,7 @@ error: induction case of the loop invariant does not hold
     =         y = <redacted>
     =     loop invariant holds at current state
     =     at tests/sources/functional/loops.move:191: loop_with_two_back_edges_incorrect
+    =     at tests/sources/functional/loops.move:192: loop_with_two_back_edges_incorrect
     =         y = <redacted>
     =     at tests/sources/functional/loops.move:193: loop_with_two_back_edges_incorrect
     =     at tests/sources/functional/loops.move:189: loop_with_two_back_edges_incorrect
@@ -141,6 +143,7 @@ error: induction case of the loop invariant does not hold
     =         y = <redacted>
     =     loop invariant holds at current state
     =     at tests/sources/functional/loops.move:147: nested_loop_inner_invariant_incorrect
+    =     at tests/sources/functional/loops.move:150: nested_loop_inner_invariant_incorrect
     =         y = <redacted>
     =     at tests/sources/functional/loops.move:145: nested_loop_inner_invariant_incorrect
 
@@ -163,5 +166,7 @@ error: induction case of the loop invariant does not hold
     =     at tests/sources/functional/loops.move:122: nested_loop_outer_invariant_incorrect
     =     enter loop, variable(s) y havocked and reassigned
     =         y = <redacted>
+    =     at tests/sources/functional/loops.move:128: nested_loop_outer_invariant_incorrect
+    =     at tests/sources/functional/loops.move:131: nested_loop_outer_invariant_incorrect
     =         x = <redacted>
     =     at tests/sources/functional/loops.move:119: nested_loop_outer_invariant_incorrect

--- a/language/move-prover/tests/sources/functional/loops_with_memory_ops.exp
+++ b/language/move-prover/tests/sources/functional/loops_with_memory_ops.exp
@@ -43,6 +43,8 @@ error: unknown assertion failed
    =     at tests/sources/functional/loops_with_memory_ops.move:74: nested_loop2
    =     enter loop, variable(s) y havocked and reassigned
    =         y = <redacted>
+   =     at tests/sources/functional/loops_with_memory_ops.move:80: nested_loop2
+   =     at tests/sources/functional/loops_with_memory_ops.move:81: nested_loop2
    =         b = <redacted>
    =         a = <redacted>
    =     at tests/sources/functional/loops_with_memory_ops.move:85: nested_loop2
@@ -94,11 +96,14 @@ error: induction case of the loop invariant does not hold
    =     at tests/sources/functional/loops_with_memory_ops.move:74: nested_loop2
    =     enter loop, variable(s) y havocked and reassigned
    =         y = <redacted>
+   =     at tests/sources/functional/loops_with_memory_ops.move:80: nested_loop2
+   =     at tests/sources/functional/loops_with_memory_ops.move:81: nested_loop2
    =         b = <redacted>
    =         a = <redacted>
    =     at tests/sources/functional/loops_with_memory_ops.move:85: nested_loop2
    =         i = <redacted>
    =     at tests/sources/functional/loops_with_memory_ops.move:86: nested_loop2
+   =     at tests/sources/functional/loops_with_memory_ops.move:89: nested_loop2
    =         a = <redacted>
    =         x = <redacted>
    =     at tests/sources/functional/loops_with_memory_ops.move:90: nested_loop2

--- a/language/move-prover/tests/sources/functional/macro_verification.exp
+++ b/language/move-prover/tests/sources/functional/macro_verification.exp
@@ -36,6 +36,7 @@ error: post-condition does not hold
    =     at tests/sources/functional/macro_verification.move:26: foreach
    =         `invariant forall j in i..len(v): v[j] == old(v)[j];` = <redacted>
    =     at tests/sources/functional/macro_verification.move:17: foreach
+   =     at tests/sources/functional/macro_verification.move:27: foreach
    =         v = <redacted>
    =     at tests/sources/functional/macro_verification.move:30: foreach (spec)
    =         `ensures len(v) == len(old(v));` = <redacted>
@@ -76,6 +77,7 @@ error: post-condition does not hold
    =     at tests/sources/functional/macro_verification.move:50: reduce
    =         `invariant sum == spec_sum(v, i);` = <redacted>
    =     at tests/sources/functional/macro_verification.move:43: reduce
+   =     at tests/sources/functional/macro_verification.move:52: reduce
    =         result = <redacted>
    =     at tests/sources/functional/macro_verification.move:55: reduce (spec)
    =         `ensures result == spec_sum(v, len(v));` = <redacted>
@@ -123,7 +125,9 @@ error: post-condition does not hold
    =     at tests/sources/functional/macro_verification.move:49: reduce
    =     at tests/sources/functional/macro_verification.move:50: reduce
    =     at tests/sources/functional/macro_verification.move:43: reduce
+   =     at tests/sources/functional/macro_verification.move:52: reduce
    =         result = <redacted>
+   =     at tests/sources/functional/macro_verification.move:53: reduce
    =         result = <redacted>
    =     at tests/sources/functional/macro_verification.move:73: reduce_test
    =     at tests/sources/functional/macro_verification.move:75: reduce_test (spec)

--- a/language/move-prover/tests/sources/functional/trace.exp
+++ b/language/move-prover/tests/sources/functional/trace.exp
@@ -45,7 +45,7 @@ error: post-condition does not hold
    │
    = Related Global Memory:
    =         Resource name: TestTracing_R
-   =         Values:  {Address(26500): <redacted>, Default: empty}
+   =         Values:  {Address(18467): <redacted>, Default: empty}
    = Related Bindings:
    =         addr = <redacted>
    =         exists<R>(addr) = <redacted>


### PR DESCRIPTION
## Motivation
The Move prover does not print the correct line number in some error traces. Consider the example below.

```
public fun test_loop(x: u64) {
    if (x != 0) {
        x = 1;
    }
    else {
        x = 2;
    };
    spec {
        assert x == 1;
    };
}

```

The following error trace is given.

```
error: unknown assertion failed
  ┌─ ./sources/loop.move:9:9
  │
9 │         assert x == 1;
  │         ^^^^^^^^^^^^^^
  │
  =     at ./sources/loop.move:1: test_loop
  =         x = 0
  =     at ./sources/loop.move:2: test_loop
  =         x = 2
  =     at ./sources/loop.move:8: test_loop
  =     at ./sources/loop.move:9: test_loop

```
However, the assignment `x = 2` occurs at Line 6 rather than Line 2. This pull request will insert at  `./sources/loop.move:6: test_loop` above `x = 2`.


## Test Plan
cargo test --release