### PR TITLE
#244

### DIFF
--- a/language/move-prover/bytecode/src/well_formed_instrumentation.rs
+++ b/language/move-prover/bytecode/src/well_formed_instrumentation.rs
@@ -35,7 +35,7 @@ impl WellFormedInstrumentationProcessor {
         Box::new(Self {})
     }
 }
-#[allow(clippy::redundant-clone)]
+#[allow(clippy::redundant_clone)]
 impl FunctionTargetProcessor for WellFormedInstrumentationProcessor {
     fn process(
         &self,


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation
#244 
`#[allow(clippy::redundant-clone)]` may cause build failure, this changes the directive to `#[allow(clippy::redundant_clone)]`. I can't imagine this wouldn't have been caught, so maybe it's something that affects certain toolchains or versions and requires further investigation. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

```
cargo install --git https://github.com/diem/move move-cli --branch main
```

## Related PRs

N/A
