### PR TITLE
[Move analyzer] Increased stack size of initial symbolication run #306_172

### DIFF
--- a/language/move-analyzer/src/bin/move-analyzer.rs
+++ b/language/move-analyzer/src/bin/move-analyzer.rs
@@ -14,6 +14,7 @@ use std::{
     collections::BTreeMap,
     path::Path,
     sync::{Arc, Mutex},
+    thread,
 };
 
 use move_analyzer::{
@@ -47,10 +48,11 @@ fn main() {
     );
 
     let (connection, io_threads) = Connection::stdio();
+    let symbols = Arc::new(Mutex::new(symbols::Symbolicator::empty_symbols()));
     let mut context = Context {
         connection,
         files: VirtualFileSystem::default(),
-        symbols: Arc::new(Mutex::new(symbols::Symbolicator::empty_symbols())),
+        symbols: symbols.clone(),
     };
 
     let (id, client_response) = context
@@ -114,8 +116,7 @@ fn main() {
             serde_json::from_value(client_response)
                 .expect("could not deserialize client capabilities");
 
-        symbolicator_runner =
-            symbols::SymbolicatorRunner::new(context.symbols.clone(), diag_sender);
+        symbolicator_runner = symbols::SymbolicatorRunner::new(symbols.clone(), diag_sender);
 
         // If initialization information from the client contains a path to the directory being
         // opened, try to initialize symbols before sending response to the client. Do not bother
@@ -124,11 +125,21 @@ fn main() {
         // to be available right after the client is initialized.
         if let Some(uri) = initialize_params.root_uri {
             if let Some(p) = symbols::SymbolicatorRunner::root_dir(&uri.to_file_path().unwrap()) {
-                if let Ok((Some(new_symbols), _)) = symbols::Symbolicator::get_symbols(p.as_path())
-                {
-                    let mut old_symbols = context.symbols.lock().unwrap();
-                    (*old_symbols).merge(new_symbols);
-                }
+                // need to evaluate in a separate thread to allow for a larger stack size (needed on
+                // Windows)
+                thread::Builder::new()
+                    .stack_size(symbols::STACK_SIZE_BYTES)
+                    .spawn(move || {
+                        if let Ok((Some(new_symbols), _)) =
+                            symbols::Symbolicator::get_symbols(p.as_path())
+                        {
+                            let mut old_symbols = symbols.lock().unwrap();
+                            (*old_symbols).merge(new_symbols);
+                        }
+                    })
+                    .unwrap()
+                    .join()
+                    .unwrap();
             }
         }
     };

--- a/language/move-analyzer/src/symbols.rs
+++ b/language/move-analyzer/src/symbols.rs
@@ -90,6 +90,9 @@ use move_symbol_pool::Symbol;
 /// Enabling/disabling the language server reporting readiness to support go-to-def and
 /// go-to-references to the IDE.
 pub const DEFS_AND_REFS_SUPPORT: bool = true;
+// Building Move code requires a larger stack size on Windows (16M has been chosen somewhat
+// arbitrarily)
+pub const STACK_SIZE_BYTES: usize = 16 * 1024 * 1024;
 
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Copy)]
 /// Location of a definition's identifier
@@ -334,7 +337,7 @@ impl SymbolicatorRunner {
         let runner = SymbolicatorRunner { mtx_cvar };
 
         thread::Builder::new()
-            .stack_size(16 * 1024 * 1024) // building Move code requires a larger stack size on Windows
+            .stack_size(STACK_SIZE_BYTES)
             .spawn(move || {
                 let (mtx, cvar) = &*thread_mtx_cvar;
                 // Locations opened in the IDE (files or directories) for which manifest file is missing


### PR DESCRIPTION
## Motivation

this PR moves initial symbolication run to be executed by a thread with increased stack size to have all symbolicator runs (both the initial one and the following ones) 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes
