### PR TITLE
[github] Automatically generate the Book #249_144

### DIFF
--- a/.github/workflows/ci-post-land.yml
+++ b/.github/workflows/ci-post-land.yml
@@ -24,8 +24,28 @@ jobs:
       changes-pull-request-number: ${{ steps.changes.outputs.changes-pull-request-number }}
       rust-changes: ${{ steps.rust-changes.outputs.changes-found }}
       base-image-changes: ${{ steps.base-image-changes.outputs.changes-found }}
+
+  generate-documentation:
+    name: Generate the Move Book using mdBook
+    runs-on: ubuntu-20.04
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
     steps:
       - uses: actions/checkout@v2.4.0
+
+      - name: Setup mdBook
+        uses: peaceiris/actions-mdbook@v1
+        with:
+          mdbook-version: '0.4.10'
+          # mdbook-version: 'latest'
+
+      - run: mdbook build language/documentation/book
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./language/documentation/book/book
         with:
           # This ensures that the tip of the PR is checked out instead of the merge between the base ref and the tip
           # On `push` this value will be empty and will "do-the-right-thing"

--- a/.github/workflows/ci-pre-land.yml
+++ b/.github/workflows/ci-pre-land.yml
@@ -1,4 +1,6 @@
-name: ci-test
+# CI jobs to be run upon the code lands to the main branch or GitHub Action test branches.
+
+name: ci-pre-land
 
 on:
   push:
@@ -39,7 +41,7 @@ jobs:
         name: determine changes
         uses: diem/actions/changes@faadd16607b77dfa2231a8f366883e01717b3225
         with:
-          workflow-file: ci-test.yml
+          workflow-file: ci-pre-land.yml
           github-token: ${{secrets.GITHUB_TOKEN}}
       - id: any-changes-found
         name: determine if there are any files listed in the CHANGES_CHANGED_FILE_OUTPUTFILE.


### PR DESCRIPTION
## Motivation

- Adding book generation: Gh-pages is the branch served online. The book is generated and pushed to the gh-pages only when the PR lands to main. For PRs themselves, only plain generation takes place in order to spot errors.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

