### PR TITLE
[move-prover] fix hyper-edge constructor in borrow analysis #298_164

### DIFF
--- a/language/move-prover/bytecode/src/borrow_analysis.rs
+++ b/language/move-prover/bytecode/src/borrow_analysis.rs
@@ -259,7 +259,7 @@ impl BorrowInfo {
     ) {
         for (dest, edge) in outgoing.iter() {
             let mut path = prefix.to_owned();
-            path.extend(edge.flatten().into_iter().cloned());
+            path.push(edge.clone());
             if let Some(succs) = ret_info.borrows_from.get(dest) {
                 self.construct_hyper_edges(leaf, ret_info, path, succs);
             } else {
@@ -268,7 +268,13 @@ impl BorrowInfo {
                     path.pop().unwrap()
                 } else {
                     path.reverse();
-                    BorrowEdge::Hyper(path)
+                    let flattened = path
+                        .iter()
+                        .map(|e| e.flatten().into_iter())
+                        .flatten()
+                        .cloned()
+                        .collect();
+                    BorrowEdge::Hyper(flattened)
                 };
                 self.borrowed_by
                     .entry(dest.clone())

--- a/language/move-prover/bytecode/tests/borrow/function_call.exp
+++ b/language/move-prover/bytecode/tests/borrow/function_call.exp
@@ -262,27 +262,27 @@ fun MultiLayerCalling::outer($t0|has_vector: &mut MultiLayerCalling::HasVector) 
   0: $t2 := MultiLayerCalling::mid($t0)
      # live_nodes: Reference($t0), Reference($t2)
      # moved_nodes: Reference($t0)
-     # borrowed_by: Reference($t0) -> {([]/.v (vector<MultiLayerCalling::HasAnotherVector>), Reference($t2))}
-     # borrows_from: Reference($t2) -> {([]/.v (vector<MultiLayerCalling::HasAnotherVector>), Reference($t0))}
+     # borrowed_by: Reference($t0) -> {(.v (vector<MultiLayerCalling::HasAnotherVector>)/[], Reference($t2))}
+     # borrows_from: Reference($t2) -> {(.v (vector<MultiLayerCalling::HasAnotherVector>)/[], Reference($t0))}
   1: $t3 := borrow_field<MultiLayerCalling::HasAnotherVector>.v($t2)
      # live_nodes: Reference($t0), Reference($t3)
      # moved_nodes: Reference($t0)
-     # borrowed_by: Reference($t0) -> {([]/.v (vector<MultiLayerCalling::HasAnotherVector>), Reference($t2))}, Reference($t2) -> {(.v (vector<u8>), Reference($t3))}
-     # borrows_from: Reference($t2) -> {([]/.v (vector<MultiLayerCalling::HasAnotherVector>), Reference($t0))}, Reference($t3) -> {(.v (vector<u8>), Reference($t2))}
+     # borrowed_by: Reference($t0) -> {(.v (vector<MultiLayerCalling::HasAnotherVector>)/[], Reference($t2))}, Reference($t2) -> {(.v (vector<u8>), Reference($t3))}
+     # borrows_from: Reference($t2) -> {(.v (vector<MultiLayerCalling::HasAnotherVector>)/[], Reference($t0))}, Reference($t3) -> {(.v (vector<u8>), Reference($t2))}
   2: $t4 := 42
      # live_nodes: Reference($t0), Reference($t3)
      # moved_nodes: Reference($t0)
-     # borrowed_by: Reference($t0) -> {([]/.v (vector<MultiLayerCalling::HasAnotherVector>), Reference($t2))}, Reference($t2) -> {(.v (vector<u8>), Reference($t3))}
-     # borrows_from: Reference($t2) -> {([]/.v (vector<MultiLayerCalling::HasAnotherVector>), Reference($t0))}, Reference($t3) -> {(.v (vector<u8>), Reference($t2))}
+     # borrowed_by: Reference($t0) -> {(.v (vector<MultiLayerCalling::HasAnotherVector>)/[], Reference($t2))}, Reference($t2) -> {(.v (vector<u8>), Reference($t3))}
+     # borrows_from: Reference($t2) -> {(.v (vector<MultiLayerCalling::HasAnotherVector>)/[], Reference($t0))}, Reference($t3) -> {(.v (vector<u8>), Reference($t2))}
   3: vector::push_back<u8>($t3, $t4)
      # live_nodes: Reference($t0)
      # moved_nodes: Reference($t0)
-     # borrowed_by: Reference($t0) -> {([]/.v (vector<MultiLayerCalling::HasAnotherVector>), Reference($t2))}, Reference($t2) -> {(.v (vector<u8>), Reference($t3))}
-     # borrows_from: Reference($t2) -> {([]/.v (vector<MultiLayerCalling::HasAnotherVector>), Reference($t0))}, Reference($t3) -> {(.v (vector<u8>), Reference($t2))}
+     # borrowed_by: Reference($t0) -> {(.v (vector<MultiLayerCalling::HasAnotherVector>)/[], Reference($t2))}, Reference($t2) -> {(.v (vector<u8>), Reference($t3))}
+     # borrows_from: Reference($t2) -> {(.v (vector<MultiLayerCalling::HasAnotherVector>)/[], Reference($t0))}, Reference($t3) -> {(.v (vector<u8>), Reference($t2))}
   4: trace_local[has_vector]($t0)
      # moved_nodes: Reference($t0)
-     # borrowed_by: Reference($t0) -> {([]/.v (vector<MultiLayerCalling::HasAnotherVector>), Reference($t2))}, Reference($t2) -> {(.v (vector<u8>), Reference($t3))}
-     # borrows_from: Reference($t2) -> {([]/.v (vector<MultiLayerCalling::HasAnotherVector>), Reference($t0))}, Reference($t3) -> {(.v (vector<u8>), Reference($t2))}
+     # borrowed_by: Reference($t0) -> {(.v (vector<MultiLayerCalling::HasAnotherVector>)/[], Reference($t2))}, Reference($t2) -> {(.v (vector<u8>), Reference($t3))}
+     # borrows_from: Reference($t2) -> {(.v (vector<MultiLayerCalling::HasAnotherVector>)/[], Reference($t0))}, Reference($t3) -> {(.v (vector<u8>), Reference($t2))}
   5: return ()
 }
 
@@ -299,5 +299,5 @@ borrowed_by: Reference($t0) -> {(.v (vector<MultiLayerCalling::HasAnotherVector>
 borrows_from: Return(0) -> {(.v (vector<MultiLayerCalling::HasAnotherVector>)/[], Reference($t0))}
 
 fun MultiLayerCalling::mid[baseline]
-borrowed_by: Reference($t0) -> {([]/.v (vector<MultiLayerCalling::HasAnotherVector>), Return(0))}
-borrows_from: Return(0) -> {([]/.v (vector<MultiLayerCalling::HasAnotherVector>), Reference($t0))}
+borrowed_by: Reference($t0) -> {(.v (vector<MultiLayerCalling::HasAnotherVector>)/[], Return(0))}
+borrows_from: Return(0) -> {(.v (vector<MultiLayerCalling::HasAnotherVector>)/[], Reference($t0))}


### PR DESCRIPTION
## Motivation

when constructing
hyper-edges, reverse the edges first before flattening all the edges.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes
## Test Plan

CI/CD tests are covered.